### PR TITLE
fix: add ability to run relayer for testnet

### DIFF
--- a/src/clients/RateModelClient.ts
+++ b/src/clients/RateModelClient.ts
@@ -34,7 +34,7 @@ export class RateModelClient {
       quoteBlock = (await this.blockFinder.getBlockForTimestamp(deposit.quoteTimestamp)).number;
       rateModel = this.getRateModelForBlockNumber(l1Token, quoteBlock);
     } catch (error) {
-      if ((await this.hubPoolClient.hubPool.provider.getNetwork()).chainId == 1)
+      if ((await this.hubPoolClient.hubPool.provider.getNetwork()).chainId === 1)
         throw new error("Bad rate model store deployment");
 
       quoteBlock = await this.blockFinder.getLatestBlock().number;

--- a/src/clients/RateModelClient.ts
+++ b/src/clients/RateModelClient.ts
@@ -25,11 +25,21 @@ export class RateModelClient {
   }
 
   async computeRealizedLpFeePct(deposit: Deposit, l1Token: string): Promise<BigNumber> {
-    const quoteBlock = (await this.blockFinder.getBlockForTimestamp(deposit.quoteTimestamp)).number;
+    // The below is a temp work around to deal with the incorrect deployment that was done on all test nets. If the rate
+    // model store is deployed after the a fill is done then some calls to this method will fail, resulting in an error.
+    // For test nets we can just work around this by using the latest block number.
+    let quoteBlock = 0;
+    let rateModel: any;
+    try {
+      quoteBlock = (await this.blockFinder.getBlockForTimestamp(deposit.quoteTimestamp)).number;
+      rateModel = this.getRateModelForBlockNumber(l1Token, quoteBlock);
+    } catch (error) {
+      quoteBlock = await this.blockFinder.getLatestBlock().number;
+      rateModel = this.getRateModelForBlockNumber(l1Token, quoteBlock);
+    }
 
     const { current, post } = await this.hubPoolClient.getPostRelayPoolUtilization(l1Token, quoteBlock, deposit.amount);
 
-    const rateModel = this.getRateModelForBlockNumber(l1Token, quoteBlock);
     const realizedLpFeePct = lpFeeCalculator.calculateRealizedLpFeePct(rateModel, current, post);
 
     this.logger.debug({

--- a/src/clients/RateModelClient.ts
+++ b/src/clients/RateModelClient.ts
@@ -34,6 +34,9 @@ export class RateModelClient {
       quoteBlock = (await this.blockFinder.getBlockForTimestamp(deposit.quoteTimestamp)).number;
       rateModel = this.getRateModelForBlockNumber(l1Token, quoteBlock);
     } catch (error) {
+      if ((await this.hubPoolClient.hubPool.provider.getNetwork()).chainId == 1)
+        throw new error("Bad rate model store deployment");
+
       quoteBlock = await this.blockFinder.getLatestBlock().number;
       rateModel = this.getRateModelForBlockNumber(l1Token, quoteBlock);
     }


### PR DESCRIPTION
This PR adds a small temp workaround to enable bots to run without finding block numbers. See comment in code as to why this was done.
