### PR TITLE
fix: fix add blue bird work around

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "@uma/common": "^2.19.0",
     "@uma/contracts-node": "^0.3.1",
     "@uma/financial-templates-lib": "2.26.0",
-    "ts-node": "^10.1.0",
-    "hardhat": "^2.9.0"
+    "bluebird": "^3.7.2",
+    "hardhat": "^2.9.0",
+    "ts-node": "^10.1.0"
   },
   "files": [
     "/dist/**/*"

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -44,7 +44,7 @@ export interface EventSearchConfig {
   fromBlock: number;
   toBlock: number | null;
   maxBlockLookBack: number;
-  concurrency: number | null;
+  concurrency?: number | null;
 }
 
 export function spreadEventWithBlockNumber(event: Event): SortableEvent {

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -1,5 +1,5 @@
 import { SortableEvent } from "../interfaces";
-import { Contract, Event, EventFilter } from "./";
+import { Contract, Event, EventFilter, Promise } from "./";
 
 export function spreadEvent(event: Event) {
   const keys = Object.keys(event.args).filter((key: string) => isNaN(+key)); // Extract non-numeric keys.
@@ -30,7 +30,6 @@ export async function paginatedEventQuery(contract: Contract, filter: EventFilte
   let numberOfQueries = 1;
   if (!searchConfig.maxBlockLookBack) searchConfig.maxBlockLookBack = searchConfig.toBlock - searchConfig.fromBlock;
   else numberOfQueries = Math.ceil((searchConfig.toBlock - searchConfig.fromBlock) / searchConfig.maxBlockLookBack);
-
   const promises = [];
   for (let i = 0; i < numberOfQueries; i++) {
     const fromBlock = searchConfig.fromBlock + i * searchConfig.maxBlockLookBack;
@@ -38,13 +37,14 @@ export async function paginatedEventQuery(contract: Contract, filter: EventFilte
     promises.push(contract.queryFilter(filter, fromBlock, toBlock));
   }
 
-  return (await Promise.all(promises)).flat();
+  return (await Promise.all(promises, { concurrency: searchConfig.concurrency | 200 })).flat(); // Default to 200 concurrent calls.
 }
 
 export interface EventSearchConfig {
   fromBlock: number;
   toBlock: number | null;
   maxBlockLookBack: number;
+  concurrency: number | null;
 }
 
 export function spreadEventWithBlockNumber(event: Event): SortableEvent {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,7 @@ export { utils, EventFilter, BaseContract, Event, Wallet } from "ethers";
 export { ethers, providers } from "ethers";
 export type { Block } from "@ethersproject/abstract-provider";
 export { config } from "dotenv";
+export { Promise } from "bluebird";
 
 // Utils specifically for this bot.
 export * from "./ProviderUtils";


### PR DESCRIPTION
The Event util can sometimes make too manny parallel calls when dealing with a lot of events. This PR adds in a blue bird promise logic to limit the max concurrency to add stability to the bots.
