### PR TITLE
feat: Implement relayer refund root construction

### DIFF
--- a/src/clients/ClientHelper.ts
+++ b/src/clients/ClientHelper.ts
@@ -1,0 +1,8 @@
+import { SpokePoolClient, HubPoolClient, RateModelClient, MultiCallerClient } from ".";
+
+export interface Clients {
+  spokePoolClients: { [chainId: number]: SpokePoolClient };
+  hubPoolClient: HubPoolClient;
+  rateModelClient: RateModelClient;
+  multiCallerClient: MultiCallerClient;
+}

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -1,0 +1,17 @@
+import { winston } from "../utils";
+
+export class ConfigStoreClient {
+  public isUpdated: boolean = false;
+
+  // eslint-disable-next-line no-useless-constructor
+  constructor(
+    readonly logger: winston.Logger,
+    readonly maxRefundsPerLeaf: number = 25, // TODO: Fetch this programatically from ConfigStore contract eventually.
+    readonly startingBlock: number = 0
+  ) {}
+
+  async update() {
+    this.isUpdated = true;
+    this.logger.debug({ at: "ConfigStoreClient", message: "Client updated!" });
+  }
+}

--- a/src/clients/DataworkerClientHelper.ts
+++ b/src/clients/DataworkerClientHelper.ts
@@ -1,0 +1,6 @@
+import { ConfigStoreClient } from ".";
+import { Clients } from "./ClientHelper";
+
+export interface DataworkerClients extends Clients {
+  configStoreClient: ConfigStoreClient;
+}

--- a/src/clients/RelayerClientHelper.ts
+++ b/src/clients/RelayerClientHelper.ts
@@ -2,13 +2,10 @@ import winston from "winston";
 import { getProvider, getSigner, getDeployedContract, Contract } from "../utils";
 import { SpokePoolClient, HubPoolClient, RateModelClient, TokenClient, MultiCallerClient } from ".";
 import { RelayerConfig } from "../relayer/RelayerConfig";
+import { Clients } from "./ClientHelper";
 
