### PR TITLE
improve: Refactor leaf executor implementation

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -37,6 +37,15 @@ export class HubPoolClient {
     return this.pendingRootBundle !== undefined && this.pendingRootBundle.unclaimedPoolRebalanceLeafCount > 0;
   }
 
+  getPendingRootBundleIfAvailable() {
+    const hasPendingProposal = this.hasPendingProposal();
+    const pendingRootBundle = hasPendingProposal ? this.getPendingRootBundleProposal() : undefined;
+    return {
+      hasPendingProposal,
+      pendingRootBundle,
+    };
+  }
+
   getProposedRootBundles() {
     return this.proposedRootBundles;
   }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -706,14 +706,7 @@ export class Dataworker {
   // TODO: this method and executeRelayerRefundLeaves have a lot of similarities, but they have some key differences
   // in both the events they search for and the comparisons they make. We should try to generalize this in the future,
   // but keeping them separate is probably the simplest for the initial implementation.
-  async executeSlowRelayLeaves() {
-    const spokePoolClients = await constructSpokePoolClientsForBlockAndUpdate(
-      this.chainIdListForBundleEvaluationBlockNumbers,
-      this.clients,
-      this.logger,
-      this.clients.hubPoolClient.latestBlockNumber
-    );
-
+  async executeSlowRelayLeaves(spokePoolClients: { [chainId: number]: SpokePoolClient }) {
     Object.entries(spokePoolClients).forEach(([chainId, client]) => {
       let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays());
 
@@ -910,14 +903,7 @@ export class Dataworker {
     });
   }
 
-  async executeRelayerRefundLeaves() {
-    const spokePoolClients = await constructSpokePoolClientsForBlockAndUpdate(
-      this.chainIdListForBundleEvaluationBlockNumbers,
-      this.clients,
-      this.logger,
-      this.clients.hubPoolClient.latestBlockNumber
-    );
-
+  async executeRelayerRefundLeaves(spokePoolClients: { [chainId: number]: SpokePoolClient }) {
     Object.entries(spokePoolClients).forEach(([chainId, client]) => {
       let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays());
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -697,6 +697,11 @@ export class Dataworker {
   // in both the events they search for and the comparisons they make. We should try to generalize this in the future,
   // but keeping them separate is probably the simplest for the initial implementation.
   async executeSlowRelayLeaves(spokePoolClients: { [chainId: number]: SpokePoolClient }) {
+    this.logger.debug({
+      at: "Dataworker#executeSlowRelayLeaves",
+      message: "Executing slow relay leaves",
+    });
+
     Object.entries(spokePoolClients).forEach(([chainId, client]) => {
       let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays());
 
@@ -807,6 +812,11 @@ export class Dataworker {
   }
 
   async executePoolRebalanceLeaves(spokePoolClients?: { [chainId: number]: SpokePoolClient }) {
+    this.logger.debug({
+      at: "Dataworker#executePoolRebalanceLeaves",
+      message: "Executing pool rebalance leaves",
+    });
+
     if (!this.clients.hubPoolClient.isUpdated) throw new Error(`HubPoolClient not updated`);
     const hubPoolChainId = (await this.clients.hubPoolClient.hubPool.provider.getNetwork()).chainId;
 
@@ -901,6 +911,11 @@ export class Dataworker {
   }
 
   async executeRelayerRefundLeaves(spokePoolClients: { [chainId: number]: SpokePoolClient }) {
+    this.logger.debug({
+      at: "Dataworker#executeRelayerRefundLeaves",
+      message: "Executing relayer refund leaves",
+    });
+
     Object.entries(spokePoolClients).forEach(([chainId, client]) => {
       let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays());
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -727,7 +727,7 @@ export class Dataworker {
           // TODO: Consider allowing dataworker to execute relayer refund leaves from partially executed root bundles,
           // i.e. imagine the situation where the pool rebalance leaf with a specific chain ID was executed
           // and we want to execute its relayer refund leaves without waiting for the other chains.
-          return this.clients.hubPoolClient.isRootBundleValid(bundle, this.clients.hubPoolClient.latestBlockNumber)
+          return this.clients.hubPoolClient.isRootBundleValid(bundle, this.clients.hubPoolClient.latestBlockNumber);
         });
 
         if (!matchingRootBundle) {
@@ -932,7 +932,7 @@ export class Dataworker {
           // TODO: Consider allowing dataworker to execute relayer refund leaves from partially executed root bundles,
           // i.e. imagine the situation where the pool rebalance leaf with a specific chain ID was executed
           // and we want to execute its relayer refund leaves without waiting for the other chains.
-          return this.clients.hubPoolClient.isRootBundleValid(bundle, this.clients.hubPoolClient.latestBlockNumber)
+          return this.clients.hubPoolClient.isRootBundleValid(bundle, this.clients.hubPoolClient.latestBlockNumber);
         });
 
         if (!matchingRootBundle) {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -792,18 +792,6 @@ export class Dataworker {
           return !fullFill;
         });
 
-        if (tree.getHexRoot() !== rootBundleRelay.slowRelayRoot) {
-          this.logger.warn({
-            at: "Dataworke#executeSlowRelayLeaves",
-            message: "Constructed a different root for the block range!",
-            chainId,
-            mainnetRootBundleBlock: matchingRootBundle.blockNumber,
-            publishedSlowRelayRoot: rootBundleRelay.slowRelayRoot,
-            constructedSlowRelayRoot: tree.getHexRoot(),
-          });
-          continue;
-        }
-
         executableLeaves.forEach((leaf) => {
           this.clients.multiCallerClient.enqueueTransaction({
             contract: client.spokePool,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -996,7 +996,7 @@ export class Dataworker {
             method: "executeRelayerRefundLeaf",
             args: [rootBundleRelay.rootBundleId, leaf, tree.getHexProof(leaf)],
             message: "Executed RelayerRefundLeaf 🌿!",
-            mrkdwn: `rootBundleId: ${rootBundleRelay.rootBundleId}\nrelayerRefundRoot: ${rootBundleRelay.relayerRefundRoot}\nLeaf: ${leaf.leafId}`, // Just a placeholder
+            mrkdwn: `rootBundleId: ${rootBundleRelay.rootBundleId}\nrelayerRefundRoot: ${rootBundleRelay.relayerRefundRoot}\nLeaf: ${leaf.leafId}\nchainId: ${chainId}\ntoken: ${leaf.l2TokenAddress}`, // Just a placeholder
           });
         });
       }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -849,7 +849,7 @@ export class Dataworker {
     const widestPossibleExpectedBlockRange = await PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       this.chainIdListForBundleEvaluationBlockNumbers,
       this.clients,
-      pendingRootBundle.proposalBlockNumber
+      this.clients.hubPoolClient.latestBlockNumber
     );
     const { valid, reason, expectedTrees } = await this.validateRootBundle(
       hubPoolChainId,

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -89,11 +89,6 @@ export async function constructSpokePoolClientsForPendingRootBundle(
         1,
         chainIdListForBundleEvaluationBlockNumbers
       )[1];
-      logger.debug({
-        at: "Dataworker#validate",
-        message: `Constructing spoke pool clients for end mainnet block in bundle range`,
-        endBlockForMainnet,
-      });
       if (constructSpokeClients)
         spokePoolClients = await constructSpokePoolClientsForBlockAndUpdate(
           chainIdListForBundleEvaluationBlockNumbers,
@@ -104,12 +99,5 @@ export async function constructSpokePoolClientsForPendingRootBundle(
     }
   }
 
-  return {
-    widestPossibleExpectedBlockRange,
-    hasPendingProposal,
-    pendingRootBundle,
-    blockRangesImpliedByBundleEndBlocks,
-    endBlockForMainnet,
-    spokePoolClients,
-  };
+  return spokePoolClients;
 }

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -57,8 +57,7 @@ export async function updateDataworkerClients(clients: DataworkerClients) {
 export async function constructSpokePoolClientsForPendingRootBundle(
   logger: winston.Logger,
   chainIdListForBundleEvaluationBlockNumbers: number[],
-  clients: DataworkerClients,
-  constructSpokeClients: boolean
+  clients: DataworkerClients
 ) {
   const widestPossibleExpectedBlockRange = await getWidestPossibleExpectedBlockRange(
     chainIdListForBundleEvaluationBlockNumbers,
@@ -89,13 +88,12 @@ export async function constructSpokePoolClientsForPendingRootBundle(
         1,
         chainIdListForBundleEvaluationBlockNumbers
       )[1];
-      if (constructSpokeClients)
-        spokePoolClients = await constructSpokePoolClientsForBlockAndUpdate(
-          chainIdListForBundleEvaluationBlockNumbers,
-          clients,
-          logger,
-          endBlockForMainnet
-        );
+      spokePoolClients = await constructSpokePoolClientsForBlockAndUpdate(
+        chainIdListForBundleEvaluationBlockNumbers,
+        clients,
+        logger,
+        endBlockForMainnet
+      );
     }
   }
 

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -1,8 +1,16 @@
 import winston from "winston";
 import { DataworkerConfig } from "./DataworkerConfig";
-import { Clients, constructClients, getSpokePoolSigners, updateClients } from "../common";
+import {
+  Clients,
+  constructClients,
+  constructSpokePoolClientsForBlockAndUpdate,
+  getSpokePoolSigners,
+  updateClients,
+} from "../common";
 import { EventSearchConfig, getDeploymentBlockNumber, getSigner, Wallet } from "../utils";
-import { TokenClient } from "../clients";
+import { SpokePoolClient, TokenClient } from "../clients";
+import { getWidestPossibleExpectedBlockRange } from "./PoolRebalanceUtils";
+import { getBlockRangeForChain } from "./DataworkerUtils";
 
 export interface DataworkerClients extends Clients {
   tokenClient: TokenClient;
@@ -44,4 +52,64 @@ export async function updateDataworkerClients(clients: DataworkerClients) {
 
   // Run approval on hub pool.
   await clients.tokenClient.setBondTokenAllowance();
+}
+
+export async function constructSpokePoolClientsForPendingRootBundle(
+  logger: winston.Logger,
+  chainIdListForBundleEvaluationBlockNumbers: number[],
+  clients: DataworkerClients,
+  constructSpokeClients: boolean
+) {
+  const widestPossibleExpectedBlockRange = await getWidestPossibleExpectedBlockRange(
+    chainIdListForBundleEvaluationBlockNumbers,
+    clients,
+    clients.hubPoolClient.latestBlockNumber
+  );
+  const { hasPendingProposal, pendingRootBundle } = clients.hubPoolClient.getPendingRootBundleIfAvailable();
+  let blockRangesImpliedByBundleEndBlocks: number[][];
+  let endBlockForMainnet: number;
+  let spokePoolClients: { [chainId: number]: SpokePoolClient };
+  if (hasPendingProposal) {
+    // The block range that we'll use to reconstruct the pending roots will be the end block specified in the
+    // pending root bundle, and the block right after the last valid root bundle proposal's end block.
+    // If the proposer didn't use the same start block, then they might have missed events and the roots will
+    // be different. We'll need to reconstruct these block ranges for the validator and executor.
+    if (pendingRootBundle.bundleEvaluationBlockNumbers)
+      blockRangesImpliedByBundleEndBlocks = widestPossibleExpectedBlockRange.map((blockRange, index) => [
+        blockRange[0],
+        pendingRootBundle.bundleEvaluationBlockNumbers[index],
+      ]);
+    // Construct spoke pool clients using spoke pools deployed at end of block range.
+    // We do make an assumption that the spoke pool contract was not changed during the block range. By using the
+    // spoke pool at this block instead of assuming its the currently deployed one, we can pay refunds for deposits
+    // on deprecated spoke pools.
+    if (blockRangesImpliedByBundleEndBlocks) {
+      endBlockForMainnet = getBlockRangeForChain(
+        blockRangesImpliedByBundleEndBlocks,
+        1,
+        chainIdListForBundleEvaluationBlockNumbers
+      )[1];
+      logger.debug({
+        at: "Dataworker#validate",
+        message: `Constructing spoke pool clients for end mainnet block in bundle range`,
+        endBlockForMainnet,
+      });
+      if (constructSpokeClients)
+        spokePoolClients = await constructSpokePoolClientsForBlockAndUpdate(
+          chainIdListForBundleEvaluationBlockNumbers,
+          clients,
+          logger,
+          endBlockForMainnet
+        );
+    }
+  }
+
+  return {
+    widestPossibleExpectedBlockRange,
+    hasPendingProposal,
+    pendingRootBundle,
+    blockRangesImpliedByBundleEndBlocks,
+    endBlockForMainnet,
+    spokePoolClients,
+  };
 }

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -41,6 +41,9 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
       await updateDataworkerClients(clients);
 
       // Construct spoke clients used to evaluate and execute leaves from pending root bundle.
+      // Since we're updating all clients once per severless run, we can precompute all spoke pool clients safely
+      // here and then recompute block ranges in the dataworker methods without any risk that the spoke pool client
+      // and the hub pool clients reference different block ranges.
       logger[startupLogLevel(config)]({
         at: "Dataworker#index",
         message: "Constructing spoke pool clients for pending root bundle",

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -48,8 +48,7 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
       const spokePoolClientsForPendingRootBundle = await constructSpokePoolClientsForPendingRootBundle(
         logger,
         dataworker.chainIdListForBundleEvaluationBlockNumbers,
-        clients,
-        true
+        clients
       );
       logger[startupLogLevel(config)]({
         at: "Dataworker#index",

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -68,7 +68,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeaves();
+    await dataworkerInstance.executePoolRebalanceLeavesTest();
 
     // Should be 2 transactions: 1 for the to chain and 1 for the from chain.
     expect(multiCallerClient.transactionCount()).to.equal(2);
@@ -85,7 +85,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeaves();
+    await dataworkerInstance.executePoolRebalanceLeavesTest();
     expect(multiCallerClient.transactionCount()).to.equal(0);
 
     // TEST 4:
@@ -100,7 +100,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeaves();
+    await dataworkerInstance.executePoolRebalanceLeavesTest();
 
     // Should be 1 leaf since this is _only_ a second partial fill repayment and doesn't involve the deposit chain.
     expect(multiCallerClient.transactionCount()).to.equal(1);

--- a/test/Dataworker.executeRelayerRefunds.ts
+++ b/test/Dataworker.executeRelayerRefunds.ts
@@ -61,7 +61,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
     await buildFillForRepaymentChain(spokePool_2, depositor, deposit, 0.5, destinationChainId);
     await updateAllClients();
 
-    await dataworkerInstance.proposeRootBundle();
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
 
     // Execute queue and check that root bundle is pending:
     await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
@@ -70,7 +70,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
     // Advance time and execute rebalance leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeavesTest();
+    await dataworkerInstance.executePoolRebalanceLeaves();
     await multiCallerClient.executeTransactionQueue();
 
     // TEST 3:
@@ -79,18 +79,18 @@ describe("Dataworker: Execute relayer refunds", async function () {
     // pool rebalance leaves because they should use the chain's end block from the latest fully executed proposed
     // root bundle, which should be the bundle block in expectedPoolRebalanceRoot2 + 1.
     await updateAllClients();
-    await dataworkerInstance.proposeRootBundle();
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
 
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeavesTest();
+    await dataworkerInstance.executePoolRebalanceLeaves();
 
     // TEST 4:
     // Submit another fill and check that dataworker proposes another root:
     await buildFillForRepaymentChain(spokePool_2, depositor, deposit, 1, destinationChainId);
     await updateAllClients();
-    await dataworkerInstance.proposeRootBundle();
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
 
     // Execute queue and execute leaves:
     await multiCallerClient.executeTransactionQueue();
@@ -98,7 +98,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeavesTest();
+    await dataworkerInstance.executePoolRebalanceLeaves();
 
     // Should be 1 leaf since this is _only_ a second partial fill repayment and doesn't involve the deposit chain.
     await multiCallerClient.executeTransactionQueue();

--- a/test/Dataworker.executeSlowRelay.ts
+++ b/test/Dataworker.executeSlowRelay.ts
@@ -61,7 +61,7 @@ describe("Dataworker: Execute slow relays", async function () {
     await buildFillForRepaymentChain(spokePool_2, depositor, deposit, 0.5, destinationChainId);
     await updateAllClients();
 
-    await dataworkerInstance.proposeRootBundle();
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
 
     // Execute queue and check that root bundle is pending:
     await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
@@ -70,7 +70,7 @@ describe("Dataworker: Execute slow relays", async function () {
     // Advance time and execute rebalance leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeavesTest();
+    await dataworkerInstance.executePoolRebalanceLeaves();
     await multiCallerClient.executeTransactionQueue();
 
     // TEST 3:
@@ -79,17 +79,17 @@ describe("Dataworker: Execute slow relays", async function () {
     // pool rebalance leaves because they should use the chain's end block from the latest fully executed proposed
     // root bundle, which should be the bundle block in expectedPoolRebalanceRoot2 + 1.
     await updateAllClients();
-    await dataworkerInstance.proposeRootBundle();
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
 
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeavesTest();
+    await dataworkerInstance.executePoolRebalanceLeaves();
 
     // TEST 4:
     // Submit a new root with no additional actions taken to make sure that this doesn't break anything.
     await updateAllClients();
-    await dataworkerInstance.proposeRootBundle();
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
 
     // Execute queue and execute leaves:
     await multiCallerClient.executeTransactionQueue();
@@ -97,7 +97,7 @@ describe("Dataworker: Execute slow relays", async function () {
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeavesTest();
+    await dataworkerInstance.executePoolRebalanceLeaves();
 
     // Should be 1 leaf since this is _only_ a second partial fill repayment and doesn't involve the deposit chain.
     await multiCallerClient.executeTransactionQueue();

--- a/test/Dataworker.executeSlowRelay.ts
+++ b/test/Dataworker.executeSlowRelay.ts
@@ -1,6 +1,6 @@
 import { buildFillForRepaymentChain } from "./utils";
 import { SignerWithAddress, expect, ethers, Contract, buildDeposit } from "./utils";
-import { HubPoolClient, AcrossConfigStoreClient, MultiCallerClient } from "../src/clients";
+import { HubPoolClient, AcrossConfigStoreClient, MultiCallerClient, SpokePoolClient } from "../src/clients";
 import { amountToDeposit, destinationChainId } from "./constants";
 import { MAX_REFUNDS_PER_RELAYER_REFUND_LEAF, MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF } from "./constants";
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
@@ -15,6 +15,7 @@ let depositor: SignerWithAddress;
 
 let hubPoolClient: HubPoolClient, configStoreClient: AcrossConfigStoreClient;
 let dataworkerInstance: Dataworker, multiCallerClient: MultiCallerClient;
+let spokePoolClients: { [chainId: number]: SpokePoolClient };
 
 let updateAllClients: () => Promise<void>;
 
@@ -33,6 +34,7 @@ describe("Dataworker: Execute slow relays", async function () {
       dataworkerInstance,
       multiCallerClient,
       updateAllClients,
+      spokePoolClients,
     } = await setupDataworker(
       ethers,
       MAX_REFUNDS_PER_RELAYER_REFUND_LEAF,
@@ -68,7 +70,7 @@ describe("Dataworker: Execute slow relays", async function () {
     // Advance time and execute rebalance leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeaves();
+    await dataworkerInstance.executePoolRebalanceLeavesTest();
     await multiCallerClient.executeTransactionQueue();
 
     // TEST 3:
@@ -82,7 +84,7 @@ describe("Dataworker: Execute slow relays", async function () {
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeaves();
+    await dataworkerInstance.executePoolRebalanceLeavesTest();
 
     // TEST 4:
     // Submit a new root with no additional actions taken to make sure that this doesn't break anything.
@@ -95,13 +97,13 @@ describe("Dataworker: Execute slow relays", async function () {
     // Advance time and execute leaves:
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.executePoolRebalanceLeaves();
+    await dataworkerInstance.executePoolRebalanceLeavesTest();
 
     // Should be 1 leaf since this is _only_ a second partial fill repayment and doesn't involve the deposit chain.
     await multiCallerClient.executeTransactionQueue();
 
     await updateAllClients();
-    await dataworkerInstance.executeSlowRelayLeaves();
+    await dataworkerInstance.executeSlowRelayLeaves(spokePoolClients);
 
     // There should be one slow relay to execute.
     expect(multiCallerClient.transactionCount()).to.equal(1);

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -80,13 +80,13 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await multiCallerClient.executeTransactionQueue();
 
     // Exit early if no pending bundle
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "No pending proposal, nothing to validate")).to.be.true;
 
     // Exit early if pending bundle but challenge period has passed
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "Challenge period passed, cannot dispute")).to.be.true;
 
     // Propose new valid root bundle
@@ -118,7 +118,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
 
     // Constructs same roots as proposed root bundle
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "Pending root bundle matches with expected")).to.be.true;
 
     // Now let's test with some invalid root bundles:
@@ -145,7 +145,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "Pending root bundle matches with expected")).to.be.true;
 
     // Bundle range end blocks are too low.
@@ -159,7 +159,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "A bundle end block is < expected start block, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -173,7 +173,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "A bundle end block is > latest block but within buffer, skipping")).to.be.true;
     await updateAllClients();
     expect(hubPoolClient.hasPendingProposal()).to.equal(true);
@@ -191,7 +191,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "A bundle end block is > latest block + buffer for its chain, submitting dispute"))
       .to.be.true;
     await multiCallerClient.executeTransactionQueue();
@@ -206,7 +206,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "Unexpected bundle block range length, disputing")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -220,7 +220,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "Empty pool rebalance root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -234,7 +234,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "Unexpected pool rebalance root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -248,7 +248,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "Unexpected pool rebalance root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -262,7 +262,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "Unexpected relayer refund root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -276,7 +276,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       utf8ToHex("BogusRoot")
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundleTest();
     expect(lastSpyLogIncludes(spy, "Unexpected slow relay root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
   });

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -75,18 +75,18 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedPoolRebalanceRoot2.runningBalances
     );
     dataworkerInstance.buildSlowRelayRoot(blockRange2, spokePoolClients);
-    await dataworkerInstance.proposeRootBundle();
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
     await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
     await multiCallerClient.executeTransactionQueue();
 
     // Exit early if no pending bundle
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "No pending proposal, nothing to validate")).to.be.true;
 
     // Exit early if pending bundle but challenge period has passed
     await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "Challenge period passed, cannot dispute")).to.be.true;
 
     // Propose new valid root bundle
@@ -113,12 +113,12 @@ describe("Dataworker: Validate pending root bundle", async function () {
       );
     }
     await updateAllClients();
-    await dataworkerInstance.proposeRootBundle();
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
     await multiCallerClient.executeTransactionQueue();
 
     // Constructs same roots as proposed root bundle
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "Pending root bundle matches with expected")).to.be.true;
 
     // Now let's test with some invalid root bundles:
@@ -145,7 +145,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "Pending root bundle matches with expected")).to.be.true;
 
     // Bundle range end blocks are too low.
@@ -159,7 +159,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "A bundle end block is < expected start block, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -173,7 +173,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "A bundle end block is > latest block but within buffer, skipping")).to.be.true;
     await updateAllClients();
     expect(hubPoolClient.hasPendingProposal()).to.equal(true);
@@ -191,7 +191,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "A bundle end block is > latest block + buffer for its chain, submitting dispute"))
       .to.be.true;
     await multiCallerClient.executeTransactionQueue();
@@ -206,7 +206,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "Unexpected bundle block range length, disputing")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -220,7 +220,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "Empty pool rebalance root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -234,7 +234,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "Unexpected pool rebalance root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -248,7 +248,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "Unexpected pool rebalance root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -262,7 +262,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "Unexpected relayer refund root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
 
@@ -276,7 +276,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       utf8ToHex("BogusRoot")
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundleTest();
+    await dataworkerInstance.validatePendingRootBundle();
     expect(lastSpyLogIncludes(spy, "Unexpected slow relay root, submitting dispute")).to.be.true;
     await multiCallerClient.executeTransactionQueue();
   });


### PR DESCRIPTION
I used this PR to execute leaves in prod (and propose a new bundle). It cuts down the number of spoke pool clients from 5 to 2

1 For the pending root bundle, used in validation and execution logic
1 For the next root bundle, used in propose logic