### PR TITLE
fix: skip WETH on optimism approval

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -97,6 +97,7 @@ export class TokenClient {
     const tokensToApprove: { chainId: string; token: string }[] = [];
     Object.keys(this.tokenData).forEach((chainId) => {
       Object.keys(this.tokenData[chainId]).forEach((token) => {
+        if (token === "0x4200000000000000000000000000000000000006") return; // Skip if WETH on optimism. This does not require approvals.
         if (this.tokenData[chainId][token].allowance.lt(toBN(MAX_SAFE_ALLOWANCE)))
           tokensToApprove.push({ chainId, token });
       });


### PR DESCRIPTION
**Changes:**
- WETH on Optimism should not have any approvals.
- polygon priority fee should scale more and only apply on that chain id.
- increase base fee scaler to ensure txs dont get stuck.
