### PR TITLE
Implement initial runningBalances computation in buildPoolRebalanceRoot

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,5 +13,7 @@ module.exports = {
   },
   rules: {
     "node/no-unsupported-features/es-syntax": ["error", { ignores: ["modules"] }],
+    camelcase: "off",
+    "@typescript-eslint/camelcase": "off",
   },
 };

--- a/src/clients/DataworkerClientHelper.ts
+++ b/src/clients/DataworkerClientHelper.ts
@@ -4,3 +4,7 @@ import { Clients } from "./ClientHelper";
 export interface DataworkerClients extends Clients {
   configStoreClient: ConfigStoreClient;
 }
+
+// Used for determining which block range corresponsd to which network. In order, the block ranges passed
+// in the HubPool's proposeRootBundle method should be: Mainnet, Optimism, Polygon, Boba, Arbitrum
+export const CHAIN_ID_LIST_INDICES = ["1", "10", "137", "288", "42161"];

--- a/src/clients/DataworkerClientHelper.ts
+++ b/src/clients/DataworkerClientHelper.ts
@@ -7,4 +7,4 @@ export interface DataworkerClients extends Clients {
 
 // Used for determining which block range corresponsd to which network. In order, the block ranges passed
 // in the HubPool's proposeRootBundle method should be: Mainnet, Optimism, Polygon, Boba, Arbitrum
-export const CHAIN_ID_LIST_INDICES = ["1", "10", "137", "288", "42161"];
+export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -40,10 +40,10 @@ export class HubPoolClient {
   getL1TokenCounterpart(repaymentChainId: string, l2Token: string) {
     let l1Token = null;
     Object.keys(this.l1TokensToDestinationTokens).forEach((_l1Token) => {
-      if (this.l1TokensToDestinationTokens[_l1Token][repaymentChainId] === l2Token)
-        l1Token = _l1Token;
+      if (this.l1TokensToDestinationTokens[_l1Token][repaymentChainId] === l2Token) l1Token = _l1Token;
     });
-    if (l1Token === null) throw new Error(`Could not find L1 Token for repayment chain ${repaymentChainId} and L2 token ${l2Token}!`);
+    if (l1Token === null)
+      throw new Error(`Could not find L1 Token for repayment chain ${repaymentChainId} and L2 token ${l2Token}!`);
     return l1Token;
   }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1,5 +1,6 @@
-import { spreadEvent, assign, Contract, winston, BigNumber, ERC20, Event } from "../utils";
+import { spreadEvent, assign, Contract, winston, BigNumber, ERC20, Event, sortEventsAscending } from "../utils";
 import { Deposit, Fill, L1Token } from "../interfaces";
+import { SpokePoolClient, CHAIN_ID_LIST_INDICES } from ".";
 
 export class HubPoolClient {
   // L1Token -> destinationChainId -> destinationToken
@@ -81,6 +82,31 @@ export class HubPoolClient {
   getTokenInfo(chainId: number | string, tokenAddress: string): L1Token {
     const deposit = { originChainId: parseInt(chainId.toString()), originToken: tokenAddress } as Deposit;
     return this.getTokenInfoForDeposit(deposit);
+  }
+
+  // TODO:
+  // Query CrossChainContractsSet events to find spoke pools at specified `block`.
+  // getCrossChainContractsForBlock(block:number): { [chainId: number]: SpokePoolClient } {
+  // }
+
+  // // Returns an ordered array of block ranges for each spoke pool. For an ordered list of `toBlocks`, this function
+  // // will find the corresponding `fromBlocks` for each chain. The order of chains can be found in CHAIN_ID_LIST.
+  // getRootBundleEvaluationBlockRange(toBlocks: number[]): number[][] {
+  //   // Find latest RootBundleExecuted event with matching chain ID while still being earlier than the toBlock.
+  //   const blockRanges: number[][] = toBlocks.map((block, i) => {
+  //     const chainId = CHAIN_ID_LIST_INDICES[i]
+  //     // Sort event block heights from latest to earliest, so we find the events right before our target block.
+  //     const precedingExecuteRootBundleEvent: Event = this.executeRootBundleEvents.sort((ex, ey) => ey.blockNumber - ex.blockNumber).find(
+  //       (e: Event) => e.args.chainId === chainId && e.blockNumber < block
+  //     );
+  //     const precedingProposeRootBundleEvent: Event = this.proposeRootBundleEvents.sort((ex, ey) => ey.blockNumber - ex.blockNumber).find(
+  //       (e: Event) => e.blockNumber < precedingExecuteRootBundleEvent.blockNumber
+  //     );
+  //   })
+  // }
+
+  getEarliestProposeRootEventAfterBlock(block: number): Event {
+    return sortEventsAscending(this.proposeRootBundleEvents).find((e: Event) => e.blockNumber > block) as Event;
   }
 
   async update() {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1,4 +1,5 @@
-import { spreadEvent, assign, Contract, winston, BigNumber, ERC20, Event, sortEventsAscending, toBN } from "../utils";
+import { assign, Contract, winston, BigNumber, ERC20, sortEventsAscending, toBN } from "../utils";
+import { spreadEvent, spreadEventWithBlockNumber } from "../utils";
 import { Deposit, L1Token, ProposedRootBundle } from "../interfaces";
 
 export class HubPoolClient {
@@ -123,9 +124,7 @@ export class HubPoolClient {
     for (const info of tokenInfo) if (!this.l1Tokens.includes(info)) this.l1Tokens.push(info);
 
     this.proposedRootBundles.push(
-      ...proposeRootBundleEvents.map((e): ProposedRootBundle => {
-        return { ...spreadEvent(e), blockNumber: e.blockNumber };
-      })
+      ...proposeRootBundleEvents.map((e): ProposedRootBundle => spreadEventWithBlockNumber(e))
     );
 
     this.isUpdated = true;

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1,5 +1,5 @@
 import { spreadEvent, assign, Contract, winston, BigNumber, ERC20 } from "../utils";
-import { Deposit, L1Token } from "../interfaces";
+import { Deposit, Fill, L1Token } from "../interfaces";
 
 export class HubPoolClient {
   // L1Token -> destinationChainId -> destinationToken
@@ -34,6 +34,16 @@ export class HubPoolClient {
         l1Token = _l1Token;
     });
     if (l1Token === null) throw new Error(`Could not find L1 Token for deposit!,${JSON.stringify(deposit)}`);
+    return l1Token;
+  }
+
+  getL1TokenCounterpart(repaymentChainId: string, l2Token: string) {
+    let l1Token = null;
+    Object.keys(this.l1TokensToDestinationTokens).forEach((_l1Token) => {
+      if (this.l1TokensToDestinationTokens[_l1Token][repaymentChainId] === l2Token)
+        l1Token = _l1Token;
+    });
+    if (l1Token === null) throw new Error(`Could not find L1 Token for repayment chain ${repaymentChainId} and L2 token ${l2Token}!`);
     return l1Token;
   }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -92,8 +92,7 @@ export class HubPoolClient {
         throw new Error("Chain ID list and bundle block eval range list length do not match");
       const chainIdIndex = chainIdList.indexOf(chain);
       if (chainIdIndex === -1) throw new Error("Can't find fill.destinationChainId in CHAIN_ID_LIST");
-      if (bundleEvaluationBlockNumbers[chainIdIndex].gt(toBN(block)))
-        // TODO: Can this be a `gte`?
+      if (bundleEvaluationBlockNumbers[chainIdIndex].gte(toBN(block)))
         endingBlockNumber = bundleEvaluationBlockNumbers[chainIdIndex].toNumber();
     });
     if (!endingBlockNumber) throw new Error("Can't find ProposeRootBundle event containing block");

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -88,12 +88,13 @@ export class HubPoolClient {
     this.logger.debug({ at: "HubPoolClient", message: "Updating client", searchConfig });
     if (searchConfig[0] > searchConfig[1]) return; // If the starting block is greater than the ending block return.
 
-    const [poolRebalanceRouteEvents, l1TokensLPEvents, proposeRootBundleEvents, executeRootBundleEvents] = await Promise.all([
+    const [poolRebalanceRouteEvents, l1TokensLPEvents, proposeRootBundleEvents, executeRootBundleEvents] =
+      await Promise.all([
         this.hubPool.queryFilter(this.hubPool.filters.SetPoolRebalanceRoute(), ...searchConfig),
         this.hubPool.queryFilter(this.hubPool.filters.L1TokenEnabledForLiquidityProvision(), ...searchConfig),
         this.hubPool.queryFilter(this.hubPool.filters.ProposeRootBundle(), ...searchConfig),
         this.hubPool.queryFilter(this.hubPool.filters.RootBundleExecuted(), ...searchConfig),
-    ]);
+      ]);
 
     for (const event of poolRebalanceRouteEvents) {
       const args = spreadEvent(event);

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -95,7 +95,6 @@ export class HubPoolClient {
       if (bundleEvaluationBlockNumbers[chainIdIndex].gte(toBN(block)))
         endingBlockNumber = bundleEvaluationBlockNumbers[chainIdIndex].toNumber();
     });
-    if (!endingBlockNumber) throw new Error("Can't find ProposeRootBundle event containing block");
     return endingBlockNumber;
   }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -95,6 +95,7 @@ export class HubPoolClient {
       const chainIdIndex = chainIdList.indexOf(chain);
       if (chainIdIndex === -1) throw new Error("Can't find fill.destinationChainId in CHAIN_ID_LIST");
       if (bundleEvaluationBlockNumbers[chainIdIndex].gt(toBN(block)))
+        // TODO: Can this be a `gte`?
         endingBlockNumber = bundleEvaluationBlockNumbers[chainIdIndex].toNumber();
     });
     if (!endingBlockNumber) throw new Error("Can't find ProposeRootBundle event containing block");

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -84,27 +84,6 @@ export class HubPoolClient {
     return this.getTokenInfoForDeposit(deposit);
   }
 
-  // TODO:
-  // Query CrossChainContractsSet events to find spoke pools at specified `block`.
-  // getCrossChainContractsForBlock(block:number): { [chainId: number]: SpokePoolClient } {
-  // }
-
-  // // Returns an ordered array of block ranges for each spoke pool. For an ordered list of `toBlocks`, this function
-  // // will find the corresponding `fromBlocks` for each chain. The order of chains can be found in CHAIN_ID_LIST.
-  // getRootBundleEvaluationBlockRange(toBlocks: number[]): number[][] {
-  //   // Find latest RootBundleExecuted event with matching chain ID while still being earlier than the toBlock.
-  //   const blockRanges: number[][] = toBlocks.map((block, i) => {
-  //     const chainId = CHAIN_ID_LIST_INDICES[i]
-  //     // Sort event block heights from latest to earliest, so we find the events right before our target block.
-  //     const precedingExecuteRootBundleEvent: Event = this.executeRootBundleEvents.sort((ex, ey) => ey.blockNumber - ex.blockNumber).find(
-  //       (e: Event) => e.args.chainId === chainId && e.blockNumber < block
-  //     );
-  //     const precedingProposeRootBundleEvent: Event = this.proposeRootBundleEvents.sort((ex, ey) => ey.blockNumber - ex.blockNumber).find(
-  //       (e: Event) => e.blockNumber < precedingExecuteRootBundleEvent.blockNumber
-  //     );
-  //   })
-  // }
-
   // This should find the ProposeRootBundle event whose bundle block number for `chain` is closest to the `block`
   // without being smaller. It returns the bundle block number for the chain.
   getRootBundleEvalBlockNumberContainingBlock(block: number, chain: number, chainIdList: number[]): number {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -106,7 +106,7 @@ export class HubPoolClient {
   // }
 
   getEarliestProposeRootEventAfterBlock(block: number): Event {
-    return sortEventsAscending(this.proposeRootBundleEvents).find((e: Event) => e.blockNumber > block) as Event;
+    return sortEventsAscending(this.proposeRootBundleEvents).find((e: Event) => e.blockNumber >= block) as Event;
   }
 
   async update() {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -7,7 +7,9 @@ export class HubPoolClient {
   private l1TokensToDestinationTokens: { [l1Token: string]: { [destinationChainId: number]: string } } = {};
   private l1Tokens: L1Token[] = []; // L1Tokens and their associated info.
   private proposedRootBundles: ProposedRootBundle[] = [];
-  private l1TokensToDestinationTokensWithBlock: { [l1Token: string]: { [destinationChainId: number]: [{ l2Token: string, block: number }] } } = {};
+  private l1TokensToDestinationTokensWithBlock: {
+    [l1Token: string]: { [destinationChainId: number]: [{ l2Token: string; block: number }] };
+  } = {};
 
   public isUpdated: boolean = false;
   public firstBlockToSearch: number;
@@ -41,17 +43,17 @@ export class HubPoolClient {
   }
 
   getL1TokenCounterpartAtBlock(l2ChainId: string, l2Token: string, block: number) {
-    const l1Token = Object.keys(this.l1TokensToDestinationTokensWithBlock).find(
-      (_l1Token) => {
-          // We assume that l2-l1 token mapping events are sorted in descending order, so find the last mapping published
-          // before the target block.
-        return this.l1TokensToDestinationTokensWithBlock[_l1Token][l2ChainId].find(
-          (mapping: { l2Token: string; block: number }) => mapping.l2Token === l2Token && mapping.block <= block
-        )
-      }
-    );
+    const l1Token = Object.keys(this.l1TokensToDestinationTokensWithBlock).find((_l1Token) => {
+      // We assume that l2-l1 token mapping events are sorted in descending order, so find the last mapping published
+      // before the target block.
+      return this.l1TokensToDestinationTokensWithBlock[_l1Token][l2ChainId].find(
+        (mapping: { l2Token: string; block: number }) => mapping.l2Token === l2Token && mapping.block <= block
+      );
+    });
     if (!l1Token)
-      throw new Error(`Could not find L1 token mapping for chain ${l2ChainId} and L2 token ${l2Token} equal to or earlier than block ${block}!`);
+      throw new Error(
+        `Could not find L1 token mapping for chain ${l2ChainId} and L2 token ${l2Token} equal to or earlier than block ${block}!`
+      );
     return l1Token;
   }
 
@@ -105,7 +107,7 @@ export class HubPoolClient {
         // as we find the first block range that contains the target block.
         break;
       }
-    };
+    }
     return endingBlockNumber;
   }
 
@@ -128,15 +130,15 @@ export class HubPoolClient {
         [args.l1Token, args.destinationChainId],
         [{ l2Token: args.destinationToken, block: event.blockNumber }]
       );
-      // Sort l2 token to l1 token mapping events in descending order so we can easily find the first mapping update 
+      // Sort l2 token to l1 token mapping events in descending order so we can easily find the first mapping update
       // equal to or earlier than a target block. This allows a caller to look up the l1 token counterpart for an l2
       // token at a specific block height.
-      this.l1TokensToDestinationTokensWithBlock[args.l1Token][args.destinationChainId]
-        .sort((mappingA: { block: number }, mappingB: { block: number }) => {
-            return mappingB.block - mappingA.block;
-        })
+      this.l1TokensToDestinationTokensWithBlock[args.l1Token][args.destinationChainId].sort(
+        (mappingA: { block: number }, mappingB: { block: number }) => {
+          return mappingB.block - mappingA.block;
+        }
+      );
     }
-
 
     // For each enabled Lp token fetch the token symbol and decimals from the token contract. Note this logic will
     // only run iff a new token has been enabled. Will only append iff the info is not there already.

--- a/src/clients/RateModelClient.ts
+++ b/src/clients/RateModelClient.ts
@@ -50,6 +50,8 @@ export class RateModelClient {
   }
 
   async update() {
+    if (this.hubPoolClient !== null && !this.hubPoolClient.isUpdated) throw new Error("HubPool not updated");
+
     const searchConfig = [this.firstBlockToSearch, await this.rateModelStore.provider.getBlockNumber()];
     this.logger.debug({ at: "RateModelClient", message: "Updating client", searchConfig });
     if (searchConfig[0] > searchConfig[1]) return; // If the starting block is greater than the ending block return.

--- a/src/clients/RateModelClient.ts
+++ b/src/clients/RateModelClient.ts
@@ -58,7 +58,6 @@ export class RateModelClient {
       ...searchConfig
     );
 
-    console.log(rateModelStoreEvents);
     for (const event of rateModelStoreEvents) {
       const args = {
         blockNumber: event.blockNumber,

--- a/src/clients/RateModelClient.ts
+++ b/src/clients/RateModelClient.ts
@@ -58,6 +58,7 @@ export class RateModelClient {
       ...searchConfig
     );
 
+    console.log(rateModelStoreEvents);
     for (const event of rateModelStoreEvents) {
       const args = {
         blockNumber: event.blockNumber,

--- a/src/clients/RateModelClient.ts
+++ b/src/clients/RateModelClient.ts
@@ -24,7 +24,10 @@ export class RateModelClient {
     this.rateModelDictionary = new across.rateModel.RateModelDictionary();
   }
 
-  async computeRealizedLpFeePct(deposit: Deposit, l1Token: string): Promise<BigNumber> {
+  async computeRealizedLpFeePct(
+    deposit: Deposit,
+    l1Token: string
+  ): Promise<{ realizedLpFeePct: BigNumber; quoteBlock: number }> {
     const quoteBlock = (await this.blockFinder.getBlockForTimestamp(deposit.quoteTimestamp)).number;
 
     const { current, post } = await this.hubPoolClient.getPostRelayPoolUtilization(l1Token, quoteBlock, deposit.amount);
@@ -42,7 +45,7 @@ export class RateModelClient {
       realizedLpFeePct,
     });
 
-    return realizedLpFeePct;
+    return { realizedLpFeePct, quoteBlock };
   }
 
   getRateModelForBlockNumber(l1Token: string, blockNumber: number | undefined = undefined): across.constants.RateModel {

--- a/src/clients/RateModelClient.ts
+++ b/src/clients/RateModelClient.ts
@@ -24,7 +24,10 @@ export class RateModelClient {
     this.rateModelDictionary = new across.rateModel.RateModelDictionary();
   }
 
-  async computeRealizedLpFeePct(deposit: Deposit, l1Token: string): Promise<{ realizedLpFeePct: BigNumber; quoteBlock: number }> {
+  async computeRealizedLpFeePct(
+    deposit: Deposit,
+    l1Token: string
+  ): Promise<{ realizedLpFeePct: BigNumber; quoteBlock: number }> {
     // The below is a temp work around to deal with the incorrect deployment that was done on all test nets. If the rate
     // model store is deployed after the a fill is done then some calls to this method will fail, resulting in an error.
     // For test nets we can just work around this by using the latest block number.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -147,9 +147,13 @@ export class SpokePoolClient {
       // Append the realizedLpFeePct.
       const deposit: Deposit = { ...spreadEvent(event), realizedLpFeePct: dataForQuoteTime[index].realizedLpFeePct };
       // Append the destination token to the deposit.
-      deposit.destinationToken = this.getDestinationTokenForDeposit(deposit); 
+      deposit.destinationToken = this.getDestinationTokenForDeposit(deposit);
       assign(this.deposits, [deposit.destinationChainId], [deposit]);
-      assign(this.depositsWithBlockNumbers, [deposit.destinationChainId], [{ ...deposit, blockNumber: dataForQuoteTime[index].quoteBlock }]);
+      assign(
+        this.depositsWithBlockNumbers,
+        [deposit.destinationChainId],
+        [{ ...deposit, blockNumber: dataForQuoteTime[index].quoteBlock }]
+      );
     }
 
     for (const event of speedUpEvents) {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,5 +1,5 @@
 import { assign, Contract, BigNumber, toBN, Event, ZERO_ADDRESS, winston } from "../utils";
-import { spreadEventWithBlockNumber, spreadEvent } from "../utils"
+import { spreadEventWithBlockNumber, spreadEvent } from "../utils";
 import { RateModelClient } from "./RateModelClient";
 import { Deposit, Fill, SpeedUp, FillWithBlock } from "../interfaces/SpokePool";
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -275,16 +275,14 @@ export class Dataworker {
 
       // 4. Map all slow fills to an L1 token using its destination chain ID and destination token.
       let filteredSlowFills = slowFills.filter(
-        // First filter out all slow fills with fillAmount == 0 and that have already been included in a previous pool
-        // rebalance.
+        // First filter out all repeat slow fills. This would be all slow fills with `fillAmount == 0` and that have a
+        // matching slow fill.
         (slowFill: Fill) =>
-          !(
-            slowFill.fillAmount.eq(toBN(0)) &&
-            slowFills.some(
+            slowFill.fillAmount.gt(toBN(0)) ||
+            !slowFills.some(
               (otherSlowFill: Fill) =>
                 otherSlowFill.originChainId === slowFill.originChainId && otherSlowFill.depositId === slowFill.depositId
             )
-          )
       );
     }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -59,7 +59,7 @@ export class Dataworker {
             if (!fill.isSlowRelay) {
               // Save fill data and associate with repayment chain and token.
               assign(fillsToRefund, [fill.repaymentChainId, fill.destinationToken, "fills"], [fill]);
-              
+
               // Update refund amount for the recipient of the refund, i.e. the relayer.
               const refund = getRefundForFills([fill]);
               const refunds = fillsToRefund[fill.repaymentChainId][fill.destinationToken].refunds;
@@ -67,8 +67,7 @@ export class Dataworker {
                 // Initiate refunds dictionary if it doesn't exist.
                 assign(fillsToRefund, [fill.repaymentChainId, fill.destinationToken, "refunds"], {});
                 fillsToRefund[fill.repaymentChainId][fill.destinationToken].refunds[fill.relayer] = refund;
-              } 
-              else if (refunds[fill.relayer]) refunds[fill.relayer] = refunds[fill.relayer].add(refund);
+              } else if (refunds[fill.relayer]) refunds[fill.relayer] = refunds[fill.relayer].add(refund);
               else refunds[fill.relayer] = refund;
             }
             const depositUnfilledAmount = fill.amount.sub(fill.totalFilledAmount);
@@ -231,7 +230,7 @@ export class Dataworker {
     if (Object.keys(fillsToRefund).length > 0) {
       Object.keys(fillsToRefund).forEach((repaymentChainId: string) => {
         Object.keys(fillsToRefund[repaymentChainId]).forEach((l2TokenAddress: string) => {
-          assign(runningBalances, [repaymentChainId, l2TokenAddress], toBN(0))
+          assign(runningBalances, [repaymentChainId, l2TokenAddress], toBN(0));
           Object.values(fillsToRefund[repaymentChainId][l2TokenAddress].refunds).forEach(
             (refund: BigNumber) =>
               (runningBalances[repaymentChainId][l2TokenAddress] =
@@ -242,7 +241,6 @@ export class Dataworker {
     }
 
     console.log(runningBalances);
-
 
     // For each destination chain ID key in unfilledDeposits
     //     Group by L1 token and for each L1 token:

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -259,7 +259,7 @@ export class Dataworker {
     const runningBalances: RunningBalances = {};
     const realizedLpFees: RunningBalances = {}; // Realized LP fees dictionary has same shape as runningBalances.
 
-    // 1. For each FilledRelay group, identified by { repaymentChainId, L1TokenAddress }, initiate a "running balance"
+    // 1. For each FilledRelay group, identified by { repaymentChainId, L1TokenAddress }, initialize a "running balance"
     // to the total refund amount for that group.
     // 2. Similarly, for each group sum the realized LP fees.
     if (Object.keys(fillsToRefund).length > 0) {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -326,7 +326,6 @@ export class Dataworker {
                 fillThatTriggeredSlowFill.destinationChainId,
                 this.chainIdListForBundleEvaluationBlockNumbers
               );
-              console.log(endingBlockNumberForRootBundleContainingSlowFill, allFills)
             // Using bundle block number for chain from ProposeRootBundleEvent, find latest fill in the root bundle.
             const lastFillBeforeSlowFillIncludedInRoot = sortEventsDescending(allFills).find(
               (fill: FillWithBlock) =>
@@ -384,6 +383,8 @@ export class Dataworker {
     // 6. Factor in latest RootBundleExecuted.runningBalance before this one.
 
     // 7. Factor in MAX_POOL_REBALANCE_LEAF_SIZE
+
+    // TODO: Add helpful logs everywhere.
 
     return {
       runningBalances,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -341,18 +341,23 @@ export class Dataworker {
   //   // 4. For all fills that completely filled a relay and that followed a partial fill from a previous epoch, we need 
   //   // to decrease running balances by the slow fill amount sent in the previous epoch, since the slow relay was never
   //   // executed, allowing the fill to be sent completely filling the deposit.
-  //   allValidFills.filter(
-  //     (fill: Fill) => fill.totalFilledAmount === fill.amount && !this._isFirstFillForDeposit(fill)
-  //   ).forEach((fullFill: FillWithBlock) => {
-  //     // If first fill for this deposit is in this epoch, then no slow fill has been sent so we can ignore this full.
-  //     // We can check this by searching for a ProposeRootBundle event with a bundle block range that contains the 
-  //     // first fill for this deposit. If not found, then the first fill is in the current bundle and we can exit early.
-  //     const firstFill = allValidFills.find((fill: FillWithBlock) => this._isFirstFillForDeposit(fill as Fill) && this._filledSameDeposit(fill as Fill, fullFill as Fill))
-  //     if (!this.clients.hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(
-  //       firstFill.blockNumber,
-  //       firstFill.destinationChainId,
-  //       this.chainIdListForBundleEvaluationBlockNumbers
-  //     )) return;
+    allValidFills.filter(
+      (fill: Fill) => !fill.isSlowRelay && fill.totalFilledAmount.eq(fill.amount) && !this._isFirstFillForDeposit(fill)
+    ).forEach((fullFill: FillWithBlock) => {
+      // If first fill for this deposit is in this epoch, then no slow fill has been sent so we can ignore this full.
+      // We can check this by searching for a ProposeRootBundle event with a bundle block range that contains the 
+      // first fill for this deposit. If not found, then the first fill is in the current bundle and we can exit early.
+      const firstFill = allValidFills.find((fill: FillWithBlock) => this._isFirstFillForDeposit(fill as Fill) && this._filledSameDeposit(fill as Fill, fullFill as Fill))
+      console.log(firstFill, this.clients.hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(
+        firstFill.blockNumber,
+        firstFill.destinationChainId,
+        this.chainIdListForBundleEvaluationBlockNumbers
+      ))
+      if (!this.clients.hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(
+        firstFill.blockNumber,
+        firstFill.destinationChainId,
+        this.chainIdListForBundleEvaluationBlockNumbers
+      )) return;
 
   //     // If first fill is in a previous epoch, find it and identify the ProposeRootBundle event that included a slow
   //     // fill refund for it.
@@ -387,7 +392,7 @@ export class Dataworker {
   //     if (runningBalance)
   //       runningBalances[fullFill.destinationChainId][l1TokenCounterpart] = runningBalance.sub(extraFundsSent);
   //     else runningBalances[fullFill.destinationChainId][l1TokenCounterpart] = extraFundsSent.mul(toBN(-1));
-  // });
+  });
 
     
     // 4. Map each deposit event to its L1 token and origin chain ID and subtract deposited amounts from running

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -81,7 +81,7 @@ export class Dataworker {
               refundObj.realizedLpFees = refundObj.realizedLpFees
                 ? refundObj.realizedLpFees.add(getRealizedLpFeeForFills([fill]))
                 : getRealizedLpFeeForFills([fill]);
-            } else slowFills.push(fill)
+            } else slowFills.push(fill);
             const depositUnfilledAmount = fill.amount.sub(fill.totalFilledAmount);
             const depositKey = `${originChainId}+${fill.depositId}`;
             assign(
@@ -278,11 +278,11 @@ export class Dataworker {
         // First filter out all repeat slow fills. This would be all slow fills with `fillAmount == 0` and that have a
         // matching slow fill.
         (slowFill: Fill) =>
-            slowFill.fillAmount.gt(toBN(0)) ||
-            !slowFills.some(
-              (otherSlowFill: Fill) =>
-                otherSlowFill.originChainId === slowFill.originChainId && otherSlowFill.depositId === slowFill.depositId
-            )
+          slowFill.fillAmount.gt(toBN(0)) ||
+          !slowFills.some(
+            (otherSlowFill: Fill) =>
+              otherSlowFill.originChainId === slowFill.originChainId && otherSlowFill.depositId === slowFill.depositId
+          )
       );
     }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -274,9 +274,9 @@ export class Dataworker {
       });
 
       // 4. Map all slow fills to an L1 token using its destination chain ID and destination token.
+      // Filter out all repeat slow fills. This would be all slow fills with `fillAmount == 0` and that have a
+      // matching slow fill.
       let filteredSlowFills = slowFills.filter(
-        // First filter out all repeat slow fills. This would be all slow fills with `fillAmount == 0` and that have a
-        // matching slow fill.
         (slowFill: Fill) =>
           slowFill.fillAmount.gt(toBN(0)) ||
           !slowFills.some(
@@ -284,6 +284,17 @@ export class Dataworker {
               otherSlowFill.originChainId === slowFill.originChainId && otherSlowFill.depositId === slowFill.depositId
           )
       );
+
+      // 5. for all non-repeat slow fills, find the FilledRelay event that originally triggered this slow relay.
+      // Recall that slow fills for a deposit are only included in the root bundle if a non-zero amount fill was
+      // submitted for that deposit.
+
+      // 6. Using the block number of the FilledRelay event that triggered the slow fill, determine the root bundle 
+      // block range that would have included the slow fill and then grab the unfilled amount for the slow fill
+      // at this previous block range.
+
+      // 7. Subtract the current slow fill filledAmount from the originally sent unfilledAmount for the original
+      // slow relay included in the root bundle to determine how to adjust the running balance.
     }
 
     console.log(runningBalances, realizedLpFees);

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1,26 +1,9 @@
-import {
-  winston,
-  assign,
-  buildSlowRelayTree,
-  MerkleTree,
-  toBN,
-  compareAddresses,
-  getRefundForFills,
-  sortEventsDescending,
-} from "../utils";
-import { RelayerRefundLeaf, RelayerRefundLeafWithGroup, BigNumber, buildRelayerRefundTree } from "../utils";
+import { winston, assign, MerkleTree, toBN, compareAddresses, getRefundForFills, sortEventsDescending } from "../utils";
+import { RelayerRefundLeaf, RelayerRefundLeafWithGroup, buildRelayerRefundTree, buildSlowRelayTree } from "../utils";
 import { getRealizedLpFeeForFills, sortEventsAscending } from "../utils";
-import {
-  FillsToRefund,
-  RelayData,
-  UnfilledDeposit,
-  Deposit,
-  Fill,
-  BundleEvaluationBlockNumbers,
-  FillWithBlock,
-} from "../interfaces";
-import { RunningBalances } from "../interfaces";
-import { CHAIN_ID_LIST_INDICES, DataworkerClients } from "../clients";
+import { FillsToRefund, RelayData, UnfilledDeposit, Deposit, Fill, FillWithBlock } from "../interfaces";
+import { RunningBalances, BundleEvaluationBlockNumbers } from "../interfaces";
+import { DataworkerClients } from "../clients";
 
 // @notice Constructs roots to submit to HubPool on L1. Fetches all data synchronously from SpokePool/HubPool clients
 // so this class assumes that those upstream clients are already updated and have fetched on-chain data from RPC's.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -316,7 +316,7 @@ export class Dataworker {
               endingBlockNumberForRootBundleContainingSlowFill
             );
             if (!lastFillBeforeSlowFillIncludedInRoot)
-              throw new Error("Can't last fill submitted before slow fill was included in root bundle proposal");
+              throw new Error("Can't find last fill submitted before slow fill was included in root bundle proposal");
 
             // Recompute how much the matched root bundle sent for this slow fill. Subtract the amount that was
             // actually executed on the L2 from the amount that was sent. This should give us the excess that was sent.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -181,7 +181,7 @@ export class Dataworker {
       (deposit: UnfilledDeposit): RelayData => ({
         depositor: deposit.deposit.depositor,
         recipient: deposit.deposit.recipient,
-        destinationToken: deposit.deposit.depositor,
+        destinationToken: deposit.deposit.destinationToken,
         amount: deposit.deposit.amount,
         originChainId: deposit.deposit.originChainId,
         destinationChainId: deposit.deposit.destinationChainId,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -242,7 +242,7 @@ export class Dataworker {
     if (Object.keys(fillsToRefund).length > 0) {
       Object.keys(fillsToRefund).forEach((repaymentChainId: string) => {
         Object.keys(fillsToRefund[repaymentChainId]).forEach((l2TokenAddress: string) => {
-          const l1TokenCounterpart = this.clients.hubPoolClient.getL1TokenCounterpart(repaymentChainId, l2TokenAddress)
+          const l1TokenCounterpart = this.clients.hubPoolClient.getL1TokenCounterpart(repaymentChainId, l2TokenAddress);
           assign(
             runningBalances,
             [repaymentChainId, l1TokenCounterpart],
@@ -261,14 +261,14 @@ export class Dataworker {
       deposits.forEach((deposit: Deposit) => {
         // TODO: Make sure that we're grabbing the L1 token counterpart at the deposit quote time. This is important if
         // the L1,L2 token mapping is different now than at the quote time.
-        const l1TokenCounterpart = this.clients.hubPoolClient.getL1TokenForDeposit(deposit)
-        if (!runningBalances[deposit.originChainId.toString()]) runningBalances[deposit.originChainId.toString()] = {}
+        const l1TokenCounterpart = this.clients.hubPoolClient.getL1TokenForDeposit(deposit);
+        if (!runningBalances[deposit.originChainId.toString()]) runningBalances[deposit.originChainId.toString()] = {};
         const runningBalanceForDeposit = runningBalances[deposit.originChainId.toString()][l1TokenCounterpart];
         if (runningBalanceForDeposit)
           runningBalances[deposit.originChainId.toString()][l1TokenCounterpart] = runningBalanceForDeposit.sub(
             deposit.amount
           );
-        else runningBalances[deposit.originChainId.toString()][l1TokenCounterpart] = deposit.amount.mul(toBN(-1))
+        else runningBalances[deposit.originChainId.toString()][l1TokenCounterpart] = deposit.amount.mul(toBN(-1));
       });
     }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -103,7 +103,7 @@ export class Dataworker {
               ]
             );
 
-            // For non-slow relays, save refund amount for the recipient of the refund, i.e. the relayer 
+            // For non-slow relays, save refund amount for the recipient of the refund, i.e. the relayer
             // for non-slow relays.
             if (!fill.isSlowRelay) {
               // Instantiate dictionary if it doesn't exist.
@@ -132,14 +132,14 @@ export class Dataworker {
         // Remove deposits with no matched fills.
         if (_unfilledDeposits.length === 0) return { unfilledAmount: toBN(0), deposit: undefined };
         // Remove deposits where there isn't a fill with fillAmount == totalFilledAmount && fillAmount > 0. This ensures
-        // that we'll only be slow relaying deposits where the first fill (i.e. the one with 
-        // fillAmount == totalFilledAmount) is in this epoch. We assume that we already included slow fills in a 
+        // that we'll only be slow relaying deposits where the first fill (i.e. the one with
+        // fillAmount == totalFilledAmount) is in this epoch. We assume that we already included slow fills in a
         // previous epoch for these ignored deposits.
         if (
           !_unfilledDeposits.some((_unfilledDeposit: UnfilledDeposit) => _unfilledDeposit.hasFirstPartialFill === true)
         )
           return { unfilledAmount: toBN(0), deposit: undefined };
-        // For each deposit, identify the smallest unfilled amount remaining after a fill since each fill can 
+        // For each deposit, identify the smallest unfilled amount remaining after a fill since each fill can
         // only decrease the unfilled amount.
         _unfilledDeposits.sort((unfilledDepositA, unfilledDepositB) =>
           unfilledDepositA.unfilledAmount.gt(unfilledDepositB.unfilledAmount)

--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -21,6 +21,17 @@ export interface RelayerRefundLeaf {
   refundAddresses: string[];
 }
 
+export interface ProposedRootBundle {
+  blockNumber: number;
+  challengePeriodEndTimestamp: number;
+  poolRebalanceLeafCount: number;
+  bundleEvaluationBlockNumbers: BigNumber[];
+  poolRebalanceRoot: string;
+  relayerRefundRoot: string;
+  slowRelayRoot: string;
+  proposer: string;
+}
+
 export interface RelayerRefundLeafWithGroup extends RelayerRefundLeaf {
   groupIndex: number;
 }

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -73,5 +73,16 @@ export interface UnfilledDeposit {
   hasFirstPartialFill?: boolean;
 }
 export interface FillsToRefund {
-  [repaymentChainId: number]: { [l2TokenAddress: string]: Fill[] };
+  [repaymentChainId: number]: {
+    [l2TokenAddress: string]: {
+      fills: Fill[];
+      refunds: { [refundAddress: string]: BigNumber };
+    };
+  };
+}
+
+export interface RunningBalances {
+  [repaymentChainId: number]: {
+    [l2TokenAddress: string]: BigNumber;
+  };
 }

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -77,6 +77,8 @@ export interface FillsToRefund {
     [l2TokenAddress: string]: {
       fills: Fill[];
       refunds: { [refundAddress: string]: BigNumber };
+      totalRefundAmount: BigNumber;
+      realizedLpFees: BigNumber;
     };
   };
 }

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -79,7 +79,7 @@ export interface FillsToRefund {
   [repaymentChainId: number]: {
     [l2TokenAddress: string]: {
       fills: Fill[];
-      refunds: { [refundAddress: string]: BigNumber };
+      refunds?: { [refundAddress: string]: BigNumber };
       totalRefundAmount: BigNumber;
       realizedLpFees: BigNumber;
     };

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -32,6 +32,9 @@ export interface Fill {
   destinationChainId: number;
 }
 
+export interface FillWithBlock extends Fill {
+  blockNumber: number;
+}
 export interface SpeedUp {
   depositor: string;
   depositorSignature: string;

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -85,6 +85,6 @@ export interface FillsToRefund {
 
 export interface RunningBalances {
   [repaymentChainId: number]: {
-    [l2TokenAddress: string]: BigNumber;
+    [l1TokenAddress: string]: BigNumber;
   };
 }

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -14,6 +14,10 @@ export interface Deposit {
   destinationToken?: string; // appended after initialization (not part of Deposit event).
   speedUpSignature?: string | undefined; // appended after initialization, if deposit was speedup (not part of Deposit event).
 }
+
+export interface DepositWithBlock extends Deposit {
+  blockNumber: number;
+}
 export interface Fill {
   amount: BigNumber;
   totalFilledAmount: BigNumber;

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -17,8 +17,8 @@ export function spreadEvent(event: Event) {
 export function spreadEventWithBlockNumber(event: Event) {
   return {
     ...spreadEvent(event),
-    blockNumber: event.blockNumber
-  }
+    blockNumber: event.blockNumber,
+  };
 }
 
 export function sortEventsAscending(events: { blockNumber: number }[]): { blockNumber: number }[] {

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -13,3 +13,18 @@ export function spreadEvent(event: Event) {
 
   return returnedObject;
 }
+
+export function spreadEventWithBlockNumber(event: Event) {
+  return {
+    ...spreadEvent(event),
+    blockNumber: event.blockNumber
+  }
+}
+
+export function sortEventsAscending(events: { blockNumber: number }[]): { blockNumber: number }[] {
+  return [...events].sort((ex, ey) => ex.blockNumber - ey.blockNumber);
+}
+
+export function sortEventsDescending(events: { blockNumber: number }[]): { blockNumber: number }[] {
+  return [...events].sort((ex, ey) => ey.blockNumber - ex.blockNumber);
+}

--- a/src/utils/FillMathUtils.ts
+++ b/src/utils/FillMathUtils.ts
@@ -6,7 +6,7 @@ export function _getRefundForFill(fill: Fill): BigNumber {
 }
 
 export function getRefundForFills(fills: Fill[]): BigNumber {
-  let accumulator = toBN(0)
+  let accumulator = toBN(0);
   fills.forEach((fill) => (accumulator = accumulator.add(_getRefundForFill(fill))));
-  return accumulator
+  return accumulator;
 }

--- a/src/utils/FillMathUtils.ts
+++ b/src/utils/FillMathUtils.ts
@@ -1,0 +1,12 @@
+import { Fill } from "../interfaces";
+import { toBNWei, BigNumber, toBN } from ".";
+
+export function _getRefundForFill(fill: Fill): BigNumber {
+  return fill.fillAmount.mul(toBNWei(1).sub(fill.realizedLpFeePct)).div(toBNWei(1));
+}
+
+export function getRefundForFills(fills: Fill[]): BigNumber {
+  let accumulator = toBN(0)
+  fills.forEach((fill) => (accumulator = accumulator.add(_getRefundForFill(fill))));
+  return accumulator
+}

--- a/src/utils/FillMathUtils.ts
+++ b/src/utils/FillMathUtils.ts
@@ -9,6 +9,10 @@ export function _getRealizedLpFeeForFill(fill: Fill): BigNumber {
   return fill.fillAmount.mul(fill.realizedLpFeePct).div(toBNWei(1));
 }
 
+export function getRefund(fillAmount: BigNumber, realizedLpFeePct: BigNumber): BigNumber {
+  return fillAmount.mul(toBNWei(1).sub(realizedLpFeePct)).div(toBNWei(1));
+}
+
 export function getRefundForFills(fills: Fill[]): BigNumber {
   let accumulator = toBN(0);
   fills.forEach((fill) => (accumulator = accumulator.add(_getRefundForFill(fill))));

--- a/src/utils/FillMathUtils.ts
+++ b/src/utils/FillMathUtils.ts
@@ -5,8 +5,18 @@ export function _getRefundForFill(fill: Fill): BigNumber {
   return fill.fillAmount.mul(toBNWei(1).sub(fill.realizedLpFeePct)).div(toBNWei(1));
 }
 
+export function _getRealizedLpFeeForFill(fill: Fill): BigNumber {
+  return fill.fillAmount.mul(fill.realizedLpFeePct).div(toBNWei(1));
+}
+
 export function getRefundForFills(fills: Fill[]): BigNumber {
   let accumulator = toBN(0);
   fills.forEach((fill) => (accumulator = accumulator.add(_getRefundForFill(fill))));
+  return accumulator;
+}
+
+export function getRealizedLpFeeForFills(fills: Fill[]): BigNumber {
+  let accumulator = toBN(0);
+  fills.forEach((fill) => (accumulator = accumulator.add(_getRealizedLpFeeForFill(fill))));
   return accumulator;
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,6 +19,7 @@ export * from "./NetworkUtils";
 export * from "./TransactionUtils";
 export * from "./MerkleTreeUtils";
 export * from "./AddressUtils";
+export * from "./FillMathUtils";
 
 export { ZERO_ADDRESS, MAX_SAFE_ALLOWANCE } from "@uma/common";
 

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -329,13 +329,11 @@ describe("Dataworker: Build merkle roots", async function () {
       amountToDeposit
     );
 
-    // Submit fills for two relayers on one repayment chain and one destination token. Note: we know that
-    // depositor address is alphabetically lower than relayer address, so submit fill from depositor first and test
-    // that data worker sorts on refund address.
-    const fill1 = await buildFillForRepaymentChain(spokePool_2, depositor, deposit3, 0.25, 100);
-    const fill2 = await buildFillForRepaymentChain(spokePool_2, depositor, deposit3, 1, 100);
-    const fill3 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 0.25, 100);
-    const fill4 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 1, 100);
+    // Submit fills with repayment chain set to one of the origin or destinationc hains.
+    const fill1 = await buildFillForRepaymentChain(spokePool_2, depositor, deposit3, 0.25, destinationChainId);
+    const fill2 = await buildFillForRepaymentChain(spokePool_2, depositor, deposit3, 1, destinationChainId);
+    const fill3 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 0.25, destinationChainId);
+    const fill4 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 1, destinationChainId);
 
     await updateAllClients();
     const merkleRoot1 = dataworkerInstance.buildPoolRebalanceRoot([]);

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -341,6 +341,24 @@ describe("Dataworker: Build merkle roots", async function () {
     const fill3 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 0.25, destinationChainId);
     const fill4 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 1, destinationChainId);
 
+    // Partial fill deposit1
+    // Partial fill deposit2
+
+    // Construct slow relay root which should include deposit1 and deposit2
+    // Construct pool rebalance root which should equal:
+    // + Refund for fill1 and fill 2
+    // - Deposit for deposit2 and deposit1
+    // + slow relay refund.
+
+    // Propose roots.
+    // Before executing the leaf, fully fill deposit1.
+
+    // Now, execute the leaf, which should trigger a FillRelay event to be emitted with isSlowRelay=true.
+    // Construct another pool rebalance root:
+    // +0 relayer refunds
+    // -0 deposits
+    // - slowRelayRefund sent in part A because it was fully filled before the slow relay was executed. 
+    // - 0 slowRelayRefund for deposit2 because the slow relay was fully executed.
     await updateAllClients();
     const merkleRoot1 = dataworkerInstance.buildPoolRebalanceRoot([]);
     console.log(getRefundForFills([fill1, fill2, fill3, fill4]));

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -126,7 +126,7 @@ describe("Dataworker: Build merkle roots", async function () {
     await updateAllClients();
     expect(dataworkerInstance.buildSlowRelayRoot([])).to.equal(null);
   });
-  it("Build relayer refund root", async function () {
+  it.only("Build relayer refund root", async function () {
     await updateAllClients();
 
     // Submit deposits for multiple L2 tokens.

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -237,7 +237,7 @@ describe("Dataworker: Build merkle roots", async function () {
     };
     await updateAllClients();
     const merkleRoot2 = dataworkerInstance.buildRelayerRefundRoot([]);
-    const leaves1And2Sorted = toBN(erc20_1.address).lt(toBN(erc20_2.address)) ? [leaf2, leaf1] : [leaf1, leaf2]
+    const leaves1And2Sorted = toBN(erc20_1.address).lt(toBN(erc20_2.address)) ? [leaf2, leaf1] : [leaf1, leaf2];
     const expectedMerkleRoot2 = await buildTree(leaves1And2Sorted);
     expect(merkleRoot2.getHexRoot()).to.equal(expectedMerkleRoot2.getHexRoot());
 
@@ -263,7 +263,7 @@ describe("Dataworker: Build merkle roots", async function () {
     };
     await updateAllClients();
     const merkleRoot3 = await dataworkerInstance.buildRelayerRefundRoot([]);
-    const leaves3And4Sorted = toBN(erc20_1.address).lt(toBN(erc20_2.address)) ? [leaf4, leaf3] : [leaf3, leaf4]
+    const leaves3And4Sorted = toBN(erc20_1.address).lt(toBN(erc20_2.address)) ? [leaf4, leaf3] : [leaf3, leaf4];
     const expectedMerkleRoot3 = await buildTree([...leaves3And4Sorted, ...leaves1And2Sorted]);
     expect(merkleRoot3.getHexRoot()).to.equal(expectedMerkleRoot3.getHexRoot());
 

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -1,17 +1,18 @@
 import { buildSlowRelayTree, RelayData, buildFillForRepaymentChain, buildRelayerRefundTree } from "./utils";
 import { SignerWithAddress, expect, ethers, Contract, toBN, toBNWei, setupTokensForWallet } from "./utils";
-import { buildDeposit, buildFill } from "./utils";
+import { buildDeposit, buildFill, buildPoolRebalanceLeaves, buildPoolRebalanceLeafTree, BigNumber } from "./utils";
 import { HubPoolClient, RateModelClient } from "../src/clients";
-import { amountToDeposit, destinationChainId, originChainId, MAX_REFUNDS_PER_LEAF } from "./constants";
+import { amountToDeposit, destinationChainId, originChainId, MAX_REFUNDS_PER_LEAF, mockTreeRoot, realizedLpFeePct } from "./constants";
+import { refundProposalLiveness, CHAIN_ID_TEST_LIST } from "./constants"
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 
 import { Dataworker } from "../src/dataworker/Dataworker"; // Tested
-import { Deposit } from "../src/interfaces/SpokePool";
+import { Deposit, RunningBalances } from "../src/interfaces/SpokePool";
 import { getRealizedLpFeeForFills, getRefundForFills } from "../src/utils";
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
-let l1Token_1: Contract;
-let depositor: SignerWithAddress, relayer: SignerWithAddress;
+let l1Token_1: Contract, hubPool: Contract, timer: Contract;
+let depositor: SignerWithAddress, relayer: SignerWithAddress, dataworker: SignerWithAddress;
 
 let rateModelClient: RateModelClient, hubPoolClient: HubPoolClient;
 let dataworkerInstance: Dataworker;
@@ -21,6 +22,7 @@ let updateAllClients: () => Promise<void>;
 describe("Dataworker: Build merkle roots", async function () {
   beforeEach(async function () {
     ({
+      hubPool,
       spokePool_1,
       erc20_1,
       spokePool_2,
@@ -31,6 +33,8 @@ describe("Dataworker: Build merkle roots", async function () {
       depositor,
       relayer,
       dataworkerInstance,
+      dataworker,
+      timer,
       updateAllClients,
     } = await setupDataworker(ethers, MAX_REFUNDS_PER_LEAF));
   });
@@ -324,45 +328,213 @@ describe("Dataworker: Build merkle roots", async function () {
       destinationChainId,
       amountToDeposit
     );
-    const deposit3 = await buildDeposit(
+    const deposit2 = await buildDeposit(
       rateModelClient,
       hubPoolClient,
-      spokePool_1,
-      erc20_1,
+      spokePool_2,
+      erc20_2,
       l1Token_1,
       depositor,
-      destinationChainId,
-      amountToDeposit
+      originChainId,
+      amountToDeposit.mul(toBN(2))
     );
+    await updateAllClients();
 
-    // Submit fills with repayment chain set to one of the origin or destinationc hains.
-    const fill1 = await buildFillForRepaymentChain(spokePool_2, depositor, deposit3, 0.25, destinationChainId);
-    const fill2 = await buildFillForRepaymentChain(spokePool_2, depositor, deposit3, 1, destinationChainId);
-    const fill3 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 0.25, destinationChainId);
-    const fill4 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 1, destinationChainId);
+    const deposits = [deposit1, deposit2]
+
+    // Note: Submit fills with repayment chain set to one of the origin or destination chains since we have spoke
+    // pools deployed on those chains.
 
     // Partial fill deposit1
+    const fill1 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 0.5, destinationChainId);
+
     // Partial fill deposit2
+    const fill2 = await buildFillForRepaymentChain(spokePool_1, depositor, deposit2, 0.3, originChainId);
+    const fill3 = await buildFillForRepaymentChain(spokePool_1, depositor, deposit2, 0.2, originChainId);
 
-    // Construct slow relay root which should include deposit1 and deposit2
-    // Construct pool rebalance root which should equal:
-    // + Refund for fill1 and fill 2
-    // - Deposit for deposit2 and deposit1
-    // + slow relay refund.
-
-    // Propose roots.
-    // Before executing the leaf, fully fill deposit1.
-
-    // Now, execute the leaf, which should trigger a FillRelay event to be emitted with isSlowRelay=true.
-    // Construct another pool rebalance root:
-    // +0 relayer refunds
-    // -0 deposits
-    // - slowRelayRefund sent in part A because it was fully filled before the slow relay was executed. 
-    // - 0 slowRelayRefund for deposit2 because the slow relay was fully executed.
+    // Prior to root bundle being executed, running balances should be:
+    // - deposited amount
+    // + partial fill refund
+    const expectedRunningBalances: RunningBalances = {
+      [destinationChainId]: {
+        [l1Token_1.address]: getRefundForFills([fill1]).sub(deposit2.amount),
+      },
+      [originChainId]: {
+        [l1Token_1.address]: getRefundForFills([fill2, fill3]).sub(deposit1.amount),
+      }
+    };
+    const expectedRealizedLpFees: RunningBalances = {
+      [destinationChainId]: {
+        [l1Token_1.address]: getRealizedLpFeeForFills([fill1]),
+      },
+      [originChainId]: {
+        [l1Token_1.address]: getRealizedLpFeeForFills([fill2, fill3]),
+      }
+    };
     await updateAllClients();
     const merkleRoot1 = dataworkerInstance.buildPoolRebalanceRoot([]);
-    console.log(getRefundForFills([fill1, fill2, fill3, fill4]));
-    console.log(getRealizedLpFeeForFills([fill1, fill2, fill3, fill4]));
-    // TODO:
+    expect(merkleRoot1.runningBalances).to.deep.equal(expectedRunningBalances)
+    expect(merkleRoot1.realizedLpFees).to.deep.equal(expectedRealizedLpFees)
+
+    // Construct slow relay root which should include deposit1 and deposit2
+    const expectedRelays: RelayData[] = deposits.map((_deposit) => {
+      return {
+        depositor: _deposit.depositor,
+        recipient: _deposit.recipient,
+        destinationToken: _deposit.destinationToken,
+        amount: _deposit.amount,
+        originChainId: _deposit.originChainId.toString(),
+        destinationChainId: _deposit.destinationChainId.toString(),
+        realizedLpFeePct: _deposit.realizedLpFeePct,
+        relayerFeePct: _deposit.relayerFeePct,
+        depositId: _deposit.depositId.toString(),
+      };
+    }) // leaves should be ordered by origin chain ID and then deposit ID (ascending).
+    .sort((relayA, relayB) => {
+      if (relayA.originChainId !== relayB.originChainId)
+        return Number(relayA.originChainId) - Number(relayB.originChainId)
+      else return Number(relayA.depositId) - Number(relayB.depositId)
+    });
+    // Returns expected merkle root where leaves are ordered by origin chain ID and then deposit ID
+    // (ascending).
+    const expectedSlowRelayTree = await buildSlowRelayTree(expectedRelays);
+
+    // Construct pool rebalance root so we can publish slow relay root to spoke pool:
+    async function constructPoolRebalanceTree(runningBalances: RunningBalances, realizedLpFees: RunningBalances) {
+      const leaves = buildPoolRebalanceLeaves(
+        Object.keys(runningBalances).map((x) => Number(x)), // Where funds are getting sent.
+        Object.values(runningBalances).map((runningBalanceForL1Token) => Object.keys(runningBalanceForL1Token)), // l1Tokens.
+        Object.values(realizedLpFees).map((realizedLpForL1Token) => Object.values(realizedLpForL1Token)), // bundleLpFees.
+        Object.values(runningBalances).map((runningBalanceForL1Token) =>
+          Object.values(runningBalanceForL1Token).map((x: BigNumber) => x.mul(toBN(-1)))
+        ), // netSendAmounts.
+        Object.values(runningBalances).map((runningBalanceForL1Token) => Object.values(runningBalanceForL1Token)), // runningBalances.
+        Object.keys(runningBalances).map((_) => 0) // group index
+      );
+      const tree = await buildPoolRebalanceLeafTree(leaves);
+    
+      return { leaves, tree };
+    }
+    const { tree: poolRebalanceTree, leaves: poolRebalanceLeaves } = await constructPoolRebalanceTree(
+      expectedRunningBalances,
+      expectedRealizedLpFees
+    );
+
+    // Propose root bundle so that we can test that the dataworker looks up ProposeRootBundle events properly.
+    // Similarly, execute the root bundle because constructing the pool rebalance root is expected to look up
+    // ExecutedRootBundleEvents.
+    const currentBlock = await hubPool.provider.getBlockNumber()
+    await hubPool.connect(dataworker).proposeRootBundle(
+      Array(CHAIN_ID_TEST_LIST.length).fill(currentBlock + 5), // Set current block number as end block for bundle. Its important that we set a block for every possible chain ID. Add 5 blocks for buffer
+      // so all fills to this point are before these blocks.
+      poolRebalanceLeaves.length, // poolRebalanceLeafCount.
+      poolRebalanceTree.getHexRoot(), // poolRebalanceRoot
+      mockTreeRoot, // relayerRefundRoot
+      expectedSlowRelayTree.getHexRoot() // slowRelayRoot
+    );
+
+    // Now, execute the root so that a slow relay is executed.
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + refundProposalLiveness + 1);
+    await Promise.all(
+      poolRebalanceLeaves.map((leaf) => {
+        return hubPool
+          .connect(dataworker)
+          .executeRootBundle(...Object.values(leaf), poolRebalanceTree.getHexProof(leaf));
+      })
+    )
+
+    // Execute 1 slow relay leaf:
+    // Before we can execute the leaves on the spoke pool, we need to actually publish them since we're using a mock
+    // adapter that doesn't send messages as you'd expect in executeRootBundle.
+    await spokePool_1.relayRootBundle(mockTreeRoot, expectedSlowRelayTree.getHexRoot());
+    const chainToExecuteSlowRelay = await spokePool_1.chainId();
+    await spokePool_1.connect(dataworker).executeSlowRelayLeaf(
+      fill2.depositor,
+      fill2.recipient,
+      fill2.destinationToken,
+      fill2.amount.toString(),
+      fill2.originChainId.toString(),
+      fill2.realizedLpFeePct.toString(),
+      fill2.relayerFeePct.toString(),
+      fill2.depositId.toString(),
+      "0", // root bundle ID
+      expectedSlowRelayTree.getHexProof(
+        // We can only execute a slow relay on its destination chain, so look up the relay data with
+        // destination chain equal to the deployed spoke pool that we are calling.
+        expectedRelays.find((_) => _.destinationChainId === chainToExecuteSlowRelay.toString())
+      )
+    );
+    const slowFill2 = {
+      ...fill2,
+      totalFilledAmount: fill2.amount, // Slow relay always fully fills deposit
+      fillAmount: fill2.amount.sub(fill3.totalFilledAmount), // Fills remaining after latest fill for deposit
+      repaymentChainId: 0, // Always set to 0 for slow fills
+      appliedRelayerFeePct: toBN(0), // Always set to 0 since there was no relayer
+      isSlowRelay: true,
+      relayer: dataworker.address, // Set to caller of `executeSlowRelayLeaf`
+    }
+    await updateAllClients();
+
+    // Running balance should now have accounted for the slow fill. However, there are no "extra" funds remaining in the
+    // spoke pool following this slow fill because there were no fills that were submitted after the root bundle
+    // was submitted that included the slow fill. The new running balance should only have added the slow fill amount.
+    const merkleRoot2 = dataworkerInstance.buildPoolRebalanceRoot([]);
+    expectedRunningBalances[slowFill2.destinationChainId][l1Token_1.address] = expectedRunningBalances[slowFill2.destinationChainId][l1Token_1.address].add(getRefundForFills([slowFill2]))
+    expectedRealizedLpFees[slowFill2.destinationChainId][l1Token_1.address] = expectedRealizedLpFees[slowFill2.destinationChainId][l1Token_1.address].add(getRealizedLpFeeForFills([slowFill2]))
+    expect(merkleRoot2.runningBalances).to.deep.equal(expectedRunningBalances)
+    expect(merkleRoot2.realizedLpFees).to.deep.equal(expectedRealizedLpFees)
+
+    // Now, submit another partial fill for the deposit whose slow fill has NOT been executed yet. This should result
+    // in the slow fill execution leaving excess funds in the spoke pool.
+    const fill4 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 0.25, destinationChainId);
+    await updateAllClients();
+    const merkleRoot3 = dataworkerInstance.buildPoolRebalanceRoot([]);
+    expectedRunningBalances[fill4.destinationChainId][l1Token_1.address] = expectedRunningBalances[fill4.destinationChainId][l1Token_1.address].add(getRefundForFills([fill4]))
+    expectedRealizedLpFees[fill4.destinationChainId][l1Token_1.address] = expectedRealizedLpFees[fill4.destinationChainId][l1Token_1.address].add(getRealizedLpFeeForFills([fill4]))
+    expect(merkleRoot3.runningBalances).to.deep.equal(expectedRunningBalances)
+    expect(merkleRoot3.realizedLpFees).to.deep.equal(expectedRealizedLpFees)
+
+    // Execute second slow relay leaf:
+    // Before we can execute the leaves on the spoke pool, we need to actually publish them since we're using a mock
+    // adapter that doesn't send messages as you'd expect in executeRootBundle.
+    await spokePool_2.relayRootBundle(mockTreeRoot, expectedSlowRelayTree.getHexRoot());
+    const secondChainToExecuteSlowRelay = await spokePool_2.chainId();
+    await spokePool_2.connect(dataworker).executeSlowRelayLeaf(
+      fill1.depositor,
+      fill1.recipient,
+      fill1.destinationToken,
+      fill1.amount.toString(),
+      fill1.originChainId.toString(),
+      fill1.realizedLpFeePct.toString(),
+      fill1.relayerFeePct.toString(),
+      fill1.depositId.toString(),
+      "0", // root bundle ID
+      expectedSlowRelayTree.getHexProof(
+        // We can only execute a slow relay on its destination chain, so look up the relay data with
+        // destination chain equal to the deployed spoke pool that we are calling.
+        expectedRelays.find((_) => _.destinationChainId === secondChainToExecuteSlowRelay.toString())
+      )
+    );
+    const slowFill1 = {
+      ...fill1,
+      totalFilledAmount: fill1.amount, // Slow relay always fully fills deposit
+      fillAmount: fill1.amount.sub(fill4.totalFilledAmount), // Fills remaining after latest fill for deposit
+      repaymentChainId: 0, // Always set to 0 for slow fills
+      appliedRelayerFeePct: toBN(0), // Always set to 0 since there was no relayer
+      isSlowRelay: true,
+      relayer: dataworker.address, // Set to caller of `executeSlowRelayLeaf`
+    }
+    await updateAllClients();
+
+    // Running balance should decrease by excess from slow fill since fill4 was sent before the slow fill could be
+    // executed. Since fill4 filled the remainder of the deposit, the entire slow fill amount should be subtracted
+    // from running balances.     
+    const merkleRoot4 = dataworkerInstance.buildPoolRebalanceRoot([]);
+    const sentAmount = fill1.amount.sub(fill1.totalFilledAmount);
+    const excess = sentAmount.sub(slowFill1.fillAmount);
+    expectedRunningBalances[slowFill1.destinationChainId][l1Token_1.address] = expectedRunningBalances[slowFill1.destinationChainId][l1Token_1.address].add(getRefundForFills([slowFill1])).sub(excess)
+    expectedRealizedLpFees[slowFill1.destinationChainId][l1Token_1.address] = expectedRealizedLpFees[slowFill1.destinationChainId][l1Token_1.address].add(getRealizedLpFeeForFills([slowFill1]))
+    expect(merkleRoot4.runningBalances).to.deep.equal(expectedRunningBalances)
+    expect(merkleRoot4.realizedLpFees).to.deep.equal(expectedRealizedLpFees)
   });
 });

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -7,7 +7,7 @@ import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 
 import { Dataworker } from "../src/dataworker/Dataworker"; // Tested
 import { Deposit } from "../src/interfaces/SpokePool";
-import { getRefundForFills } from "../src/utils";
+import { getRealizedLpFeeForFills, getRefundForFills } from "../src/utils";
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
 let l1Token_1: Contract;
@@ -340,6 +340,7 @@ describe("Dataworker: Build merkle roots", async function () {
     await updateAllClients();
     const merkleRoot1 = dataworkerInstance.buildPoolRebalanceRoot([]);
     console.log(getRefundForFills([fill1, fill2, fill3, fill4]));
+    console.log(getRealizedLpFeeForFills([fill1, fill2, fill3, fill4]));
     // TODO:
   });
 });

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -306,7 +306,7 @@ describe("Dataworker: Build merkle roots", async function () {
   it("Build pool rebalance root", async function () {
     // Helper function we'll use in this lifecycle test to keep track of updated counter variables.
     const updateAndCheckExpectedPoolRebalanceCounters = (
-      expectedRunningBalances: RunningBalances, 
+      expectedRunningBalances: RunningBalances,
       expectedRealizedLpFees: RunningBalances,
       runningBalanceDelta: BigNumber,
       realizedLpFeeDelta: BigNumber,
@@ -318,8 +318,8 @@ describe("Dataworker: Build merkle roots", async function () {
       expectedRealizedLpFees[l2Chain][l1Token] = expectedRealizedLpFees[l2Chain][l1Token].add(realizedLpFeeDelta);
       expect(test.runningBalances).to.deep.equal(expectedRunningBalances);
       expect(test.realizedLpFees).to.deep.equal(expectedRealizedLpFees);
-    }
-    
+    };
+
     await updateAllClients();
 
     // Submit deposits for multiple L2 tokens.
@@ -370,7 +370,7 @@ describe("Dataworker: Build merkle roots", async function () {
     // Partial fill deposit3
     const fill4 = await buildFillForRepaymentChain(spokePool_1, depositor, deposit3, 0.5, originChainId);
     const blockOfLastFill = await hubPool.provider.getBlockNumber();
-    
+
     // Prior to root bundle being executed, running balances should be:
     // - deposited amount
     // + partial fill refund
@@ -520,9 +520,9 @@ describe("Dataworker: Build merkle roots", async function () {
       dataworkerInstance.buildPoolRebalanceRoot([])
     );
 
-    // Now demonstrate that for a deposit whose first fill is NOT contained in a ProposeRootBundle event, it won't 
+    // Now demonstrate that for a deposit whose first fill is NOT contained in a ProposeRootBundle event, it won't
     // affect running balance:
-    // Submit another deposit and partial fill, this should mine at a block after the ending block of the last 
+    // Submit another deposit and partial fill, this should mine at a block after the ending block of the last
     // ProposeRootBundle block range.
     // Fully fill the deposit.
     // Update client and construct root. This should increase running balance by total deposit amount, to refund

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -445,11 +445,11 @@ describe("Dataworker: Build merkle roots", async function () {
 
     // Running balance should now have accounted for the slow fill. However, there are no "extra" funds remaining in the
     // spoke pool following this slow fill because there were no fills that were submitted after the root bundle
-    // was submitted that included the slow fill. The new running balance should only have added the slow fill amount.
+    // was submitted that included the slow fill. The new running balance should therefore be identical to the old one.
     updateAndCheckExpectedPoolRebalanceCounters(
       expectedRunningBalances,
       expectedRealizedLpFees,
-      getRefundForFills([slowFill2]),
+      toBN(0),
       getRealizedLpFeeForFills([slowFill2]),
       slowFill2.destinationChainId,
       l1Token_1.address,
@@ -495,7 +495,7 @@ describe("Dataworker: Build merkle roots", async function () {
     updateAndCheckExpectedPoolRebalanceCounters(
       expectedRunningBalances,
       expectedRealizedLpFees,
-      getRefundForFills([slowFill1]).sub(excess),
+      excess.mul(toBN(-1)),
       getRealizedLpFeeForFills([slowFill1]),
       fill5.destinationChainId,
       l1Token_1.address,

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -304,7 +304,7 @@ describe("Dataworker: Build merkle roots", async function () {
     const expectedMerkleRoot4 = await buildTree([leaf5, leaf6, leaf3, leaf4, leaf1, leaf2]);
     expect(merkleRoot4.getHexRoot()).to.equal(expectedMerkleRoot4.getHexRoot());
   });
-  it("Build pool rebalance root", async function() {
+  it("Build pool rebalance root", async function () {
     await updateAllClients();
 
     // Submit deposits for multiple L2 tokens.
@@ -339,7 +339,7 @@ describe("Dataworker: Build merkle roots", async function () {
 
     await updateAllClients();
     const merkleRoot1 = dataworkerInstance.buildPoolRebalanceRoot([]);
-    console.log(getRefundForFills([fill1, fill2, fill3, fill4]))
+    console.log(getRefundForFills([fill1, fill2, fill3, fill4]));
     // TODO:
-  })
+  });
 });

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -289,7 +289,6 @@ describe("Dataworker: Load data used in all functions", async function () {
       [slowFill3.destinationChainId]: {
         [erc20_1.address]: {
           fills: [slowFill3], // Slow fill gets added to fills list
-          totalRefundAmount: getRefundForFills([slowFill3]), // Slow fill does affect total refund amount
           realizedLpFees: getRealizedLpFeeForFills([slowFill3]), // Slow fill does affect realized LP fee
         },
       },
@@ -318,7 +317,6 @@ describe("Dataworker: Load data used in all functions", async function () {
       [slowFill3.destinationChainId]: {
         [erc20_1.address]: {
           fills: [slowFill3],
-          totalRefundAmount: getRefundForFills([slowFill3]),
           realizedLpFees: getRealizedLpFeeForFills([slowFill3]),
         },
       },

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -332,7 +332,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       appliedRelayerFeePct: toBN(0), // Always set to 0 since there was no relayer
       isSlowRelay: true,
       relayer: depositor.address, // Set to caller of `executeSlowRelayLeaf`
-    }
+    };
     const data5 = dataworkerInstance._loadData();
     expect(data5.fillsToRefund).to.deep.equal({
       [slowFill3.destinationChainId]: {
@@ -340,7 +340,7 @@ describe("Dataworker: Load data used in all functions", async function () {
           fills: [slowFill3], // Slow fill gets added to fills list
           totalRefundAmount: getRefundForFills([slowFill3]), // Slow fill does affect total refund amount
           realizedLpFees: getRealizedLpFeeForFills([slowFill3]), // Slow fill does affect realized LP fee
-        }
+        },
       },
       [repaymentChainId]: {
         [erc20_2.address]: {
@@ -369,7 +369,7 @@ describe("Dataworker: Load data used in all functions", async function () {
           fills: [slowFill3],
           totalRefundAmount: getRefundForFills([slowFill3]),
           realizedLpFees: getRealizedLpFeeForFills([slowFill3]),
-        }
+        },
       },
       [repaymentChainId]: {
         [erc20_2.address]: {
@@ -381,7 +381,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         [erc20_1.address]: {
           fills: [fill2, fill3, fill4],
           refunds: { [relayer.address]: getRefundForFills([fill2, fill3, fill4]) },
-          totalRefundAmount: getRefundForFills([fill2, fill3, fill4 ]),
+          totalRefundAmount: getRefundForFills([fill2, fill3, fill4]),
           realizedLpFees: getRealizedLpFeeForFills([fill2, fill3, fill4]),
         },
       },

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -306,8 +306,8 @@ describe("Dataworker: Load data used in all functions", async function () {
     // Note: If the dataworker does not explicitly filter out slow relays then the fillsToRefund object
     // will contain refunds associated with repaymentChainId 0.
     expect(data5.fillsToRefund).to.deep.equal({
-      [repaymentChainId]: { 
-        [erc20_2.address]: { fills: [fill1], refunds: { [relayer.address]: getRefundForFills([fill1]) } }, 
+      [repaymentChainId]: {
+        [erc20_2.address]: { fills: [fill1], refunds: { [relayer.address]: getRefundForFills([fill1]) } },
         [erc20_1.address]: {
           fills: [fill2, fill3],
           refunds: { [relayer.address]: getRefundForFills([fill2, fill3]) },

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -6,7 +6,7 @@ import { amountToDeposit, repaymentChainId, destinationChainId, originChainId } 
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 
 import { Dataworker } from "../src/dataworker/Dataworker"; // Tested
-import { toBN, getRefundForFills } from "../src/utils";
+import { toBN, getRefundForFills, getRealizedLpFeeForFills } from "../src/utils";
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
 let l1Token_1: Contract, l1Token_2: Contract;
@@ -220,7 +220,12 @@ describe("Dataworker: Load data used in all functions", async function () {
     const data1 = dataworkerInstance._loadData();
     expect(data1.fillsToRefund).to.deep.equal({
       [repaymentChainId]: {
-        [erc20_2.address]: { fills: [fill1], refunds: { [relayer.address]: getRefundForFills([fill1]) } },
+        [erc20_2.address]: {
+          fills: [fill1],
+          refunds: { [relayer.address]: getRefundForFills([fill1]) },
+          totalRefundAmount: getRefundForFills([fill1]),
+          realizedLpFees: getRealizedLpFeeForFills([fill1]),
+        },
       },
     });
 
@@ -230,8 +235,18 @@ describe("Dataworker: Load data used in all functions", async function () {
     const data2 = dataworkerInstance._loadData();
     expect(data2.fillsToRefund).to.deep.equal({
       [repaymentChainId]: {
-        [erc20_2.address]: { fills: [fill1], refunds: { [relayer.address]: getRefundForFills([fill1]) } },
-        [erc20_1.address]: { fills: [fill2], refunds: { [relayer.address]: getRefundForFills([fill2]) } },
+        [erc20_2.address]: {
+          fills: [fill1],
+          refunds: { [relayer.address]: getRefundForFills([fill1]) },
+          totalRefundAmount: getRefundForFills([fill1]),
+          realizedLpFees: getRealizedLpFeeForFills([fill1]),
+        },
+        [erc20_1.address]: {
+          fills: [fill2],
+          refunds: { [relayer.address]: getRefundForFills([fill2]) },
+          totalRefundAmount: getRefundForFills([fill2]),
+          realizedLpFees: getRealizedLpFeeForFills([fill2]),
+        },
       },
     });
 
@@ -307,10 +322,17 @@ describe("Dataworker: Load data used in all functions", async function () {
     // will contain refunds associated with repaymentChainId 0.
     expect(data5.fillsToRefund).to.deep.equal({
       [repaymentChainId]: {
-        [erc20_2.address]: { fills: [fill1], refunds: { [relayer.address]: getRefundForFills([fill1]) } },
+        [erc20_2.address]: {
+          fills: [fill1],
+          refunds: { [relayer.address]: getRefundForFills([fill1]) },
+          totalRefundAmount: getRefundForFills([fill1]),
+          realizedLpFees: getRealizedLpFeeForFills([fill1]),
+        },
         [erc20_1.address]: {
           fills: [fill2, fill3],
           refunds: { [relayer.address]: getRefundForFills([fill2, fill3]) },
+          totalRefundAmount: getRefundForFills([fill2, fill3]),
+          realizedLpFees: getRealizedLpFeeForFills([fill2, fill3]),
         },
       },
     });
@@ -322,10 +344,17 @@ describe("Dataworker: Load data used in all functions", async function () {
     const data6 = dataworkerInstance._loadData();
     expect(data6.fillsToRefund).to.deep.equal({
       [repaymentChainId]: {
-        [erc20_2.address]: { fills: [fill1], refunds: { [relayer.address]: getRefundForFills([fill1]) } },
+        [erc20_2.address]: {
+          fills: [fill1],
+          refunds: { [relayer.address]: getRefundForFills([fill1]) },
+          totalRefundAmount: getRefundForFills([fill1]),
+          realizedLpFees: getRealizedLpFeeForFills([fill1]),
+        },
         [erc20_1.address]: {
           fills: [fill2, fill3, fill4],
           refunds: { [relayer.address]: getRefundForFills([fill2, fill3, fill4]) },
+          totalRefundAmount: getRefundForFills([fill2, fill3, fill4]),
+          realizedLpFees: getRealizedLpFeeForFills([fill2, fill3, fill4]),
         },
       },
     });

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -42,7 +42,7 @@ describe("Dataworker: Load data used in all functions", async function () {
   it("Default conditions", async function () {
     // Throws error if hub pool client is not updated.
     expect(() => dataworkerInstance._loadData()).to.throw(/HubPoolClient not updated/);
-    await hubPoolClient.update()
+    await hubPoolClient.update();
     await rateModelClient.update();
 
     // Throws error if config store client not updated.
@@ -351,7 +351,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       originChainId,
       amountToDeposit
     );
-    const realizedLpFeePctData = await rateModelClient.computeRealizedLpFeePct(deposit1, l1Token_1.address)
+    const realizedLpFeePctData = await rateModelClient.computeRealizedLpFeePct(deposit1, l1Token_1.address);
 
     // Should include all deposits, even those not matched by a relay
     await updateAllClients();

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -351,10 +351,11 @@ describe("Dataworker: Load data used in all functions", async function () {
       originChainId,
       amountToDeposit
     );
+    const realizedLpFeePctData = await rateModelClient.computeRealizedLpFeePct(deposit1, l1Token_1.address)
 
     // Should include all deposits, even those not matched by a relay
     await updateAllClients();
     const data1 = dataworkerInstance._loadData();
-    expect(data1.deposits).to.deep.equal([deposit1]);
+    expect(data1.deposits).to.deep.equal([{ ...deposit1, blockNumber: realizedLpFeePctData.quoteBlock }]);
   });
 });

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -54,6 +54,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       unfilledDeposits: [],
       deposits: [],
       fillsToRefund: {},
+      allFills: [],
       slowFills: [],
     });
   });

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -360,7 +360,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       },
     });
   });
-  it("Returns slow fills", async function() {
+  it("Returns slow fills", async function () {
     await updateAllClients();
 
     // We're going to slow relay deposit1
@@ -415,7 +415,6 @@ describe("Dataworker: Load data used in all functions", async function () {
       [] // Proof for tree with 1 leaf is empty
     );
 
-
     // The unfilled deposit has now been fully filled.
     await updateAllClients();
     const data1 = dataworkerInstance._loadData();
@@ -431,7 +430,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       },
     ]);
   });
-  it("Returns deposits", async function() {
+  it("Returns deposits", async function () {
     await updateAllClients();
 
     const deposit1 = await buildDeposit(
@@ -449,5 +448,5 @@ describe("Dataworker: Load data used in all functions", async function () {
     await updateAllClients();
     const data1 = dataworkerInstance._loadData();
     expect(data1.deposits).to.deep.equal([deposit1]);
-  })
+  });
 });

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -54,7 +54,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       unfilledDeposits: [],
       deposits: [],
       fillsToRefund: {},
-      allFills: [],
+      allValidFills: [],
     });
   });
   it("Returns unfilled deposits", async function () {

--- a/test/HubPoolClient.DepositToDestinationToken.ts
+++ b/test/HubPoolClient.DepositToDestinationToken.ts
@@ -60,14 +60,24 @@ describe("HubPoolClient: Deposit to Destination Token", async function () {
 
     expect(hubPoolClient.getDestinationTokenForDeposit(depositData)).to.equal(randomDestinationToken2);
   });
-  it("Get L1 token counterparts at block height", async function() {
+  it("Get L1 token counterparts at block height", async function () {
     await hubPoolClient.update();
-    expect(() => hubPoolClient.getL1TokenCounterpartAtBlock(destinationChainId.toString(), randomDestinationToken, 0)).to.throw(/Could not find L1 token mapping/);
+    expect(() =>
+      hubPoolClient.getL1TokenCounterpartAtBlock(destinationChainId.toString(), randomDestinationToken, 0)
+    ).to.throw(/Could not find L1 token mapping/);
 
     await hubPool.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomDestinationToken);
-    const currentBlock = await hubPool.provider.getBlockNumber()
+    const currentBlock = await hubPool.provider.getBlockNumber();
     await hubPoolClient.update();
-    expect(hubPoolClient.getL1TokenCounterpartAtBlock(destinationChainId.toString(), randomDestinationToken, currentBlock)).to.equal(randomL1Token);
-    expect(() => hubPoolClient.getL1TokenCounterpartAtBlock(destinationChainId.toString(), randomDestinationToken, currentBlock-10)).to.throw(/Could not find L1 token mapping/);
-  })
+    expect(
+      hubPoolClient.getL1TokenCounterpartAtBlock(destinationChainId.toString(), randomDestinationToken, currentBlock)
+    ).to.equal(randomL1Token);
+    expect(() =>
+      hubPoolClient.getL1TokenCounterpartAtBlock(
+        destinationChainId.toString(),
+        randomDestinationToken,
+        currentBlock - 10
+      )
+    ).to.throw(/Could not find L1 token mapping/);
+  });
 });

--- a/test/HubPoolClient.DepositToDestinationToken.ts
+++ b/test/HubPoolClient.DepositToDestinationToken.ts
@@ -1,6 +1,6 @@
 import { getContractFactory, expect, ethers, Contract, SignerWithAddress, originChainId } from "./utils";
 import { zeroAddress, destinationChainId, toBN, deployRateModelStore, contractAt, createSpyLogger } from "./utils";
-import { randomLl1Token, randomOriginToken, randomDestinationToken, randomDestinationToken2 } from "./constants";
+import { randomL1Token, randomOriginToken, randomDestinationToken, randomDestinationToken2 } from "./constants";
 import { HubPoolClient } from "../src/clients";
 
 let hubPool: Contract, lpTokenFactory: Contract, mockAdapter: Contract, rateModelStore: Contract;
@@ -20,7 +20,7 @@ describe("HubPoolClient: Deposit to Destination Token", async function () {
     mockAdapter = await (await getContractFactory("Mock_Adapter", owner)).deploy();
     await hubPool.setCrossChainContracts(originChainId, mockAdapter.address, zeroAddress);
 
-    ({ rateModelStore } = await deployRateModelStore(owner, [await contractAt("ERC20", owner, randomLl1Token)]));
+    ({ rateModelStore } = await deployRateModelStore(owner, [await contractAt("ERC20", owner, randomL1Token)]));
 
     hubPoolClient = new HubPoolClient(createSpyLogger().spyLogger, hubPool);
   });
@@ -29,11 +29,11 @@ describe("HubPoolClient: Deposit to Destination Token", async function () {
     await hubPoolClient.update();
     expect(hubPoolClient.getL1TokensToDestinationTokens()).to.deep.equal({});
 
-    await hubPool.setPoolRebalanceRoute(destinationChainId, randomLl1Token, randomDestinationToken);
-    await hubPool.setPoolRebalanceRoute(originChainId, randomLl1Token, randomOriginToken);
+    await hubPool.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomDestinationToken);
+    await hubPool.setPoolRebalanceRoute(originChainId, randomL1Token, randomOriginToken);
     await hubPoolClient.update();
     expect(hubPoolClient.getL1TokensToDestinationTokens()).to.deep.equal({
-      [randomLl1Token]: { [destinationChainId]: randomDestinationToken, [originChainId]: randomOriginToken },
+      [randomL1Token]: { [destinationChainId]: randomDestinationToken, [originChainId]: randomOriginToken },
     });
 
     const depositData = {
@@ -52,12 +52,22 @@ describe("HubPoolClient: Deposit to Destination Token", async function () {
     expect(hubPoolClient.getDestinationTokenForDeposit(depositData)).to.equal(randomDestinationToken);
 
     // Now try changing the destination token. Client should correctly handel this.
-    await hubPool.setPoolRebalanceRoute(destinationChainId, randomLl1Token, randomDestinationToken2);
+    await hubPool.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomDestinationToken2);
     await hubPoolClient.update();
     expect(hubPoolClient.getL1TokensToDestinationTokens()).to.deep.equal({
-      [randomLl1Token]: { [destinationChainId]: randomDestinationToken2, [originChainId]: randomOriginToken },
+      [randomL1Token]: { [destinationChainId]: randomDestinationToken2, [originChainId]: randomOriginToken },
     });
 
     expect(hubPoolClient.getDestinationTokenForDeposit(depositData)).to.equal(randomDestinationToken2);
   });
+  it("Get L1 token counterparts at block height", async function() {
+    await hubPoolClient.update();
+    expect(() => hubPoolClient.getL1TokenCounterpartAtBlock(destinationChainId.toString(), randomDestinationToken, 0)).to.throw(/Could not find L1 token mapping/);
+
+    await hubPool.setPoolRebalanceRoute(destinationChainId, randomL1Token, randomDestinationToken);
+    const currentBlock = await hubPool.provider.getBlockNumber()
+    await hubPoolClient.update();
+    expect(hubPoolClient.getL1TokenCounterpartAtBlock(destinationChainId.toString(), randomDestinationToken, currentBlock)).to.equal(randomL1Token);
+    expect(() => hubPoolClient.getL1TokenCounterpartAtBlock(destinationChainId.toString(), randomDestinationToken, currentBlock-10)).to.throw(/Could not find L1 token mapping/);
+  })
 });

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -43,8 +43,8 @@ describe("HubPoolClient: RootBundle Events", async function () {
 
     await hubPoolClient.update();
 
-    // Happy case where `chainIdList` contains chain ID and block is lower than the bundle block range for that chain.
-    expect(hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(20, 2, [1, 2])).to.equal(22);
+    // Happy case where `chainIdList` contains chain ID and block is <= than the bundle block range for that chain.
+    expect(hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(22, 2, [1, 2])).to.equal(22);
 
     // `block` is greater than bundle block number for the chain.
     expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(23, 2, [1, 2])).to.throw(
@@ -52,12 +52,12 @@ describe("HubPoolClient: RootBundle Events", async function () {
     );
 
     // Chain ID list doesn't contain `chain`
-    expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(20, 2, [1, 3])).to.throw(
+    expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(22, 2, [1, 3])).to.throw(
       /Can't find fill.destinationChainId in CHAIN_ID_LIST/
     );
 
     // Chain ID list length doesn't match bundle block range length
-    expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(20, 2, [1])).to.throw(
+    expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(22, 2, [1])).to.throw(
       /Chain ID list and bundle block eval range list length do not match/
     );
   });

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -4,7 +4,7 @@ import { HubPoolClient } from "../src/clients";
 import * as constants from "./constants";
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 
-let hubPool: Contract, timer: Contract;
+let hubPool: Contract;
 let l1Token_1: Contract, l1Token_2: Contract;
 let dataworker: SignerWithAddress;
 
@@ -29,48 +29,8 @@ async function constructSimpleTree() {
 
 describe("HubPoolClient: RootBundle Events", async function () {
   beforeEach(async function () {
-    ({ hubPool, l1Token_1, l1Token_2, dataworker, timer } = await setupDataworker(
-      ethers,
-      constants.MAX_REFUNDS_PER_LEAF
-    ));
+    ({ hubPool, l1Token_1, l1Token_2, dataworker } = await setupDataworker(ethers, constants.MAX_REFUNDS_PER_LEAF));
     hubPoolClient = new HubPoolClient(createSpyLogger().spyLogger, hubPool);
-  });
-  it("Fetches ProposeRootBundle events", async function () {
-    const { tree } = await constructSimpleTree();
-
-    await hubPoolClient.update();
-
-    await hubPool.connect(dataworker).proposeRootBundle(
-      [0, 0], // bundleEvaluationBlockNumbers used by bots to construct bundles. Length must equal the number of leaves.
-      2, // poolRebalanceLeafCount.
-      tree.getHexRoot(),
-      constants.mockTreeRoot,
-      constants.mockTreeRoot
-    );
-
-    await hubPoolClient.update();
-
-    // TODO:
-  });
-  it("Fetches ExecuteRootBundle events", async function () {
-    const { tree, leaves } = await constructSimpleTree();
-
-    await hubPoolClient.update();
-
-    await hubPool.connect(dataworker).proposeRootBundle(
-      [0, 0], // bundleEvaluationBlockNumbers used by bots to construct bundles. Length must equal the number of leaves.
-      2, // poolRebalanceLeafCount.
-      tree.getHexRoot(),
-      constants.mockTreeRoot,
-      constants.mockTreeRoot
-    );
-
-    // Advance time so the request can be executed and execute first leaf.
-    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + constants.refundProposalLiveness + 1);
-    await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves[0]), tree.getHexProof(leaves[0]));
-    await hubPoolClient.update();
-
-    // TODO:
   });
   it("gets ProposeRootBundle event containing correct bundle block eval number", async function () {
     const { tree } = await constructSimpleTree();

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -11,44 +11,44 @@ let dataworker: SignerWithAddress;
 let hubPoolClient: HubPoolClient;
 
 async function constructSimpleTree() {
-    const runningBalance = toBNWei(100);
-    const netSendAmount = toBNWei(100);
-    const bundleLpFees = toBNWei(1);
-    const leaves = buildPoolRebalanceLeaves(
-        [constants.originChainId, constants.destinationChainId], // Where funds are getting sent.
-        [[l1Token_1.address, l1Token_2.address], []], // l1Token.
-        [[bundleLpFees, bundleLpFees], []], // bundleLpFees.
-        [[netSendAmount, netSendAmount], []], // netSendAmounts.
-        [[runningBalance, runningBalance], []], // runningBalances.
-        [0, 0]
-    );
-    const tree = await buildPoolRebalanceLeafTree(leaves);
-  
-    return { leaves, tree };
+  const runningBalance = toBNWei(100);
+  const netSendAmount = toBNWei(100);
+  const bundleLpFees = toBNWei(1);
+  const leaves = buildPoolRebalanceLeaves(
+    [constants.originChainId, constants.destinationChainId], // Where funds are getting sent.
+    [[l1Token_1.address, l1Token_2.address], []], // l1Token.
+    [[bundleLpFees, bundleLpFees], []], // bundleLpFees.
+    [[netSendAmount, netSendAmount], []], // netSendAmounts.
+    [[runningBalance, runningBalance], []], // runningBalances.
+    [0, 0]
+  );
+  const tree = await buildPoolRebalanceLeafTree(leaves);
+
+  return { leaves, tree };
 }
-  
+
 describe("HubPoolClient: RootBundle Events", async function () {
-    beforeEach(async function () {
-        ({ hubPool, l1Token_1, l1Token_2, dataworker, timer } = await setupDataworker(
-            ethers,
-            constants.MAX_REFUNDS_PER_LEAF
-        ))
-        hubPoolClient = new HubPoolClient(createSpyLogger().spyLogger, hubPool);
-    });    
+  beforeEach(async function () {
+    ({ hubPool, l1Token_1, l1Token_2, dataworker, timer } = await setupDataworker(
+      ethers,
+      constants.MAX_REFUNDS_PER_LEAF
+    ));
+    hubPoolClient = new HubPoolClient(createSpyLogger().spyLogger, hubPool);
+  });
   it("Fetches ProposeRootBundle events", async function () {
-      const { tree } = await constructSimpleTree();
+    const { tree } = await constructSimpleTree();
 
-      await hubPoolClient.update();
+    await hubPoolClient.update();
 
-        await hubPool.connect(dataworker).proposeRootBundle(
-            [0, 0], // bundleEvaluationBlockNumbers used by bots to construct bundles. Length must equal the number of leaves.
-            2, // poolRebalanceLeafCount.
-            tree.getHexRoot(),
-            constants.mockTreeRoot,
-            constants.mockTreeRoot
-        );
-    
-        await hubPoolClient.update();
+    await hubPool.connect(dataworker).proposeRootBundle(
+      [0, 0], // bundleEvaluationBlockNumbers used by bots to construct bundles. Length must equal the number of leaves.
+      2, // poolRebalanceLeafCount.
+      tree.getHexRoot(),
+      constants.mockTreeRoot,
+      constants.mockTreeRoot
+    );
+
+    await hubPoolClient.update();
 
     // TODO:
   });
@@ -57,19 +57,19 @@ describe("HubPoolClient: RootBundle Events", async function () {
 
     await hubPoolClient.update();
 
-      await hubPool.connect(dataworker).proposeRootBundle(
-          [0, 0], // bundleEvaluationBlockNumbers used by bots to construct bundles. Length must equal the number of leaves.
-          2, // poolRebalanceLeafCount.
-          tree.getHexRoot(),
-          constants.mockTreeRoot,
-          constants.mockTreeRoot
-      );
-  
-        // Advance time so the request can be executed and execute first leaf.
-        await timer.setCurrentTime(Number(await timer.getCurrentTime()) + constants.refundProposalLiveness + 1);
-        await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves[0]), tree.getHexProof(leaves[0]))
-      await hubPoolClient.update();
+    await hubPool.connect(dataworker).proposeRootBundle(
+      [0, 0], // bundleEvaluationBlockNumbers used by bots to construct bundles. Length must equal the number of leaves.
+      2, // poolRebalanceLeafCount.
+      tree.getHexRoot(),
+      constants.mockTreeRoot,
+      constants.mockTreeRoot
+    );
 
-  // TODO:
-});
+    // Advance time so the request can be executed and execute first leaf.
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + constants.refundProposalLiveness + 1);
+    await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves[0]), tree.getHexProof(leaves[0]));
+    await hubPoolClient.update();
+
+    // TODO:
+  });
 });

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -72,4 +72,33 @@ describe("HubPoolClient: RootBundle Events", async function () {
 
     // TODO:
   });
+  it("gets ProposeRootBundle event containing correct bundle block eval number", async function () {
+    const { tree } = await constructSimpleTree();
+
+    await hubPoolClient.update();
+
+    await hubPool
+      .connect(dataworker)
+      .proposeRootBundle([11, 22], 2, tree.getHexRoot(), constants.mockTreeRoot, constants.mockTreeRoot);
+
+    await hubPoolClient.update();
+
+    // Happy case where `chainIdList` contains chain ID and block is lower than the bundle block range for that chain.
+    expect(hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(20, 2, [1, 2])).to.equal(22);
+
+    // `block` is greater than bundle block number for the chain.
+    expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(23, 2, [1, 2])).to.throw(
+      /Can't find ProposeRootBundle event containing block/
+    );
+
+    // Chain ID list doesn't contain `chain`
+    expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(20, 2, [1, 3])).to.throw(
+      /Can't find fill.destinationChainId in CHAIN_ID_LIST/
+    );
+
+    // Chain ID list length doesn't match bundle block range length
+    expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(20, 2, [1])).to.throw(
+      /Chain ID list and bundle block eval range list length do not match/
+    );
+  });
 });

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -1,0 +1,75 @@
+import { buildPoolRebalanceLeafTree, buildPoolRebalanceLeaves, createSpyLogger } from "./utils";
+import { SignerWithAddress, expect, ethers, Contract, toBNWei } from "./utils";
+import { HubPoolClient } from "../src/clients";
+import * as constants from "./constants";
+import { setupDataworker } from "./fixtures/Dataworker.Fixture";
+
+let hubPool: Contract, timer: Contract;
+let l1Token_1: Contract, l1Token_2: Contract;
+let dataworker: SignerWithAddress;
+
+let hubPoolClient: HubPoolClient;
+
+async function constructSimpleTree() {
+    const runningBalance = toBNWei(100);
+    const netSendAmount = toBNWei(100);
+    const bundleLpFees = toBNWei(1);
+    const leaves = buildPoolRebalanceLeaves(
+        [constants.originChainId, constants.destinationChainId], // Where funds are getting sent.
+        [[l1Token_1.address, l1Token_2.address], []], // l1Token.
+        [[bundleLpFees, bundleLpFees], []], // bundleLpFees.
+        [[netSendAmount, netSendAmount], []], // netSendAmounts.
+        [[runningBalance, runningBalance], []], // runningBalances.
+        [0, 0]
+    );
+    const tree = await buildPoolRebalanceLeafTree(leaves);
+  
+    return { leaves, tree };
+}
+  
+describe("HubPoolClient: RootBundle Events", async function () {
+    beforeEach(async function () {
+        ({ hubPool, l1Token_1, l1Token_2, dataworker, timer } = await setupDataworker(
+            ethers,
+            constants.MAX_REFUNDS_PER_LEAF
+        ))
+        hubPoolClient = new HubPoolClient(createSpyLogger().spyLogger, hubPool);
+    });    
+  it("Fetches ProposeRootBundle events", async function () {
+      const { tree } = await constructSimpleTree();
+
+      await hubPoolClient.update();
+
+        await hubPool.connect(dataworker).proposeRootBundle(
+            [0, 0], // bundleEvaluationBlockNumbers used by bots to construct bundles. Length must equal the number of leaves.
+            2, // poolRebalanceLeafCount.
+            tree.getHexRoot(),
+            constants.mockTreeRoot,
+            constants.mockTreeRoot
+        );
+    
+        await hubPoolClient.update();
+
+    // TODO:
+  });
+  it("Fetches ExecuteRootBundle events", async function () {
+    const { tree, leaves } = await constructSimpleTree();
+
+    await hubPoolClient.update();
+
+      await hubPool.connect(dataworker).proposeRootBundle(
+          [0, 0], // bundleEvaluationBlockNumbers used by bots to construct bundles. Length must equal the number of leaves.
+          2, // poolRebalanceLeafCount.
+          tree.getHexRoot(),
+          constants.mockTreeRoot,
+          constants.mockTreeRoot
+      );
+  
+        // Advance time so the request can be executed and execute first leaf.
+        await timer.setCurrentTime(Number(await timer.getCurrentTime()) + constants.refundProposalLiveness + 1);
+        await hubPool.connect(dataworker).executeRootBundle(...Object.values(leaves[0]), tree.getHexProof(leaves[0]))
+      await hubPoolClient.update();
+
+  // TODO:
+});
+});

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -47,9 +47,7 @@ describe("HubPoolClient: RootBundle Events", async function () {
     expect(hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(22, 2, [1, 2])).to.equal(22);
 
     // `block` is greater than bundle block number for the chain.
-    expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(23, 2, [1, 2])).to.throw(
-      /Can't find ProposeRootBundle event containing block/
-    );
+    expect(hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(23, 2, [1, 2])).to.equal(undefined);
 
     // Chain ID list doesn't contain `chain`
     expect(() => hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(22, 2, [1, 3])).to.throw(

--- a/test/RateModelClient.RealizedLpFeePct.ts
+++ b/test/RateModelClient.RealizedLpFeePct.ts
@@ -101,7 +101,7 @@ describe("RateModelClient: RealizedLpFeePct", async function () {
 
     // Relayed amount being 10% of total LP amount should give exact same results as this test in v1:
     // - https://github.com/UMAprotocol/protocol/blob/3b1a88ead18088e8056ecfefb781c97fce7fdf4d/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js#L1037
-    expect(await rateModelClient.computeRealizedLpFeePct(depositData, l1Token.address)).to.equal(
+    expect((await rateModelClient.computeRealizedLpFeePct(depositData, l1Token.address)).realizedLpFeePct).to.equal(
       toBNWei("0.000117987509354032")
     );
 
@@ -123,7 +123,7 @@ describe("RateModelClient: RealizedLpFeePct", async function () {
 
     // Submit a deposit with a de minimis amount of tokens so we can isolate the computed realized lp fee % to the
     // pool utilization factor.
-    expect(
+    expect((
       await rateModelClient.computeRealizedLpFeePct(
         {
           ...depositData,
@@ -134,12 +134,12 @@ describe("RateModelClient: RealizedLpFeePct", async function () {
         },
         l1Token.address
       )
-    ).to.equal(toBNWei("0.001371068779697899"));
+    ).realizedLpFeePct).to.equal(toBNWei("0.001371068779697899"));
 
     // Relaying 10% of pool should give exact same result as this test, which sends a relay that is 10% of the pool's
     // size when the pool is already at 60% utilization. The resulting post-relay utilization is therefore 70%.
     // - https://github.com/UMAprotocol/protocol/blob/3b1a88ead18088e8056ecfefb781c97fce7fdf4d/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js#L1064
-    expect(
+    expect((
       await rateModelClient.computeRealizedLpFeePct(
         {
           ...depositData,
@@ -149,7 +149,7 @@ describe("RateModelClient: RealizedLpFeePct", async function () {
         },
         l1Token.address
       )
-    ).to.equal(toBNWei("0.002081296752280018"));
+    ).realizedLpFeePct).to.equal(toBNWei("0.002081296752280018"));
   });
 });
 

--- a/test/RateModelClient.RealizedLpFeePct.ts
+++ b/test/RateModelClient.RealizedLpFeePct.ts
@@ -123,33 +123,37 @@ describe("RateModelClient: RealizedLpFeePct", async function () {
 
     // Submit a deposit with a de minimis amount of tokens so we can isolate the computed realized lp fee % to the
     // pool utilization factor.
-    expect((
-      await rateModelClient.computeRealizedLpFeePct(
-        {
-          ...depositData,
-          amount: toBNWei("0.0000001"),
-          // Note: we need to set the deposit quote timestamp to one after the utilisation % jumped from 0% to 10%.
-          // This is because the rate model uses the quote time to fetch the liquidity utilization at that quote time.
-          quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
-        },
-        l1Token.address
-      )
-    ).realizedLpFeePct).to.equal(toBNWei("0.001371068779697899"));
+    expect(
+      (
+        await rateModelClient.computeRealizedLpFeePct(
+          {
+            ...depositData,
+            amount: toBNWei("0.0000001"),
+            // Note: we need to set the deposit quote timestamp to one after the utilisation % jumped from 0% to 10%.
+            // This is because the rate model uses the quote time to fetch the liquidity utilization at that quote time.
+            quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
+          },
+          l1Token.address
+        )
+      ).realizedLpFeePct
+    ).to.equal(toBNWei("0.001371068779697899"));
 
     // Relaying 10% of pool should give exact same result as this test, which sends a relay that is 10% of the pool's
     // size when the pool is already at 60% utilization. The resulting post-relay utilization is therefore 70%.
     // - https://github.com/UMAprotocol/protocol/blob/3b1a88ead18088e8056ecfefb781c97fce7fdf4d/packages/financial-templates-lib/test/clients/InsuredBridgeL1Client.js#L1064
-    expect((
-      await rateModelClient.computeRealizedLpFeePct(
-        {
-          ...depositData,
-          // Same as before, we need to use a timestamp following the `executeRootBundle` call so that we can capture
-          // the current pool utilization at 10%.
-          quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
-        },
-        l1Token.address
-      )
-    ).realizedLpFeePct).to.equal(toBNWei("0.002081296752280018"));
+    expect(
+      (
+        await rateModelClient.computeRealizedLpFeePct(
+          {
+            ...depositData,
+            // Same as before, we need to use a timestamp following the `executeRootBundle` call so that we can capture
+            // the current pool utilization at 10%.
+            quoteTimestamp: (await ethers.provider.getBlock("latest")).timestamp,
+          },
+          l1Token.address
+        )
+      ).realizedLpFeePct
+    ).to.equal(toBNWei("0.002081296752280018"));
   });
 });
 

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -136,7 +136,8 @@ async function updateAllClients() {
 }
 
 async function fillWithRealizedLpFeePct(spokePool, relayer, depositor, deposit, relayAmount = amountToRelay) {
-  const realizedLpFeePctForDeposit = (await rateModelClient.computeRealizedLpFeePct(deposit, l1Token.address)).realizedLpFeePct;
+  const realizedLpFeePctForDeposit = (await rateModelClient.computeRealizedLpFeePct(deposit, l1Token.address))
+    .realizedLpFeePct;
   return await fillRelay(
     spokePool,
     deposit.destinationToken,

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -1,4 +1,4 @@
-import { createSpyLogger, sinon, deployAndConfigureHubPool, enableRoutesOnHubPool, buildDepositStruct } from "./utils";
+import { createSpyLogger, deployAndConfigureHubPool, enableRoutesOnHubPool, buildDepositStruct } from "./utils";
 import { deploySpokePoolWithToken, destinationChainId, deployRateModelStore, getLastBlockTime, expect } from "./utils";
 import { simpleDeposit, fillRelay, ethers, Contract, SignerWithAddress, setupTokensForWallet, winston } from "./utils";
 import { amountToLp, originChainId, amountToRelay } from "./constants";
@@ -10,7 +10,7 @@ let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Co
 let hubPool: Contract, l1Token: Contract, rateModelStore: Contract;
 let owner: SignerWithAddress, depositor: SignerWithAddress, relayer: SignerWithAddress;
 
-let spy: sinon.SinonSpy, spyLogger: winston.Logger;
+let spyLogger: winston.Logger;
 let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
 let rateModelClient: RateModelClient, hubPoolClient: HubPoolClient;
 
@@ -29,7 +29,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     ]));
 
     ({ rateModelStore } = await deployRateModelStore(owner, [l1Token]));
-    ({ spy, spyLogger } = createSpyLogger());
+    ({ spyLogger } = createSpyLogger());
     hubPoolClient = new HubPoolClient(spyLogger, hubPool);
     rateModelClient = new RateModelClient(spyLogger, rateModelStore, hubPoolClient);
     spokePoolClient_1 = new SpokePoolClient(spyLogger, spokePool_1, rateModelClient, originChainId);
@@ -136,7 +136,7 @@ async function updateAllClients() {
 }
 
 async function fillWithRealizedLpFeePct(spokePool, relayer, depositor, deposit, relayAmount = amountToRelay) {
-  const realizedLpFeePctForDeposit = await rateModelClient.computeRealizedLpFeePct(deposit, l1Token.address);
+  const realizedLpFeePctForDeposit = (await rateModelClient.computeRealizedLpFeePct(deposit, l1Token.address)).realizedLpFeePct;
   return await fillRelay(
     spokePool,
     deposit.destinationToken,

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -15,7 +15,7 @@ export const sampleRateModel = {
   R2: toWei(0.75).toString(),
 };
 
-export const CHAIN_ID_TEST_LIST = [originChainId, destinationChainId, repaymentChainId]
+export const CHAIN_ID_TEST_LIST = [originChainId, destinationChainId, repaymentChainId];
 
 export const baseSpeedUpString = "ACROSS-V2-FEE-1.0";
 

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,5 +1,5 @@
 import { randomAddress, toWei, originChainId, destinationChainId, repaymentChainId } from "./utils";
-export const randomLl1Token = randomAddress();
+export const randomL1Token = randomAddress();
 export const randomOriginToken = randomAddress();
 export const randomDestinationToken = randomAddress();
 export const randomDestinationToken2 = randomAddress();

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,4 +1,4 @@
-import { randomAddress, toWei } from "./utils";
+import { randomAddress, toWei, originChainId, destinationChainId, repaymentChainId } from "./utils";
 export const randomLl1Token = randomAddress();
 export const randomOriginToken = randomAddress();
 export const randomDestinationToken = randomAddress();
@@ -14,6 +14,8 @@ export const sampleRateModel = {
   R1: toWei(0.07).toString(),
   R2: toWei(0.75).toString(),
 };
+
+export const CHAIN_ID_TEST_LIST = [originChainId, destinationChainId, repaymentChainId]
 
 export const baseSpeedUpString = "ACROSS-V2-FEE-1.0";
 

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -3,7 +3,7 @@ import { deploySpokePoolWithToken, enableRoutesOnHubPool, Contract, hre, enableR
 import { SignerWithAddress, setupTokensForWallet, getLastBlockTime } from "../utils";
 import { createSpyLogger, winston, deployAndConfigureHubPool, deployRateModelStore } from "../utils";
 import * as clients from "../../src/clients";
-import { amountToLp, destinationChainId, originChainId } from "../constants";
+import { amountToLp, destinationChainId, originChainId, CHAIN_ID_TEST_LIST } from "../constants";
 
 import { Dataworker } from "../../src/dataworker/Dataworker"; // Tested
 
@@ -48,7 +48,7 @@ export async function setupDataworker(
     owner,
     [
       { l2ChainId: destinationChainId, spokePool: spokePool_2 },
-      { l2ChainId: originChainId, spokePool: spokePool_2 },
+      { l2ChainId: originChainId, spokePool: spokePool_1 },
     ],
     umaEcosystem.finder.address,
     umaEcosystem.timer.address
@@ -95,13 +95,17 @@ export async function setupDataworker(
     destinationChainId
   );
 
-  const dataworkerInstance = new Dataworker(spyLogger, {
-    spokePoolClients: { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 },
-    hubPoolClient,
-    rateModelClient,
-    multiCallerClient,
-    configStoreClient,
-  });
+  const dataworkerInstance = new Dataworker(
+    spyLogger,
+    {
+      spokePoolClients: { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 },
+      hubPoolClient,
+      rateModelClient,
+      multiCallerClient,
+      configStoreClient,
+    },
+    CHAIN_ID_TEST_LIST
+  );
 
   // Give owner tokens to LP on HubPool with.
   await setupTokensForWallet(spokePool_1, owner, [l1Token_1, l1Token_2], null, 100); // Seed owner to LP.

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -27,6 +27,7 @@ export async function setupDataworker(
   timer: Contract;
   spokePoolClient_1: clients.SpokePoolClient;
   spokePoolClient_2: clients.SpokePoolClient;
+  configStoreClient: clients.ConfigStoreClient;
   rateModelClient: clients.RateModelClient;
   hubPoolClient: clients.HubPoolClient;
   dataworkerInstance: Dataworker;
@@ -138,6 +139,7 @@ export async function setupDataworker(
     timer: umaEcosystem.timer,
     spokePoolClient_1,
     spokePoolClient_2,
+    configStoreClient,
     rateModelClient,
     hubPoolClient,
     dataworkerInstance,

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -8,7 +8,7 @@ import {
   MultiCallerClient,
   ConfigStoreClient,
 } from "../../src/clients";
-import { amountToLp, destinationChainId, originChainId, MAX_REFUNDS_PER_LEAF } from "../constants";
+import { amountToLp, destinationChainId, originChainId, MAX_REFUNDS_PER_LEAF, repaymentChainId } from "../constants";
 
 import { Dataworker } from "../../src/dataworker/Dataworker"; // Tested
 

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -1,3 +1,5 @@
+import * as utils from "@across-protocol/contracts-v2/dist/test-utils";
+import { umaEcosystemFixture } from "@across-protocol/contracts-v2/dist/test/fixtures/UmaEcosystem.Fixture"
 import { deploySpokePoolWithToken, enableRoutesOnHubPool, Contract, hre, enableRoutes } from "../utils";
 import { SignerWithAddress, setupTokensForWallet, getLastBlockTime } from "../utils";
 import { createSpyLogger, winston, deployAndConfigureHubPool, deployRateModelStore } from "../utils";
@@ -16,16 +18,17 @@ export const dataworkerFixture = hre.deployments.createFixture(async ({ ethers }
   return await setupDataworker(ethers, maxRefundLeaf);
 });
 
-export async function setupDataworker(
-  ethers: any,
-  maxRefundsPerLeaf: number
-): Promise<{
+// Sets up all contracts neccessary to build and execute leaves in dataworker merkle roots: relayer refund, slow relay,
+// and pool rebalance roots.
+export async function setupDataworker(ethers: any, maxRefundLeaf: number): Promise<{
+  hubPool: Contract;
   spokePool_1: Contract;
   erc20_1: Contract;
   spokePool_2: Contract;
   erc20_2: Contract;
   l1Token_1: Contract;
   l1Token_2: Contract;
+  timer: Contract;
   spokePoolClient_1: SpokePoolClient;
   spokePoolClient_2: SpokePoolClient;
   rateModelClient: RateModelClient;
@@ -36,16 +39,24 @@ export async function setupDataworker(
   owner: SignerWithAddress;
   depositor: SignerWithAddress;
   relayer: SignerWithAddress;
+  dataworker: SignerWithAddress;
   updateAllClients: () => Promise<void>;
 }> {
-  const [owner, depositor, relayer] = await ethers.getSigners();
+  const [owner, depositor, relayer, dataworker] = await ethers.getSigners();
+
+  // Deploy UMA system and link Finder with HubPool, which we'll need to execute roots.
+  const parentFixture = await umaEcosystemFixture();
+
   const { spokePool: spokePool_1, erc20: erc20_1 } = await deploySpokePoolWithToken(originChainId, destinationChainId);
   const { spokePool: spokePool_2, erc20: erc20_2 } = await deploySpokePoolWithToken(destinationChainId, originChainId);
 
   // Only set cross chain contracts for one spoke pool to begin with.
-  const { hubPool, l1Token_1, l1Token_2 } = await deployAndConfigureHubPool(owner, [
-    { l2ChainId: destinationChainId, spokePool: spokePool_2 },
-  ]);
+  const { hubPool, l1Token_1, l1Token_2 } = await deployAndConfigureHubPool(
+    owner,
+    [{ l2ChainId: destinationChainId, spokePool: spokePool_2 }],
+    parentFixture.finder.address,
+    parentFixture.timer.address,
+  );
 
   // Enable deposit routes for second L2 tokens so relays can be sent between spoke pool 1 <--> 2.
   await enableRoutes(spokePool_1, [{ originToken: erc20_2.address, destinationChainId: destinationChainId }]);
@@ -59,13 +70,26 @@ export async function setupDataworker(
     { destinationChainId: destinationChainId, l1Token: l1Token_2, destinationToken: erc20_1 },
   ]);
 
+  // Enable cross chain contracts so that pool rebalance leaves can be executed.
+  const mockAdapter = await (await utils.getContractFactory("Mock_Adapter", owner)).deploy();
+  await hubPool.setCrossChainContracts(destinationChainId, mockAdapter.address, spokePool_1.address);
+  await hubPool.setCrossChainContracts(originChainId, mockAdapter.address, spokePool_2.address);
+  
+  // Set bond currency on hub pool so that roots can be proposed.
+  await parentFixture.collateralWhitelist.addToWhitelist(l1Token_1.address);
+  await parentFixture.store.setFinalFee(l1Token_1.address, { rawValue: "0" });
+  await hubPool.setBond(l1Token_1.address, "1"); // We set to 1 Wei since we can't set to 0.
+
+  // Give dataworker final fee bond to propose roots with:
+  await setupTokensForWallet(hubPool, dataworker, [l1Token_1], null, 100);
+
   const { spyLogger } = createSpyLogger();
   const { rateModelStore } = await deployRateModelStore(owner, [l1Token_1, l1Token_2]);
   const hubPoolClient = new HubPoolClient(spyLogger, hubPool);
   const rateModelClient = new RateModelClient(spyLogger, rateModelStore, hubPoolClient);
 
   const multiCallerClient = new MultiCallerClient(spyLogger, null); // leave out the gasEstimator for now.
-  const configStoreClient = new ConfigStoreClient(spyLogger, MAX_REFUNDS_PER_LEAF);
+  const configStoreClient = new ConfigStoreClient(spyLogger, maxRefundLeaf);
 
   const spokePoolClient_1 = new SpokePoolClient(
     spyLogger,
@@ -109,12 +133,14 @@ export async function setupDataworker(
   await spokePool_2.setCurrentTime(await getLastBlockTime(spokePool_2.provider));
 
   return {
+    hubPool,
     spokePool_1,
     erc20_1,
     spokePool_2,
     erc20_2,
     l1Token_1,
     l1Token_2,
+    timer: parentFixture.timer,
     spokePoolClient_1,
     spokePoolClient_2,
     rateModelClient,
@@ -125,6 +151,7 @@ export async function setupDataworker(
     owner,
     depositor,
     relayer,
+    dataworker,
     updateAllClients: async () => {
       await hubPoolClient.update();
       await configStoreClient.update();

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -1,5 +1,5 @@
 import * as utils from "@across-protocol/contracts-v2/dist/test-utils";
-import { umaEcosystemFixture } from "@across-protocol/contracts-v2/dist/test/fixtures/UmaEcosystem.Fixture"
+import { umaEcosystemFixture } from "@across-protocol/contracts-v2/dist/test/fixtures/UmaEcosystem.Fixture";
 import { deploySpokePoolWithToken, enableRoutesOnHubPool, Contract, hre, enableRoutes } from "../utils";
 import { SignerWithAddress, setupTokensForWallet, getLastBlockTime } from "../utils";
 import { createSpyLogger, winston, deployAndConfigureHubPool, deployRateModelStore } from "../utils";
@@ -20,7 +20,10 @@ export const dataworkerFixture = hre.deployments.createFixture(async ({ ethers }
 
 // Sets up all contracts neccessary to build and execute leaves in dataworker merkle roots: relayer refund, slow relay,
 // and pool rebalance roots.
-export async function setupDataworker(ethers: any, maxRefundLeaf: number): Promise<{
+export async function setupDataworker(
+  ethers: any,
+  maxRefundLeaf: number
+): Promise<{
   hubPool: Contract;
   spokePool_1: Contract;
   erc20_1: Contract;
@@ -55,7 +58,7 @@ export async function setupDataworker(ethers: any, maxRefundLeaf: number): Promi
     owner,
     [{ l2ChainId: destinationChainId, spokePool: spokePool_2 }],
     parentFixture.finder.address,
-    parentFixture.timer.address,
+    parentFixture.timer.address
   );
 
   // Enable deposit routes for second L2 tokens so relays can be sent between spoke pool 1 <--> 2.
@@ -74,7 +77,7 @@ export async function setupDataworker(ethers: any, maxRefundLeaf: number): Promi
   const mockAdapter = await (await utils.getContractFactory("Mock_Adapter", owner)).deploy();
   await hubPool.setCrossChainContracts(destinationChainId, mockAdapter.address, spokePool_1.address);
   await hubPool.setCrossChainContracts(originChainId, mockAdapter.address, spokePool_2.address);
-  
+
   // Set bond currency on hub pool so that roots can be proposed.
   await parentFixture.collateralWhitelist.addToWhitelist(l1Token_1.address);
   await parentFixture.store.setFinalFee(l1Token_1.address, { rawValue: "0" });

--- a/test/fixtures/UmaEcosystemFixture.ts
+++ b/test/fixtures/UmaEcosystemFixture.ts
@@ -1,0 +1,30 @@
+import * as utils from "@across-protocol/contracts-v2/dist/test-utils";
+import { Contract } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { utf8ToHex } from "@across-protocol/contracts-v2/dist/test-utils";
+import { interfaceName } from "@uma/common";
+
+export async function setupUmaEcosystem(owner: SignerWithAddress): Promise<{
+  timer: Contract;
+  finder: Contract;
+  collateralWhitelist: Contract;
+  store: Contract;
+}> {
+  // Setup minimum UMA ecosystem contracts. Note that we don't use the umaEcosystemFixture because Hardhat Fixture's
+  // seem to produce non-deterministic behavior between tests.
+  const timer = await (await utils.getContractFactory("Timer", owner)).deploy();
+  const finder = await (await utils.getContractFactory("Finder", owner)).deploy();
+  const collateralWhitelist = await (await utils.getContractFactory("AddressWhitelist", owner)).deploy();
+  const store = await (
+    await utils.getContractFactory("Store", owner)
+  ).deploy({ rawValue: "0" }, { rawValue: "0" }, timer.address);
+  await finder.changeImplementationAddress(utf8ToHex(interfaceName.CollateralWhitelist), collateralWhitelist.address);
+  await finder.changeImplementationAddress(utf8ToHex(interfaceName.Store), store.address);
+
+  return {
+    timer,
+    finder,
+    collateralWhitelist,
+    store,
+  };
+}

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -28,7 +28,7 @@ export function assertPromiseError(promise: Promise<any>, errMessage?: string) {
 }
 
 export async function setupTokensForWallet(
-  spokePool: utils.Contract,
+  contractToApprove: utils.Contract,
   wallet: utils.SignerWithAddress,
   tokens: utils.Contract[],
   weth?: utils.Contract,
@@ -36,9 +36,11 @@ export async function setupTokensForWallet(
 ) {
   await utils.seedWallet(wallet, tokens, weth, utils.amountToSeedWallets.mul(seedMultiplier));
   await Promise.all(
-    tokens.map((token) => token.connect(wallet).approve(spokePool.address, utils.amountToDeposit.mul(seedMultiplier)))
+    tokens.map((token) =>
+      token.connect(wallet).approve(contractToApprove.address, utils.amountToDeposit.mul(seedMultiplier))
+    )
   );
-  if (weth) await weth.connect(wallet).approve(spokePool.address, utils.amountToDeposit);
+  if (weth) await weth.connect(wallet).approve(contractToApprove.address, utils.amountToDeposit);
 }
 
 export function createSpyLogger() {
@@ -79,12 +81,14 @@ export async function deployRateModelStore(signer: utils.SignerWithAddress, toke
 
 export async function deployAndConfigureHubPool(
   signer: utils.SignerWithAddress,
-  spokePools: { l2ChainId: number; spokePool: utils.Contract }[]
+  spokePools: { l2ChainId: number; spokePool: utils.Contract }[],
+  finderAddress: string = zeroAddress,
+  timerAddress: string = zeroAddress
 ) {
   const lpTokenFactory = await (await utils.getContractFactory("LpTokenFactory", signer)).deploy();
   const hubPool = await (
     await utils.getContractFactory("HubPool", signer)
-  ).deploy(lpTokenFactory.address, zeroAddress, zeroAddress, zeroAddress);
+  ).deploy(lpTokenFactory.address, finderAddress, zeroAddress, timerAddress);
 
   const mockAdapter = await (await utils.getContractFactory("Mock_Adapter", signer)).deploy();
 

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -258,7 +258,7 @@ export async function buildDepositStruct(
   return {
     ...deposit,
     destinationToken: hubPoolClient.getDestinationTokenForDeposit(deposit),
-    realizedLpFeePct: await rateModelClient.computeRealizedLpFeePct(deposit, l1TokenForDepositedToken.address),
+    realizedLpFeePct: (await rateModelClient.computeRealizedLpFeePct(deposit, l1TokenForDepositedToken.address)).realizedLpFeePct,
   };
 }
 export async function buildDeposit(

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -258,7 +258,8 @@ export async function buildDepositStruct(
   return {
     ...deposit,
     destinationToken: hubPoolClient.getDestinationTokenForDeposit(deposit),
-    realizedLpFeePct: (await rateModelClient.computeRealizedLpFeePct(deposit, l1TokenForDepositedToken.address)).realizedLpFeePct,
+    realizedLpFeePct: (await rateModelClient.computeRealizedLpFeePct(deposit, l1TokenForDepositedToken.address))
+      .realizedLpFeePct,
   };
 }
 export async function buildDeposit(

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -381,12 +381,13 @@ export async function buildFillForRepaymentChain(
   relayer: SignerWithAddress,
   depositToFill: Deposit,
   pctOfDepositToFill: number,
-  repaymentChainId: number
+  repaymentChainId: number,
+  destinationToken: string = depositToFill.destinationToken
 ): Promise<Fill> {
   const relayDataFromDeposit = {
     depositor: depositToFill.depositor,
     recipient: depositToFill.recipient,
-    destinationToken: depositToFill.destinationToken,
+    destinationToken,
     amount: depositToFill.amount,
     originChainId: depositToFill.originChainId.toString(),
     destinationChainId: depositToFill.destinationChainId.toString(),

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -2,7 +2,7 @@ import * as utils from "@across-protocol/contracts-v2/dist/test-utils";
 import { TokenRolesEnum } from "@uma/common";
 export { MAX_SAFE_ALLOWANCE } from "@uma/common";
 import { SpyTransport } from "@uma/financial-templates-lib";
-import { sampleRateModel, toBN, zeroAddress } from "../constants";
+import { sampleRateModel, zeroAddress } from "../constants";
 
 import { SpokePoolClient } from "../../src/clients/SpokePoolClient";
 import { RateModelClient } from "../../src/clients/RateModelClient";
@@ -10,8 +10,8 @@ import { HubPoolClient } from "../../src/clients/HubPoolClient";
 
 import { deposit, Contract, SignerWithAddress, fillRelay, BigNumber } from "./index";
 import { amountToDeposit, depositRelayerFeePct } from "../constants";
-import { Deposit, Fill, RelayData, RunningBalances } from "../../src/interfaces/SpokePool";
-import { buildRelayerRefundTree, MerkleTree, toBN, toBNWei } from "../../src/utils";
+import { Deposit, Fill, RunningBalances } from "../../src/interfaces/SpokePool";
+import { buildRelayerRefundTree, toBN, toBNWei } from "../../src/utils";
 
 import winston from "winston";
 import sinon from "sinon";


### PR DESCRIPTION
This PR does NOT fully implement `buildPoolRebalanceRoot`. It implements steps 1-3 in the list "To determine the amount to modify the running balances:" as described in the [ACROSS-V2 UMIP](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-157.md#constructing-the-poolrebalanceroot). 

This PR is already large so I'm going to stop here, and I've included a simple test to demonstrate how it works.

Checklist

- [X] Initiate `runningBalances` to total refund amount for all recipient addresses for `{ repaymentChainId, l2TokenAddress }`
- [X] Set `realizedLpFees`
- [X] Account for `FundsDeposited` events
- [X] Account for slow relays 