### PR TITLE
improve: Add secondary and tertiary sorting indices for event sorting functions

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -176,8 +176,12 @@ export class HubPoolClient {
     );
     for (const info of tokenInfo) if (!this.l1Tokens.includes(info)) this.l1Tokens.push(info);
 
-    this.proposedRootBundles.push(...proposeRootBundleEvents.map((event) => spreadEventWithBlockNumber(event)));
-    this.executedRootBundles.push(...executedRootBundleEvents.map((event) => spreadEventWithBlockNumber(event)));
+    this.proposedRootBundles.push(
+      ...proposeRootBundleEvents.map((event) => spreadEventWithBlockNumber(event) as ProposedRootBundle)
+    );
+    this.executedRootBundles.push(
+      ...executedRootBundleEvents.map((event) => spreadEventWithBlockNumber(event) as ExecutedRootBundle)
+    );
 
     this.isUpdated = true;
     this.firstBlockToSearch = searchConfig[1] + 1; // Next iteration should start off from where this one ended.

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -170,7 +170,7 @@ export class SpokePoolClient {
 
     for (const event of fillEvents) {
       this.fills.push(spreadEvent(event));
-      this.fillsWithBlockNumbers.push(spreadEventWithBlockNumber(event));
+      this.fillsWithBlockNumbers.push(spreadEventWithBlockNumber(event) as FillWithBlock);
     }
 
     for (const event of enableDepositsEvents) {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -65,8 +65,8 @@ export class Dataworker {
 
         fillsForOriginChain.forEach((fillWithBlock) => {
           const matchedDeposit: Deposit = originClient.getDepositForFill(fillWithBlock);
-          // Now create a copy of fill with blockNumber removed.
-          const { blockNumber, ...fill } = fillWithBlock;
+          // Now create a copy of fill with block data removed.
+          const { blockNumber, transactionIndex, logIndex, ...fill } = fillWithBlock;
 
           if (matchedDeposit) {
             // Fill was validated. Save it under all blocks with the block number so we can sort it by time.
@@ -478,8 +478,10 @@ export class Dataworker {
   ) {
     this._loadData();
 
-    // Construct roots locally using class functions and compare with input roots.
-    // If any roots mismatch, efficiently pinpoint the errors to give details to the caller.
+    // Look at latest propose root bundle event earlier than a block number
+
+    // Construct roots locally using class functions and compare with the event we found earlier.
+    // If any roots mismatch, pinpoint the errors to give details to the caller.
   }
 
   async executeSlowRelayLeaves(bundleBlockNumbers: BundleEvaluationBlockNumbers) {

--- a/src/interfaces/Common.ts
+++ b/src/interfaces/Common.ts
@@ -1,0 +1,5 @@
+export interface SortableEvent {
+    blockNumber: number;
+    transactionIndex: number;
+    logIndex: number;
+}

--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "../utils";
+import {SortableEvent} from "./Common";
 // @notice Passed as input to HubPool.proposeRootBundle
 export type BundleEvaluationBlockNumbers = number[];
 
@@ -21,8 +22,7 @@ export interface RelayerRefundLeaf {
   refundAddresses: string[];
 }
 
-export interface ProposedRootBundle {
-  blockNumber: number;
+export interface ProposedRootBundle extends SortableEvent {
   challengePeriodEndTimestamp: number;
   poolRebalanceLeafCount: number;
   bundleEvaluationBlockNumbers: BigNumber[];
@@ -32,8 +32,7 @@ export interface ProposedRootBundle {
   proposer: string;
 }
 
-export interface ExecutedRootBundle {
-  blockNumber: number;
+export interface ExecutedRootBundle extends SortableEvent {
   chainId: number;
   bundleLpFees: BigNumber[];
   netSendAmounts: BigNumber[];

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -1,4 +1,5 @@
 import { BigNumber } from "ethers";
+import { SortableEvent } from "./Common";
 
 export interface Deposit {
   depositId: number;
@@ -15,8 +16,7 @@ export interface Deposit {
   speedUpSignature?: string | undefined; // appended after initialization, if deposit was speedup (not part of Deposit event).
 }
 
-export interface DepositWithBlock extends Deposit {
-  blockNumber: number;
+export interface DepositWithBlock extends Deposit, SortableEvent {
 }
 export interface Fill {
   amount: BigNumber;
@@ -36,9 +36,9 @@ export interface Fill {
   destinationChainId: number;
 }
 
-export interface FillWithBlock extends Fill {
-  blockNumber: number;
+export interface FillWithBlock extends Fill, SortableEvent {
 }
+
 export interface SpeedUp {
   depositor: string;
   depositorSignature: string;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from "./SpokePool";
 export * from "./HubPool";
+export * from "./Common";

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -1,4 +1,5 @@
 import { Event } from "ethers";
+import { SortableEvent } from "../interfaces"
 
 export function spreadEvent(event: Event) {
   const keys = Object.keys(event.args).filter((key: string) => isNaN(+key)); // Extract non-numeric keys.
@@ -17,17 +18,27 @@ export function spreadEvent(event: Event) {
   return returnedObject;
 }
 
-export function spreadEventWithBlockNumber(event: Event) {
+export function spreadEventWithBlockNumber(event: Event): SortableEvent {
   return {
     ...spreadEvent(event),
     blockNumber: event.blockNumber,
+    transactionIndex: event.transactionIndex,
+    logIndex: event.logIndex,
   };
 }
 
-export function sortEventsAscending(events: { blockNumber: number }[]): { blockNumber: number }[] {
-  return [...events].sort((ex, ey) => ex.blockNumber - ey.blockNumber);
+export function sortEventsAscending(events: SortableEvent[]): SortableEvent[] {
+  return [...events].sort((ex, ey) => {
+    if (ex.blockNumber !== ey.blockNumber) return ex.blockNumber - ey.blockNumber;
+    if (ex.transactionIndex !== ey.transactionIndex) return ex.transactionIndex - ey.transactionIndex;
+    return ex.logIndex - ey.logIndex;
+  });
 }
 
-export function sortEventsDescending(events: { blockNumber: number }[]): { blockNumber: number }[] {
-  return [...events].sort((ex, ey) => ey.blockNumber - ex.blockNumber);
+export function sortEventsDescending(events: SortableEvent[]): SortableEvent[] {
+  return [...events].sort((ex, ey) => {
+    if (ex.blockNumber !== ey.blockNumber) return ey.blockNumber - ex.blockNumber;
+    if (ex.transactionIndex !== ey.transactionIndex) return ey.transactionIndex - ex.transactionIndex;
+    return ey.logIndex - ex.logIndex;
+  });
 }


### PR DESCRIPTION
This PR adds secondary and tertiary sorting by `transactionIndex` and `logIndex` to event sorting methods, as described in the [UMIP](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-157.md#data-specifications-and-implementation): 

> Note 2: when referencing "later" or "earlier" events, the primary sort should be on the block number, the secondary sort should be on the transactionIndex, and the tertiary sort should be on the logIndex.