### PR TITLE
feat: add back get target logic and update how we use `contracts-v2` export for `getContractInfoFromAddress`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=8.3.0"
   },
   "dependencies": {
-    "@across-protocol/contracts-v2": "^0.0.53",
+    "@across-protocol/contracts-v2": "^0.0.54",
     "@across-protocol/sdk-v2": "^0.0.1",
     "@defi-wonderland/smock": "^2.0.7",
     "@uma/common": "^2.19.0",

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -1,4 +1,4 @@
-import { winston, getNetworkName, assign, Contract, runTransaction, rejectAfterDelay } from "../utils";
+import { winston, getNetworkName, assign, Contract, runTransaction, rejectAfterDelay, getTarget } from "../utils";
 import { willSucceed, etherscanLink } from "../utils";
 export interface AugmentedTransaction {
   contract: Contract;
@@ -51,7 +51,7 @@ export class MultiCallerClient {
             .filter((transaction) => !transaction.succeed)
             .map((transaction) => {
               return {
-                target: transaction.transaction.contract.address,
+                target: getTarget(transaction.transaction.contract.address),
                 reason: transaction.reason,
                 message: transaction.transaction.message,
                 mrkdwn: transaction.transaction.mrkdwn,
@@ -150,7 +150,7 @@ export class MultiCallerClient {
         at: "MultiCallerClient",
         message: "some transactions in the bundle contain different targets",
         transactions: transactions.map(({ contract, chainId }) => {
-          return { targetAddress: contract.address, chainId };
+          return { target: getTarget(contract.address), chainId };
         }),
       });
       return null; // If there is a problem in the targets in the bundle return null. This will be a noop.

--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -5,10 +5,10 @@ import * as typechain from "@across-protocol/contracts-v2"; //TODO: refactor onc
 // Return an ethers contract instance for a deployed contract, imported from the Across-protocol contracts repo.
 export function getDeployedContract(contractName: string, networkId: number, signer?: Wallet): Contract {
   try {
-    if (contractName === "SpokePool") contractName = castSpokePoolName(networkId);
-
     const address = getDeployedAddress(contractName, networkId);
-    const artifact = typechain[`${[contractName.replace("_", "")]}__factory`];
+    // If the contractName is SpokePool then we need to modify it to find the correct contract factory artifact.
+    const factoryName = contractName === "SpokePool" ? castSpokePoolName(networkId) : contractName;
+    const artifact = typechain[`${[factoryName.replace("_", "")]}__factory`];
     return new Contract(address, artifact.abi, signer);
   } catch (error) {
     throw new Error(`Could not find address for contract ${contractName} on ${networkId}`);
@@ -16,7 +16,7 @@ export function getDeployedContract(contractName: string, networkId: number, sig
 }
 
 // If the name of the contract is SpokePool then we need to apply a transformation on the name to get the correct
-// contract name. For example, if the network is "mainnet" then the contract is called Ethereum_SpokePool.
+// contract factory name. For example, if the network is "mainnet" then the contract is called Ethereum_SpokePool.
 export function castSpokePoolName(networkId: number): string {
   let networkName = getNetworkName(networkId);
   if (networkName == "Mainnet" || networkName == "Rinkeby" || networkName == "Kovan" || networkName == "Goerli")
@@ -34,7 +34,6 @@ export function getParamType(contractName: string, functionName: string, paramNa
 
 export function getDeploymentBlockNumber(contractName: string, networkId: number) {
   try {
-    if (contractName === "SpokePool") contractName = castSpokePoolName(networkId);
     return getDeployedBlockNumber(contractName, networkId);
   } catch (error) {
     throw new Error(`Could not find deployment block for contract ${contractName} on ${networkId}`);

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -1,5 +1,5 @@
 import { AugmentedTransaction } from "../clients";
-import { winston, Contract, toBN } from "../utils";
+import { winston, Contract, toBN, getContractInfoFromAddress } from "../utils";
 
 // Note that this function will throw if the call to the contract on method for given args reverts. Implementers
 // of this method should be considerate of this and catch the response to deal with the error accordingly.
@@ -40,4 +40,8 @@ export async function willSucceed(
     console.error(error);
     return { transaction, succeed: false, reason: error.reason };
   }
+}
+
+export function getTarget(targetAddress: string) {
+  return { targetAddress, ...getContractInfoFromAddress(targetAddress) };
 }

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -6,7 +6,7 @@ import { winston, Contract, toBN, getContractInfoFromAddress } from "../utils";
 export async function runTransaction(logger: winston.Logger, contract: Contract, method: string, args: any) {
   try {
     const gas = await getGasPrice(contract.provider);
-    logger.debug({ at: "TxUtil", message: "sending tx", target: contract.address, method, args, gas });
+    logger.debug({ at: "TxUtil", message: "sending tx", target: getTarget(contract.address), method, args, gas });
     return await contract[method](...args, gas);
   } catch (error) {
     logger.error({ at: "TxUtil", message: "Error executing tx", error });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,4 +35,4 @@ export {
   AcrossConfigStore__factory as AcrossConfigStore,
 } from "@across-protocol/contracts-v2";
 
-export { getDeployedAddress, getDeployedBlockNumber } from "@across-protocol/contracts-v2";
+export { getDeployedAddress, getDeployedBlockNumber, getContractInfoFromAddress } from "@across-protocol/contracts-v2";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@across-protocol/contracts-v2@^0.0.53":
-  version "0.0.53"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-0.0.53.tgz#59de48fc187c9053a96e8a455efea52592609bf0"
-  integrity sha512-l2WC18VCEf3sXsXxRey2h9f3BmRGTxB+voQIdm75XjJ5zTvvCTWYYBzWGGBTCptpiJCWpUPQBoicsEdReAOW0w==
+"@across-protocol/contracts-v2@^0.0.54":
+  version "0.0.54"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-0.0.54.tgz#86b7cadb885fb00e72ae864d9483a41b863262ea"
+  integrity sha512-IHuN6Sc8O9fUcQ3McZcZo6iGN7NFfO05Gaf2DD1K1LimNjotzeTsYZv+YSniOFsXKAWmgtd5xjzaJnE/UXGzJA==
   dependencies:
     "@defi-wonderland/smock" "^2.0.7"
     "@eth-optimism/contracts" "^0.5.11"


### PR DESCRIPTION
A previous bad merge conflict resolution done in PR https://github.com/across-protocol/relayer-v2/pull/37/files removed a whole chunk of logic added in PR https://github.com/across-protocol/relayer-v2/pull/36. This PR adds this back.

Additionally, this PR updates how the contracts repo is used in accordance with the changes discussed in this https://github.com/across-protocol/contracts-v2/pull/155#discussion_r870087070 thread