-export interface RelayerClients {
-  spokePoolClients: { [chainId: number]: SpokePoolClient };
-  hubPoolClient: HubPoolClient;
-  rateModelClient: RateModelClient;
+export interface RelayerClients extends Clients {
   tokenClient: TokenClient;
-  multiCallerClient: MultiCallerClient;
 }
 
 export function constructRelayerClients(logger: winston.Logger, config: RelayerConfig): RelayerClients {

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,4 +1,7 @@
 export * from "./RelayerClientHelper";
+export * from "./ClientHelper";
+export * from "./DataworkerClientHelper";
+export * from "./ConfigStoreClient";
 export * from "./HubPoolClient";
 export * from "./SpokePoolClient";
 export * from "./RateModelClient";

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -213,7 +213,7 @@ export class Dataworker {
     return indexedLeaves.length > 0 ? buildRelayerRefundTree(indexedLeaves) : null;
   }
 
-  async buildPoolRebalanceRoot(bundleBlockNumbers: BundleEvaluationBlockNumbers) {
+  buildPoolRebalanceRoot(bundleBlockNumbers: BundleEvaluationBlockNumbers) {
     const { fillsToRefund, deposits, unfilledDeposits } = this._loadData();
 
     // For each destination chain ID key in unfilledDeposits
@@ -263,6 +263,4 @@ export class Dataworker {
   async executeRelayerRefundLeaves() {
     // TODO:
   }
-
-  // Private helper functions
 }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -9,7 +9,6 @@ import {
   buildRelayerRefundTree,
   toBNWei,
 } from "../utils";
-import { SpokePoolClient, HubPoolClient } from "../clients";
 import { SpokePoolClient, HubPoolClient, MultiCallerClient } from "../clients";
 import { FillsToRefund, RelayData, UnfilledDeposit, Deposit, Fill } from "../interfaces/SpokePool";
 import { BundleEvaluationBlockNumbers } from "../interfaces/HubPool";

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -170,7 +170,7 @@ export class Dataworker {
         const sortedRefundAddresses = Object.keys(refunds).sort((addressA, addressB) => {
           if (refunds[addressA].gt(refunds[addressB])) return -1;
           if (refunds[addressA].lt(refunds[addressB])) return 1;
-          const sortOutput = this.sortAddresses(addressA, addressB);
+          const sortOutput = this.compareAddresses(addressA, addressB);
           if (sortOutput !== 0) return sortOutput;
           else throw new Error("Unexpected matching address");
         });
@@ -199,9 +199,10 @@ export class Dataworker {
       .sort((leafA, leafB) => {
         if (leafA.chainId !== leafB.chainId) {
           return leafA.chainId - leafB.chainId;
-        } else if (this.sortAddresses(leafA.l2TokenAddress, leafB.l2TokenAddress) !== 0) {
-          return this.sortAddresses(leafA.l2TokenAddress, leafB.l2TokenAddress);
-        } else return leafA.groupIndex - leafB.groupIndex;
+        } else if (this.compareAddresses(leafA.l2TokenAddress, leafB.l2TokenAddress) !== 0) {
+          return this.compareAddresses(leafA.l2TokenAddress, leafB.l2TokenAddress);
+        } else if (leafA.groupIndex !== leafB.groupIndex) return leafA.groupIndex - leafB.groupIndex;
+        else throw new Error("Unexpected leaf group indices match");
       })
       .map((leaf: RelayerRefundLeafWithGroup, i: number): RelayerRefundLeaf => {
         delete leaf.groupIndex; // Delete group index now that we've used it to sort leaves for the same
@@ -264,7 +265,7 @@ export class Dataworker {
   }
 
   // Private helper functions
-  sortAddresses(addressA: string, addressB: string) {
+  compareAddresses(addressA: string, addressB: string) {
     // Convert address strings to BigNumbers and then sort numerical value of the BigNumber.
     const bnAddressA = BigNumber.from(addressA);
     const bnAddressB = BigNumber.from(addressB);

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -108,11 +108,7 @@ export class Dataworker {
       .filter((unfilledDeposit: UnfilledDeposit) => unfilledDeposit.unfilledAmount.gt(0));
 
     // Remove deposits that have been fully filled from unfilled deposit array
-    return {
-      fillsToRefund,
-      deposits,
-      unfilledDeposits,
-    };
+    return { fillsToRefund, deposits, unfilledDeposits };
   }
 
   async buildSlowRelayRoot(bundleBlockNumbers: BundleEvaluationBlockNumbers): Promise<MerkleTree<RelayData>> | null {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1,4 +1,4 @@
-import { winston, assign, buildSlowRelayTree, MerkleTree, toBN } from "../utils";
+import { winston, assign, buildSlowRelayTree, MerkleTree, toBN, compareAddresses } from "../utils";
 import { RelayerRefundLeaf, RelayerRefundLeafWithGroup, BigNumber, buildRelayerRefundTree, toBNWei } from "../utils";
 import { FillsToRefund, RelayData, UnfilledDeposit, Deposit, Fill, BundleEvaluationBlockNumbers } from "../interfaces";
 import { DataworkerClients } from "../clients";
@@ -170,7 +170,7 @@ export class Dataworker {
         const sortedRefundAddresses = Object.keys(refunds).sort((addressA, addressB) => {
           if (refunds[addressA].gt(refunds[addressB])) return -1;
           if (refunds[addressA].lt(refunds[addressB])) return 1;
-          const sortOutput = this.compareAddresses(addressA, addressB);
+          const sortOutput = compareAddresses(addressA, addressB);
           if (sortOutput !== 0) return sortOutput;
           else throw new Error("Unexpected matching address");
         });
@@ -199,8 +199,8 @@ export class Dataworker {
       .sort((leafA, leafB) => {
         if (leafA.chainId !== leafB.chainId) {
           return leafA.chainId - leafB.chainId;
-        } else if (this.compareAddresses(leafA.l2TokenAddress, leafB.l2TokenAddress) !== 0) {
-          return this.compareAddresses(leafA.l2TokenAddress, leafB.l2TokenAddress);
+        } else if (compareAddresses(leafA.l2TokenAddress, leafB.l2TokenAddress) !== 0) {
+          return compareAddresses(leafA.l2TokenAddress, leafB.l2TokenAddress);
         } else if (leafA.groupIndex !== leafB.groupIndex) return leafA.groupIndex - leafB.groupIndex;
         else throw new Error("Unexpected leaf group indices match");
       })
@@ -265,12 +265,4 @@ export class Dataworker {
   }
 
   // Private helper functions
-  compareAddresses(addressA: string, addressB: string) {
-    // Convert address strings to BigNumbers and then sort numerical value of the BigNumber.
-    const bnAddressA = BigNumber.from(addressA);
-    const bnAddressB = BigNumber.from(addressB);
-    if (bnAddressA.gt(bnAddressB)) return 1;
-    else if (bnAddressA.lt(bnAddressB)) return -1;
-    else return 0;
-  }
 }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -194,7 +194,6 @@ export class Dataworker {
           l2TokenAddress,
           refundAddresses: sortedRefundAddresses,
           refundAmounts: sortedRefundAddresses.map((address) => refunds[address]),
-          // TODO: Make sure refund arrays length are capped and their contents are split in the worst case
         });
       });
     });
@@ -212,9 +211,8 @@ export class Dataworker {
       .map((leaf: RelayerRefundLeaf, i: number) => {
         return { ...leaf, leafId: toBN(i) };
       });
-    // const indexedLeaves = leaves.map((leaf: RelayerRefundLeaf, i: number) => {
-    //   return { ...leaf, leafId: toBN(i) };
-    // });
+
+    // TODO: Make sure refund arrays length are capped and their contents are split in the worst case
     return indexedLeaves.length > 0 ? await buildRelayerRefundTree(indexedLeaves) : null;
   }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1,4 +1,14 @@
-import { winston, assign, buildSlowRelayTree, MerkleTree, toBN, RelayerRefundLeaf, BigNumber, buildRelayerRefundTree, toBNWei } from "../utils";
+import {
+  winston,
+  assign,
+  buildSlowRelayTree,
+  MerkleTree,
+  toBN,
+  RelayerRefundLeaf,
+  BigNumber,
+  buildRelayerRefundTree,
+  toBNWei,
+} from "../utils";
 import { SpokePoolClient, HubPoolClient, MultiCallBundler } from "../clients";
 import { FillsToRefund, RelayData, UnfilledDeposit, Deposit, Fill } from "../interfaces/SpokePool";
 import { BundleEvaluationBlockNumbers } from "../interfaces/HubPool";
@@ -163,7 +173,7 @@ export class Dataworker {
         const refunds: { [refundAddress: string]: BigNumber } = {};
         fillsToRefund[repaymentChainId][l2TokenAddress].forEach((fill: Fill) => {
           const existingFillAmountForRelayer = refunds[fill.relayer] ? refunds[fill.relayer] : toBN(0);
-          const currentRefundAmount = fill.fillAmount.mul(toBNWei(1).sub(fill.realizedLpFeePct)).div(toBNWei(1))
+          const currentRefundAmount = fill.fillAmount.mul(toBNWei(1).sub(fill.realizedLpFeePct)).div(toBNWei(1));
           assign(refunds, [fill.relayer], existingFillAmountForRelayer.add(currentRefundAmount));
         });
         // Sort leaves deterministically so that the same root is always produced from the same _loadData return value.
@@ -189,12 +199,11 @@ export class Dataworker {
     if (leaves.length === 0) return null;
     leaves.sort((leafA, leafB) => {
       if (!leafA.chainId.eq(leafB.chainId)) {
-        return leafA.chainId.sub(leafB.chainId).toNumber()
-      }
-      else if (leafA.l2TokenAddress.localeCompare(leafB.l2TokenAddress) !== 0) {
-        return leafA.l2TokenAddress.localeCompare(leafB.l2TokenAddress)
-      } else throw new Error("TODO: Implement tertiary sorting of leaves")
-    })
+        return leafA.chainId.sub(leafB.chainId).toNumber();
+      } else if (leafA.l2TokenAddress.localeCompare(leafB.l2TokenAddress) !== 0) {
+        return leafA.l2TokenAddress.localeCompare(leafB.l2TokenAddress);
+      } else throw new Error("TODO: Implement tertiary sorting of leaves");
+    });
     const sortedLeaves = leaves.map((leaf: RelayerRefundLeaf, i: number) => {
       return { ...leaf, leafId: toBN(i) };
     });

--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -3,20 +3,20 @@ import { BigNumber } from "../utils";
 export type BundleEvaluationBlockNumbers = number[];
 
 export interface PoolRebalanceLeaf {
-  chainId: BigNumber;
-  groupIndex: BigNumber;
+  chainId: number;
+  groupIndex: number;
   bundleLpFees: BigNumber[];
   netSendAmounts: BigNumber[];
   runningBalances: BigNumber[];
-  leafId: BigNumber;
+  leafId: number;
   l1Tokens: string[];
 }
 
 export interface RelayerRefundLeaf {
   amountToReturn: BigNumber;
-  chainId: BigNumber;
+  chainId: number;
   refundAmounts: BigNumber[];
-  leafId: BigNumber;
+  leafId: number;
   l2TokenAddress: string;
   refundAddresses: string[];
 }

--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -21,6 +21,10 @@ export interface RelayerRefundLeaf {
   refundAddresses: string[];
 }
 
+export interface RelayerRefundLeafWithGroup extends RelayerRefundLeaf {
+  groupIndex: number;
+}
+
 export interface L1Token {
   address: string;
   symbol: string;

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -73,5 +73,5 @@ export interface UnfilledDeposit {
   hasFirstPartialFill?: boolean;
 }
 export interface FillsToRefund {
-  [repaymentChainId: number]: { [refundAddress: string]: Fill[] };
+  [repaymentChainId: number]: { [l2TokenAddress: string]: Fill[] };
 }

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -1,11 +1,11 @@
 import { BigNumber } from ".";
 
 export function compareAddresses(addressA: string, addressB: string) {
-    // Convert address strings to BigNumbers and then sort numerical value of the BigNumber, which sorts the addresses
-    // effectively by their hex value.
-    const bnAddressA = BigNumber.from(addressA);
-    const bnAddressB = BigNumber.from(addressB);
-    if (bnAddressA.gt(bnAddressB)) return 1;
-    else if (bnAddressA.lt(bnAddressB)) return -1;
-    else return 0;
-  }
+  // Convert address strings to BigNumbers and then sort numerical value of the BigNumber, which sorts the addresses
+  // effectively by their hex value.
+  const bnAddressA = BigNumber.from(addressA);
+  const bnAddressB = BigNumber.from(addressB);
+  if (bnAddressA.gt(bnAddressB)) return 1;
+  else if (bnAddressA.lt(bnAddressB)) return -1;
+  else return 0;
+}

--- a/src/utils/AddressUtils.ts
+++ b/src/utils/AddressUtils.ts
@@ -1,0 +1,11 @@
+import { BigNumber } from ".";
+
+export function compareAddresses(addressA: string, addressB: string) {
+    // Convert address strings to BigNumbers and then sort numerical value of the BigNumber, which sorts the addresses
+    // effectively by their hex value.
+    const bnAddressA = BigNumber.from(addressA);
+    const bnAddressB = BigNumber.from(addressB);
+    if (bnAddressA.gt(bnAddressB)) return 1;
+    else if (bnAddressA.lt(bnAddressB)) return -1;
+    else return 0;
+  }

--- a/src/utils/MerkleTreeUtils.ts
+++ b/src/utils/MerkleTreeUtils.ts
@@ -1,4 +1,4 @@
-import { getParamType, utils } from ".";
+import { getParamType, utils, BigNumber } from ".";
 import { RelayData, PoolRebalanceLeaf, RelayerRefundLeaf } from "../interfaces";
 import { MerkleTree } from "@across-protocol/contracts-v2";
 
@@ -37,4 +37,4 @@ export async function buildRelayerRefundTree(relayerRefundLeaves: RelayerRefundL
   return new MerkleTree<RelayerRefundLeaf>(relayerRefundLeaves, hashFn);
 }
 
-export { MerkleTree };
+export { MerkleTree, RelayerRefundLeaf };

--- a/src/utils/MerkleTreeUtils.ts
+++ b/src/utils/MerkleTreeUtils.ts
@@ -1,5 +1,5 @@
 import { getParamType, utils, BigNumber } from ".";
-import { RelayData, PoolRebalanceLeaf, RelayerRefundLeaf } from "../interfaces";
+import { RelayData, PoolRebalanceLeaf, RelayerRefundLeaf, RelayerRefundLeafWithGroup } from "../interfaces";
 import { MerkleTree } from "@across-protocol/contracts-v2";
 
 export async function buildSlowRelayTree(relays: RelayData[]) {
@@ -37,4 +37,4 @@ export async function buildRelayerRefundTree(relayerRefundLeaves: RelayerRefundL
   return new MerkleTree<RelayerRefundLeaf>(relayerRefundLeaves, hashFn);
 }
 
-export { MerkleTree, RelayerRefundLeaf };
+export { MerkleTree, RelayerRefundLeaf, RelayerRefundLeafWithGroup };

--- a/src/utils/MerkleTreeUtils.ts
+++ b/src/utils/MerkleTreeUtils.ts
@@ -1,16 +1,16 @@
-import { getParamType, utils, BigNumber } from ".";
+import { getParamType, utils } from ".";
 import { RelayData, PoolRebalanceLeaf, RelayerRefundLeaf, RelayerRefundLeafWithGroup } from "../interfaces";
 import { MerkleTree } from "@across-protocol/contracts-v2";
 
-export async function buildSlowRelayTree(relays: RelayData[]) {
-  const paramType = await getParamType("MerkleLibTest", "verifySlowRelayFulfillment", "slowRelayFulfillment");
+export function buildSlowRelayTree(relays: RelayData[]) {
+  const paramType = getParamType("MerkleLibTest", "verifySlowRelayFulfillment", "slowRelayFulfillment");
   const hashFn = (input: RelayData) => {
     return utils.keccak256(utils.defaultAbiCoder.encode([paramType!], [input]));
   };
   return new MerkleTree(relays, hashFn);
 }
 
-export async function buildPoolRebalanceLeafTree(poolRebalanceLeaves: PoolRebalanceLeaf[]) {
+export function buildPoolRebalanceLeafTree(poolRebalanceLeaves: PoolRebalanceLeaf[]) {
   for (let i = 0; i < poolRebalanceLeaves.length; i++) {
     // The 4 provided parallel arrays must be of equal length.
     if (
@@ -20,19 +20,19 @@ export async function buildPoolRebalanceLeafTree(poolRebalanceLeaves: PoolRebala
       throw new Error("Provided lef arrays are not of equal length");
   }
 
-  const paramType = await getParamType("MerkleLibTest", "verifyPoolRebalance", "rebalance");
+  const paramType = getParamType("MerkleLibTest", "verifyPoolRebalance", "rebalance");
   const hashFn = (input: PoolRebalanceLeaf) => utils.keccak256(utils.defaultAbiCoder.encode([paramType!], [input]));
   return new MerkleTree<PoolRebalanceLeaf>(poolRebalanceLeaves, hashFn);
 }
 
-export async function buildRelayerRefundTree(relayerRefundLeaves: RelayerRefundLeaf[]) {
+export function buildRelayerRefundTree(relayerRefundLeaves: RelayerRefundLeaf[]) {
   for (let i = 0; i < relayerRefundLeaves.length; i++) {
     // The 2 provided parallel arrays must be of equal length.
-    if (relayerRefundLeaves[i].refundAddresses.length != relayerRefundLeaves[i].refundAmounts.length)
+    if (relayerRefundLeaves[i].refundAddresses.length !== relayerRefundLeaves[i].refundAmounts.length)
       throw new Error("Provided lef arrays are not of equal length");
   }
 
-  const paramType = await getParamType("MerkleLibTest", "verifyRelayerRefund", "refund");
+  const paramType = getParamType("MerkleLibTest", "verifyRelayerRefund", "refund");
   const hashFn = (input: RelayerRefundLeaf) => utils.keccak256(utils.defaultAbiCoder.encode([paramType!], [input]));
   return new MerkleTree<RelayerRefundLeaf>(relayerRefundLeaves, hashFn);
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -18,6 +18,7 @@ export * from "./ExecutionUtils";
 export * from "./NetworkUtils";
 export * from "./TransactionUtils";
 export * from "./MerkleTreeUtils";
+export * from "./AddressUtils";
 
 export { ZERO_ADDRESS, MAX_SAFE_ALLOWANCE } from "@uma/common";
 

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -16,7 +16,6 @@ import { amountToDeposit, destinationChainId, originChainId } from "./constants"
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 
 import { Dataworker } from "../src/dataworker/Dataworker"; // Tested
-import { RelayerRefundLeaf } from "../src/utils";
 import { Deposit } from "../src/interfaces/SpokePool";
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -20,7 +20,7 @@ import { RelayerRefundLeaf } from "../src/utils";
 import { Deposit } from "../src/interfaces/SpokePool";
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
-let l1Token_1: Contract, l1Token_2: Contract;
+let l1Token_1: Contract;
 let depositor: SignerWithAddress, relayer: SignerWithAddress;
 
 let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -9,13 +9,12 @@ import {
   toBN,
   toBNWei,
   setupTokensForWallet,
-  BigNumber,
 } from "./utils";
 import { SignerWithAddress } from "./utils";
 import { buildDeposit, buildFill } from "./utils";
-import { SpokePoolClient, HubPoolClient, RateModelClient } from "../src/clients";
+import { HubPoolClient, RateModelClient } from "../src/clients";
 import { amountToDeposit, destinationChainId, originChainId, MAX_REFUNDS_PER_LEAF } from "./constants";
-import { setupDataworker, dataworkerFixture } from "./fixtures/Dataworker.Fixture";
+import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 
 import { Dataworker } from "../src/dataworker/Dataworker"; // Tested
 import { Deposit } from "../src/interfaces/SpokePool";
@@ -24,9 +23,10 @@ let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Co
 let l1Token_1: Contract;
 let depositor: SignerWithAddress, relayer: SignerWithAddress;
 
-let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
 let rateModelClient: RateModelClient, hubPoolClient: HubPoolClient;
 let dataworkerInstance: Dataworker;
+
+let updateAllClients: () => Promise<void>;
 
 describe("Dataworker: Build merkle roots", async function () {
   beforeEach(async function () {
@@ -41,8 +41,7 @@ describe("Dataworker: Build merkle roots", async function () {
       depositor,
       relayer,
       dataworkerInstance,
-      spokePoolClient_1,
-      spokePoolClient_2,
+      updateAllClients,
     } = await setupDataworker(ethers, MAX_REFUNDS_PER_LEAF));
   });
   it("Default conditions", async function () {
@@ -316,10 +315,3 @@ describe("Dataworker: Build merkle roots", async function () {
     expect(merkleRoot4.getHexRoot()).to.equal(expectedMerkleRoot4.getHexRoot());
   });
 });
-
-async function updateAllClients() {
-  await hubPoolClient.update();
-  await rateModelClient.update();
-  await spokePoolClient_1.update();
-  await spokePoolClient_2.update();
-}

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -1,4 +1,14 @@
-import { expect, ethers, Contract, buildSlowRelayTree, RelayData, buildFillForRepaymentChain, buildRelayerRefundTree, toBN, toBNWei } from "./utils";
+import {
+  expect,
+  ethers,
+  Contract,
+  buildSlowRelayTree,
+  RelayData,
+  buildFillForRepaymentChain,
+  buildRelayerRefundTree,
+  toBN,
+  toBNWei,
+} from "./utils";
 import { SignerWithAddress } from "./utils";
 import { buildDeposit, buildFill } from "./utils";
 import { SpokePoolClient, HubPoolClient, RateModelClient } from "../src/clients";
@@ -7,7 +17,7 @@ import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 
 import { Dataworker } from "../src/dataworker/Dataworker"; // Tested
 import { RelayerRefundLeaf } from "../src/utils";
-import { Deposit } from "../src/interfaces/SpokePool"
+import { Deposit } from "../src/interfaces/SpokePool";
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
 let l1Token_1: Contract, l1Token_2: Contract;
@@ -126,7 +136,7 @@ describe("Dataworker: Build merkle roots", async function () {
     await updateAllClients();
     expect(await dataworkerInstance.buildSlowRelayRoot([])).to.equal(null);
   });
-  it.only("Build relayer refund root", async function() {
+  it.only("Build relayer refund root", async function () {
     await updateAllClients();
 
     // Submit deposits for multiple L2 tokens.
@@ -205,15 +215,16 @@ describe("Dataworker: Build merkle roots", async function () {
       return await buildRelayerRefundTree(
         leaves.map((leaf, id) => {
           return { ...leaf, leafId: toBN(id) };
-      }));
-    }
+        })
+      );
+    };
     const leaf1 = {
       chainId: toBN(100),
       amountToReturn: toBN(0),
       l2TokenAddress: erc20_2.address,
       refundAddresses: [relayer.address, depositor.address], // Sorted ascending alphabetically
       refundAmounts: [expectedRefundAmount(deposit1), expectedRefundAmount(deposit3)], // Refund amounts should aggregate across all fills.
-    }
+    };
 
     await updateAllClients();
     const merkleRoot1 = await dataworkerInstance.buildRelayerRefundRoot([]);
@@ -229,7 +240,7 @@ describe("Dataworker: Build merkle roots", async function () {
       l2TokenAddress: erc20_1.address,
       refundAddresses: [relayer.address, depositor.address],
       refundAmounts: [expectedRefundAmount(deposit2), expectedRefundAmount(deposit4)],
-    }
+    };
     await updateAllClients();
     const merkleRoot2 = await dataworkerInstance.buildRelayerRefundRoot([]);
     const expectedMerkleRoot2 = await buildTree([leaf1, leaf2]);
@@ -247,19 +258,19 @@ describe("Dataworker: Build merkle roots", async function () {
       l2TokenAddress: erc20_2.address,
       refundAddresses: [relayer.address],
       refundAmounts: [expectedRefundAmount(deposit5)],
-    }
+    };
     const leaf4 = {
       chainId: toBN(99),
       amountToReturn: toBN(0),
       l2TokenAddress: erc20_1.address,
       refundAddresses: [relayer.address],
       refundAmounts: [expectedRefundAmount(deposit6)],
-    }
+    };
     await updateAllClients();
     const merkleRoot3 = await dataworkerInstance.buildRelayerRefundRoot([]);
     const expectedMerkleRoot3 = await buildTree([leaf3, leaf4, leaf1, leaf2]);
     expect(merkleRoot3.getHexRoot()).to.equal(expectedMerkleRoot3.getHexRoot());
-  })
+  });
 });
 
 async function updateAllClients() {

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -1,4 +1,4 @@
-import { expect, ethers, Contract, buildSlowRelayTree, RelayData } from "./utils";
+import { expect, ethers, Contract, buildSlowRelayTree, RelayData, buildFillForRepaymentChain, buildRelayerRefundTree, toBN, toBNWei } from "./utils";
 import { SignerWithAddress } from "./utils";
 import { buildDeposit, buildFill } from "./utils";
 import { SpokePoolClient, HubPoolClient, RateModelClient } from "../src/clients";
@@ -6,9 +6,11 @@ import { amountToDeposit, destinationChainId, originChainId } from "./constants"
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 
 import { Dataworker } from "../src/dataworker/Dataworker"; // Tested
+import { RelayerRefundLeaf } from "../src/utils";
+import { Deposit } from "../src/interfaces/SpokePool"
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
-let l1Token: Contract;
+let l1Token_1: Contract, l1Token_2: Contract;
 let depositor: SignerWithAddress, relayer: SignerWithAddress;
 
 let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
@@ -24,7 +26,8 @@ describe("Dataworker: Build merkle roots", async function () {
       erc20_2,
       rateModelClient,
       hubPoolClient,
-      l1Token,
+      l1Token_1,
+      l1Token_2,
       depositor,
       relayer,
       dataworkerInstance,
@@ -46,7 +49,7 @@ describe("Dataworker: Build merkle roots", async function () {
       hubPoolClient,
       spokePool_1,
       erc20_1,
-      l1Token,
+      l1Token_1,
       depositor,
       destinationChainId,
       amountToDeposit
@@ -56,7 +59,7 @@ describe("Dataworker: Build merkle roots", async function () {
       hubPoolClient,
       spokePool_2,
       erc20_2,
-      l1Token,
+      l1Token_1,
       depositor,
       originChainId,
       amountToDeposit
@@ -66,7 +69,7 @@ describe("Dataworker: Build merkle roots", async function () {
       hubPoolClient,
       spokePool_1,
       erc20_1,
-      l1Token,
+      l1Token_1,
       depositor,
       destinationChainId,
       amountToDeposit
@@ -76,7 +79,7 @@ describe("Dataworker: Build merkle roots", async function () {
       hubPoolClient,
       spokePool_2,
       erc20_2,
-      l1Token,
+      l1Token_1,
       depositor,
       originChainId,
       amountToDeposit
@@ -123,6 +126,140 @@ describe("Dataworker: Build merkle roots", async function () {
     await updateAllClients();
     expect(await dataworkerInstance.buildSlowRelayRoot([])).to.equal(null);
   });
+  it.only("Build relayer refund root", async function() {
+    await updateAllClients();
+
+    // Submit deposits for multiple L2 tokens.
+    const deposit1 = await buildDeposit(
+      rateModelClient,
+      hubPoolClient,
+      spokePool_1,
+      erc20_1,
+      l1Token_1,
+      depositor,
+      destinationChainId,
+      amountToDeposit
+    );
+    const deposit2 = await buildDeposit(
+      rateModelClient,
+      hubPoolClient,
+      spokePool_2,
+      erc20_2,
+      l1Token_1,
+      depositor,
+      originChainId,
+      amountToDeposit.mul(2)
+    );
+    const deposit3 = await buildDeposit(
+      rateModelClient,
+      hubPoolClient,
+      spokePool_1,
+      erc20_1,
+      l1Token_1,
+      depositor,
+      destinationChainId,
+      amountToDeposit
+    );
+    const deposit4 = await buildDeposit(
+      rateModelClient,
+      hubPoolClient,
+      spokePool_2,
+      erc20_2,
+      l1Token_1,
+      depositor,
+      originChainId,
+      amountToDeposit
+    );
+    const deposit5 = await buildDeposit(
+      rateModelClient,
+      hubPoolClient,
+      spokePool_2,
+      erc20_2,
+      l1Token_1,
+      depositor,
+      originChainId,
+      amountToDeposit
+    );
+    const deposit6 = await buildDeposit(
+      rateModelClient,
+      hubPoolClient,
+      spokePool_1,
+      erc20_1,
+      l1Token_1,
+      depositor,
+      destinationChainId,
+      amountToDeposit
+    );
+
+    // Submit fills for two relayers on one repayment chain and one destination token. Note: we know that
+    // depositor address is alphabetically lower than relayer address, so submit fill from depositor first and test
+    // that data worker sorts on refund address.
+    await buildFillForRepaymentChain(spokePool_2, depositor, deposit3, 0.25, 100);
+    await buildFillForRepaymentChain(spokePool_2, depositor, deposit3, 1, 100);
+    await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 0.25, 100);
+    await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 1, 100);
+
+    const expectedRefundAmount = (deposit: Deposit) =>
+      deposit.amount.mul(toBNWei(1).sub(deposit.realizedLpFeePct)).div(toBNWei(1));
+    const buildTree = async (leaves) => {
+      return await buildRelayerRefundTree(
+        leaves.map((leaf, id) => {
+          return { ...leaf, leafId: toBN(id) };
+      }));
+    }
+    const leaf1 = {
+      chainId: toBN(100),
+      amountToReturn: toBN(0),
+      l2TokenAddress: erc20_2.address,
+      refundAddresses: [relayer.address, depositor.address], // Sorted ascending alphabetically
+      refundAmounts: [expectedRefundAmount(deposit1), expectedRefundAmount(deposit3)], // Refund amounts should aggregate across all fills.
+    }
+
+    await updateAllClients();
+    const merkleRoot1 = await dataworkerInstance.buildRelayerRefundRoot([]);
+    const expectedMerkleRoot1 = await buildTree([leaf1]);
+    expect(merkleRoot1.getHexRoot()).to.equal(expectedMerkleRoot1.getHexRoot());
+
+    // Submit fills for a second destination token on on the same repayment chain.
+    await buildFillForRepaymentChain(spokePool_1, relayer, deposit2, 1, 100);
+    await buildFillForRepaymentChain(spokePool_1, depositor, deposit4, 1, 100);
+    const leaf2 = {
+      chainId: toBN(100),
+      amountToReturn: toBN(0),
+      l2TokenAddress: erc20_1.address,
+      refundAddresses: [relayer.address, depositor.address],
+      refundAmounts: [expectedRefundAmount(deposit2), expectedRefundAmount(deposit4)],
+    }
+    await updateAllClients();
+    const merkleRoot2 = await dataworkerInstance.buildRelayerRefundRoot([]);
+    const expectedMerkleRoot2 = await buildTree([leaf1, leaf2]);
+    expect(merkleRoot2.getHexRoot()).to.equal(expectedMerkleRoot2.getHexRoot());
+
+    // Submit fills for multiple repayment chains. Note: Send the fills for destination tokens in the
+    // reverse order of the fills we sent above to test that the data worker is correctly sorting leaves
+    // by L2 token address in ascending order. Also set repayment chain ID lower than first few leaves to test
+    // that these leaves come first.
+    await buildFillForRepaymentChain(spokePool_1, relayer, deposit5, 1, 99);
+    await buildFillForRepaymentChain(spokePool_2, relayer, deposit6, 1, 99);
+    const leaf3 = {
+      chainId: toBN(99),
+      amountToReturn: toBN(0),
+      l2TokenAddress: erc20_2.address,
+      refundAddresses: [relayer.address],
+      refundAmounts: [expectedRefundAmount(deposit5)],
+    }
+    const leaf4 = {
+      chainId: toBN(99),
+      amountToReturn: toBN(0),
+      l2TokenAddress: erc20_1.address,
+      refundAddresses: [relayer.address],
+      refundAmounts: [expectedRefundAmount(deposit6)],
+    }
+    await updateAllClients();
+    const merkleRoot3 = await dataworkerInstance.buildRelayerRefundRoot([]);
+    const expectedMerkleRoot3 = await buildTree([leaf3, leaf4, leaf1, leaf2]);
+    expect(merkleRoot3.getHexRoot()).to.equal(expectedMerkleRoot3.getHexRoot());
+  })
 });
 
 async function updateAllClients() {

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -46,9 +46,10 @@ describe("Dataworker: Build merkle roots", async function () {
     } = await setupDataworker(ethers));
   });
   it("Default conditions", async function () {
-    // Before any deposits, returns null.
+    // When given empty input data, returns null.
     await updateAllClients();
     expect(await dataworkerInstance.buildSlowRelayRoot([])).to.equal(null);
+    expect(await dataworkerInstance.buildRelayerRefundRoot([])).to.equal(null);
   });
   it("Build slow relay root", async function () {
     await updateAllClients();

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -1,16 +1,5 @@
-import {
-  expect,
-  ethers,
-  Contract,
-  buildSlowRelayTree,
-  RelayData,
-  buildFillForRepaymentChain,
-  buildRelayerRefundTree,
-  toBN,
-  toBNWei,
-  setupTokensForWallet,
-} from "./utils";
-import { SignerWithAddress } from "./utils";
+import { buildSlowRelayTree, RelayData, buildFillForRepaymentChain, buildRelayerRefundTree } from "./utils";
+import { SignerWithAddress, expect, ethers, Contract, toBN, toBNWei, setupTokensForWallet } from "./utils";
 import { buildDeposit, buildFill } from "./utils";
 import { HubPoolClient, RateModelClient } from "../src/clients";
 import { amountToDeposit, destinationChainId, originChainId, MAX_REFUNDS_PER_LEAF } from "./constants";
@@ -119,7 +108,7 @@ describe("Dataworker: Build merkle roots", async function () {
     // Returns expected merkle root where leaves are ordered by origin chain ID and then deposit ID
     // (ascending).
     await updateAllClients();
-    const merkleRoot1 = await dataworkerInstance.buildSlowRelayRoot([]);
+    const merkleRoot1 = dataworkerInstance.buildSlowRelayRoot([]);
     const expectedMerkleRoot1 = await buildSlowRelayTree([
       expectedRelaysUnsorted[0],
       expectedRelaysUnsorted[2],
@@ -134,7 +123,7 @@ describe("Dataworker: Build merkle roots", async function () {
     await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit3, 1);
     await buildFill(spokePool_1, erc20_1, depositor, relayer, deposit4, 1);
     await updateAllClients();
-    expect(await dataworkerInstance.buildSlowRelayRoot([])).to.equal(null);
+    expect(dataworkerInstance.buildSlowRelayRoot([])).to.equal(null);
   });
   it("Build relayer refund root", async function () {
     await updateAllClients();
@@ -227,7 +216,7 @@ describe("Dataworker: Build merkle roots", async function () {
     };
 
     await updateAllClients();
-    const merkleRoot1 = await dataworkerInstance.buildRelayerRefundRoot([]);
+    const merkleRoot1 = dataworkerInstance.buildRelayerRefundRoot([]);
     const expectedMerkleRoot1 = await buildTree([leaf1]);
     expect(merkleRoot1.getHexRoot()).to.equal(expectedMerkleRoot1.getHexRoot());
 
@@ -242,7 +231,7 @@ describe("Dataworker: Build merkle roots", async function () {
       refundAmounts: [expectedRefundAmount(deposit4), expectedRefundAmount(deposit2)],
     };
     await updateAllClients();
-    const merkleRoot2 = await dataworkerInstance.buildRelayerRefundRoot([]);
+    const merkleRoot2 = dataworkerInstance.buildRelayerRefundRoot([]);
     const expectedMerkleRoot2 = await buildTree([leaf1, leaf2]);
     expect(merkleRoot2.getHexRoot()).to.equal(expectedMerkleRoot2.getHexRoot());
 
@@ -310,7 +299,7 @@ describe("Dataworker: Build merkle roots", async function () {
       refundAmounts: [expectedRefundAmount(deposit7).mul(toBNWei("0.01")).div(toBNWei("1"))],
     };
     await updateAllClients();
-    const merkleRoot4 = await dataworkerInstance.buildRelayerRefundRoot([]);
+    const merkleRoot4 = dataworkerInstance.buildRelayerRefundRoot([]);
     const expectedMerkleRoot4 = await buildTree([leaf5, leaf6, leaf3, leaf4, leaf1, leaf2]);
     expect(merkleRoot4.getHexRoot()).to.equal(expectedMerkleRoot4.getHexRoot());
   });

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -136,7 +136,7 @@ describe("Dataworker: Build merkle roots", async function () {
     await updateAllClients();
     expect(await dataworkerInstance.buildSlowRelayRoot([])).to.equal(null);
   });
-  it.only("Build relayer refund root", async function () {
+  it("Build relayer refund root", async function () {
     await updateAllClients();
 
     // Submit deposits for multiple L2 tokens.
@@ -158,7 +158,7 @@ describe("Dataworker: Build merkle roots", async function () {
       l1Token_1,
       depositor,
       originChainId,
-      amountToDeposit.mul(2)
+      amountToDeposit
     );
     const deposit3 = await buildDeposit(
       rateModelClient,
@@ -178,7 +178,7 @@ describe("Dataworker: Build merkle roots", async function () {
       l1Token_1,
       depositor,
       originChainId,
-      amountToDeposit
+      amountToDeposit.mul(2)
     );
     const deposit5 = await buildDeposit(
       rateModelClient,
@@ -238,8 +238,8 @@ describe("Dataworker: Build merkle roots", async function () {
       chainId: toBN(100),
       amountToReturn: toBN(0),
       l2TokenAddress: erc20_1.address,
-      refundAddresses: [relayer.address, depositor.address],
-      refundAmounts: [expectedRefundAmount(deposit2), expectedRefundAmount(deposit4)],
+      refundAddresses: [depositor.address, relayer.address], // Reversed order because deposit4 refund amount is larger.
+      refundAmounts: [expectedRefundAmount(deposit4), expectedRefundAmount(deposit2)],
     };
     await updateAllClients();
     const merkleRoot2 = await dataworkerInstance.buildRelayerRefundRoot([]);

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -37,7 +37,6 @@ describe("Dataworker: Build merkle roots", async function () {
       rateModelClient,
       hubPoolClient,
       l1Token_1,
-      l1Token_2,
       depositor,
       relayer,
       dataworkerInstance,

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -32,7 +32,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       dataworkerInstance,
       spokePoolClient_1,
       spokePoolClient_2,
-    } = await setupDataworker(ethers));
+    } = await setupDataworker(ethers, 25));
   });
 
   it("Default conditions", async function () {
@@ -49,6 +49,7 @@ describe("Dataworker: Load data used in all functions", async function () {
     await updateAllClients();
     expect(dataworkerInstance._loadData()).to.deep.equal({
       unfilledDeposits: [],
+      deposits: [],
       fillsToRefund: {},
     });
   });

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -16,6 +16,8 @@ let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
 let rateModelClient: RateModelClient, hubPoolClient: HubPoolClient;
 let dataworkerInstance: Dataworker;
 
+let updateAllClients: () => Promise<void>;
+
 describe("Dataworker: Load data used in all functions", async function () {
   beforeEach(async function () {
     ({
@@ -32,6 +34,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       dataworkerInstance,
       spokePoolClient_1,
       spokePoolClient_2,
+      updateAllClients,
     } = await setupDataworker(ethers, 25));
   });
 
@@ -311,10 +314,3 @@ describe("Dataworker: Load data used in all functions", async function () {
     });
   });
 });
-
-async function updateAllClients() {
-  await hubPoolClient.update();
-  await rateModelClient.update();
-  await spokePoolClient_1.update();
-  await spokePoolClient_2.update();
-}

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -145,7 +145,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       amountToDeposit
     );
     const fill3 = await buildFill(spokePool_1, erc20_1, depositor, relayer, deposit5, 0.25);
-    
+
     // One unfilled deposit that we're going to slow fill:
     await updateAllClients();
     const data6 = dataworkerInstance._loadData();
@@ -262,7 +262,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       l1Token_2,
       depositor,
       originChainId,
-      amountToDeposit,
+      amountToDeposit
     );
     const fill3 = await buildFill(spokePool_1, erc20_1, depositor, relayer, deposit3, 0.25);
     const slowRelays = [

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -21,7 +21,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     [owner, depositor, relayer] = await ethers.getSigners();
     ({ spokePool: spokePool_1, erc20: erc20_1 } = await deploySpokePoolWithToken(originChainId, destinationChainId));
     ({ spokePool: spokePool_2, erc20: erc20_2 } = await deploySpokePoolWithToken(destinationChainId, originChainId));
-    ({ hubPool, l1Token } = await deployAndConfigureHubPool(owner, [
+    ({ hubPool, l1Token_1: l1Token } = await deployAndConfigureHubPool(owner, [
       { l2ChainId: destinationChainId, spokePool: spokePool_2 },
     ]));
 

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -28,7 +28,7 @@ describe("Relayer: Token balance shortfall", async function () {
     [owner, depositor, relayer] = await ethers.getSigners();
     ({ spokePool: spokePool_1, erc20: erc20_1 } = await deploySpokePoolWithToken(originChainId, destinationChainId));
     ({ spokePool: spokePool_2, erc20: erc20_2 } = await deploySpokePoolWithToken(destinationChainId, originChainId));
-    ({ hubPool, l1Token } = await deployAndConfigureHubPool(owner, [
+    ({ hubPool, l1Token_1: l1Token } = await deployAndConfigureHubPool(owner, [
       { l2ChainId: destinationChainId, spokePool: spokePool_2 },
     ]));
 

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -23,7 +23,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     // prop is the chainId set on the spoke pool. The second prop is the chain ID enabled in the route on the spokePool.
     ({ spokePool: spokePool_1, erc20: erc20_1 } = await deploySpokePoolWithToken(originChainId, destinationChainId));
     ({ spokePool: spokePool_2, erc20: erc20_2 } = await deploySpokePoolWithToken(destinationChainId, originChainId));
-    ({ hubPool, l1Token } = await deployAndConfigureHubPool(owner, [
+    ({ hubPool, l1Token_1: l1Token } = await deployAndConfigureHubPool(owner, [
       { l2ChainId: originChainId, spokePool: spokePool_1 },
       { l2ChainId: destinationChainId, spokePool: spokePool_2 },
     ]));

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -4,6 +4,9 @@ export const randomOriginToken = randomAddress();
 export const randomDestinationToken = randomAddress();
 export const randomDestinationToken2 = randomAddress();
 
+// Max number of refunds in relayer refund leaf for a { repaymentChainId, L2TokenAddress }.
+export const MAX_REFUNDS_PER_LEAF = 3;
+
 // DAI's Rate model.
 export const sampleRateModel = {
   UBar: toWei(0.8).toString(),

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -40,7 +40,7 @@ export async function setupDataworker(ethers: any): Promise<{
   // Enable deposit routes for second L2 tokens so relays can be sent between spoke pool 1 <--> 2.
   await enableRoutes(spokePool_1, [{ originToken: erc20_2.address, destinationChainId: destinationChainId }]);
   await enableRoutes(spokePool_2, [{ originToken: erc20_1.address, destinationChainId: originChainId }]);
-  
+
   // For each chain, enable routes to both erc20's so that we can fill relays
   await enableRoutesOnHubPool(hubPool, [
     { destinationChainId: originChainId, l1Token: l1Token_1, destinationToken: erc20_1 },

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -2,15 +2,18 @@ import { deploySpokePoolWithToken, enableRoutesOnHubPool, Contract, hre, enableR
 import { SignerWithAddress, setupTokensForWallet, getLastBlockTime } from "../utils";
 import { createSpyLogger, winston, deployAndConfigureHubPool, deployRateModelStore } from "../utils";
 import { SpokePoolClient, HubPoolClient, RateModelClient, MultiCallerClient } from "../../src/clients";
-import { amountToLp, destinationChainId, originChainId } from "../constants";
+import { amountToLp, destinationChainId, MAX_REFUNDS_PER_LEAF, originChainId } from "../constants";
 
 import { Dataworker } from "../../src/dataworker/Dataworker"; // Tested
 
-export const dataworkerFixture = hre.deployments.createFixture(async ({ ethers }) => {
-  return await setupDataworker(ethers);
+export const dataworkerFixture = hre.deployments.createFixture(async ({ ethers }, maxRefundLeaf: number) => {
+  return await setupDataworker(ethers, maxRefundLeaf);
 });
 
-export async function setupDataworker(ethers: any): Promise<{
+export async function setupDataworker(
+  ethers: any,
+  maxRefundsPerLeaf: number
+): Promise<{
   spokePool_1: Contract;
   erc20_1: Contract;
   spokePool_2: Contract;
@@ -73,7 +76,8 @@ export async function setupDataworker(ethers: any): Promise<{
     spyLogger,
     { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 },
     hubPoolClient,
-    multiCallerClient
+    multiCallerClient,
+    maxRefundsPerLeaf
   );
 
   // Give owner tokens to LP on HubPool with.

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -1,4 +1,4 @@
-import { deploySpokePoolWithToken, enableRoutesOnHubPool, Contract, hre } from "../utils";
+import { deploySpokePoolWithToken, enableRoutesOnHubPool, Contract, hre, enableRoutes } from "../utils";
 import { SignerWithAddress, setupTokensForWallet, getLastBlockTime } from "../utils";
 import { createSpyLogger, winston, deployAndConfigureHubPool, deployRateModelStore } from "../utils";
 import { SpokePoolClient, HubPoolClient, RateModelClient, MultiCallBundler } from "../../src/clients";
@@ -15,7 +15,8 @@ export async function setupDataworker(ethers: any): Promise<{
   erc20_1: Contract;
   spokePool_2: Contract;
   erc20_2: Contract;
-  l1Token: Contract;
+  l1Token_1: Contract;
+  l1Token_2: Contract;
   spokePoolClient_1: SpokePoolClient;
   spokePoolClient_2: SpokePoolClient;
   rateModelClient: RateModelClient;
@@ -32,18 +33,24 @@ export async function setupDataworker(ethers: any): Promise<{
   const { spokePool: spokePool_2, erc20: erc20_2 } = await deploySpokePoolWithToken(destinationChainId, originChainId);
 
   // Only set cross chain contracts for one spoke pool to begin with.
-  const { hubPool, l1Token } = await deployAndConfigureHubPool(owner, [
+  const { hubPool, l1Token_1, l1Token_2 } = await deployAndConfigureHubPool(owner, [
     { l2ChainId: destinationChainId, spokePool: spokePool_2 },
   ]);
 
+  // Enable deposit routes for second L2 tokens so relays can be sent between spoke pool 1 <--> 2.
+  await enableRoutes(spokePool_1, [{ originToken: erc20_2.address, destinationChainId: destinationChainId }]);
+  await enableRoutes(spokePool_2, [{ originToken: erc20_1.address, destinationChainId: originChainId }]);
+  
   // For each chain, enable routes to both erc20's so that we can fill relays
   await enableRoutesOnHubPool(hubPool, [
-    { destinationChainId: originChainId, l1Token, destinationToken: erc20_1 },
-    { destinationChainId: destinationChainId, l1Token, destinationToken: erc20_2 },
+    { destinationChainId: originChainId, l1Token: l1Token_1, destinationToken: erc20_1 },
+    { destinationChainId: destinationChainId, l1Token: l1Token_1, destinationToken: erc20_2 },
+    { destinationChainId: originChainId, l1Token: l1Token_2, destinationToken: erc20_2 },
+    { destinationChainId: destinationChainId, l1Token: l1Token_2, destinationToken: erc20_1 },
   ]);
 
   const { spyLogger } = createSpyLogger();
-  const { rateModelStore } = await deployRateModelStore(owner, [l1Token]);
+  const { rateModelStore } = await deployRateModelStore(owner, [l1Token_1, l1Token_2]);
   const hubPoolClient = new HubPoolClient(spyLogger, hubPool);
   const rateModelClient = new RateModelClient(spyLogger, rateModelStore, hubPoolClient);
 
@@ -70,17 +77,19 @@ export async function setupDataworker(ethers: any): Promise<{
   );
 
   // Give owner tokens to LP on HubPool with.
-  await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // Seed owner to LP.
-  await l1Token.approve(hubPool.address, amountToLp);
-  await hubPool.addLiquidity(l1Token.address, amountToLp);
+  await setupTokensForWallet(spokePool_1, owner, [l1Token_1, l1Token_2], null, 100); // Seed owner to LP.
+  await l1Token_1.approve(hubPool.address, amountToLp);
+  await l1Token_2.approve(hubPool.address, amountToLp);
+  await hubPool.addLiquidity(l1Token_1.address, amountToLp);
+  await hubPool.addLiquidity(l1Token_2.address, amountToLp);
 
   // Give depositors the tokens they'll deposit into spoke pools:
-  await setupTokensForWallet(spokePool_1, depositor, [erc20_1], null, 10);
-  await setupTokensForWallet(spokePool_2, depositor, [erc20_2], null, 10);
+  await setupTokensForWallet(spokePool_1, depositor, [erc20_1, erc20_2], null, 10);
+  await setupTokensForWallet(spokePool_2, depositor, [erc20_2, erc20_1], null, 10);
 
   // Give relayers the tokens they'll need to relay on spoke pools:
-  await setupTokensForWallet(spokePool_1, relayer, [erc20_1, erc20_2, l1Token], null, 10);
-  await setupTokensForWallet(spokePool_2, relayer, [erc20_1, erc20_2, l1Token], null, 10);
+  await setupTokensForWallet(spokePool_1, relayer, [erc20_1, erc20_2, l1Token_1, l1Token_2], null, 10);
+  await setupTokensForWallet(spokePool_2, relayer, [erc20_1, erc20_2, l1Token_1, l1Token_2], null, 10);
 
   // Set the spokePool's time to the provider time. This is done to enable the block utility time finder identify a
   // "reasonable" block number based off the block time when looking at quote timestamps.
@@ -92,7 +101,8 @@ export async function setupDataworker(ethers: any): Promise<{
     erc20_1,
     spokePool_2,
     erc20_2,
-    l1Token,
+    l1Token_1,
+    l1Token_2,
     spokePoolClient_1,
     spokePoolClient_2,
     rateModelClient,

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -397,7 +397,7 @@ export async function buildFillForRepaymentChain(
         .mul(toBNWei(pctOfDepositToFill))
         .div(toBNWei(1))
         .div(toBNWei(1)),
-        repaymentChainId
+      repaymentChainId
     )
   );
   const [events, destinationChainId] = await Promise.all([

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -31,7 +31,7 @@ export async function setupTokensForWallet(
   spokePool: utils.Contract,
   wallet: utils.SignerWithAddress,
   tokens: utils.Contract[],
-  weth: utils.Contract,
+  weth?: utils.Contract,
   seedMultiplier: number = 1
 ) {
   await utils.seedWallet(wallet, tokens, weth, utils.amountToSeedWallets.mul(seedMultiplier));

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -91,10 +91,12 @@ export async function deployAndConfigureHubPool(
     await hubPool.setCrossChainContracts(spokePool.l2ChainId, mockAdapter.address, spokePool.spokePool.address);
   }
 
-  const l1Token = await (await utils.getContractFactory("ExpandedERC20", signer)).deploy("Rando L1", "L1", 18);
-  await l1Token.addMember(TokenRolesEnum.MINTER, signer.address);
+  const l1Token_1 = await (await utils.getContractFactory("ExpandedERC20", signer)).deploy("Rando L1", "L1", 18);
+  await l1Token_1.addMember(TokenRolesEnum.MINTER, signer.address);
+  const l1Token_2 = await (await utils.getContractFactory("ExpandedERC20", signer)).deploy("Rando L1", "L1", 18);
+  await l1Token_2.addMember(TokenRolesEnum.MINTER, signer.address);
 
-  return { hubPool, mockAdapter, l1Token };
+  return { hubPool, mockAdapter, l1Token_1, l1Token_2 };
 }
 
 export async function enableRoutesOnHubPool(
@@ -341,6 +343,61 @@ export async function buildModifiedFill(
         .div(toBNWei(1)),
       updatedRelayerFeePct,
       signature
+    )
+  );
+  const [events, destinationChainId] = await Promise.all([
+    spokePool.queryFilter(spokePool.filters.FilledRelay()),
+    spokePool.chainId(),
+  ]);
+  const lastEvent = events[events.length - 1];
+  if (lastEvent.args)
+    return {
+      amount: lastEvent.args.amount,
+      totalFilledAmount: lastEvent.args.totalFilledAmount,
+      fillAmount: lastEvent.args.fillAmount,
+      repaymentChainId: Number(lastEvent.args.repaymentChainId),
+      originChainId: Number(lastEvent.args.originChainId),
+      relayerFeePct: lastEvent.args.relayerFeePct,
+      appliedRelayerFeePct: lastEvent.args.appliedRelayerFeePct,
+      realizedLpFeePct: lastEvent.args.realizedLpFeePct,
+      depositId: lastEvent.args.depositId,
+      destinationToken: lastEvent.args.destinationToken,
+      relayer: lastEvent.args.relayer,
+      depositor: lastEvent.args.depositor,
+      recipient: lastEvent.args.recipient,
+      isSlowRelay: lastEvent.args.isSlowRelay,
+      destinationChainId: Number(destinationChainId),
+    };
+  else return null;
+}
+
+export async function buildFillForRepaymentChain(
+  spokePool: Contract,
+  relayer: SignerWithAddress,
+  depositToFill: Deposit,
+  pctOfDepositToFill: number,
+  repaymentChainId: number
+): Promise<Fill> {
+  const relayDataFromDeposit = {
+    depositor: depositToFill.depositor,
+    recipient: depositToFill.recipient,
+    destinationToken: depositToFill.destinationToken,
+    amount: depositToFill.amount,
+    originChainId: depositToFill.originChainId.toString(),
+    destinationChainId: depositToFill.destinationChainId.toString(),
+    realizedLpFeePct: depositToFill.realizedLpFeePct,
+    relayerFeePct: depositToFill.relayerFeePct,
+    depositId: depositToFill.depositId.toString(),
+  };
+  await spokePool.connect(relayer).fillRelay(
+    ...utils.getFillRelayParams(
+      relayDataFromDeposit,
+      depositToFill.amount
+        .mul(toBNWei(1).sub(depositToFill.realizedLpFeePct.add(depositToFill.relayerFeePct)))
+        .mul(toBNWei(pctOfDepositToFill))
+        .div(toBNWei(1))
+        .div(toBNWei(1)),
+        repaymentChainId
     )
   );
   const [events, destinationChainId] = await Promise.all([


### PR DESCRIPTION
- Change key of `fillsToRefund` from `relayerAddress` to `destinationToken` since we need to group refunds for a given `repaymentChainId` by `destinationToken`

Follow up PR will implement:
- Implementing `amountToReturn` computation and logic