### PR TITLE
feat: Use spoke pool client lookback in dataworker

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -229,7 +229,7 @@ export class SpokePoolClient {
     }
 
     for (const event of relayedRootBundleEvents) {
-      this.rootBundleRelays.push(spreadEvent(event));
+      this.rootBundleRelays.push(spreadEventWithBlockNumber(event) as RootBundleRelayWithBlock);
     }
 
     for (const event of executedRelayerRefundRootEvents) {

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -15,6 +15,15 @@ export class CommonConfig {
   readonly relayerDiscount: BigNumber;
   readonly sendingTransactionsEnabled: boolean;
 
+  // Note: maxSpokeClientLookBack is a very dangerous config variable to set because it can unexpectedly produce invalid
+  // root bundles if it misses older events. This should only be used in Relayer functions, or carefully in Dataworker
+  // functions. For example, if you want to limit the amount of blocks looked back when trying to execute root bundles,
+  // then you should also limit the amount of root bundles that you look back by setting the SPOKE_ROOTS_LOOKBACK_COUNT
+  // variable to something small. A reasonable setting would be to look back ~48 hours per chain and only 1-2 root
+  // bundles per chain, since it is very unlikely that the 2 most recent root bundles will contain events from more
+  // than 48 hours into the past.
+  readonly maxSpokeClientLookBack: { [chainId: number]: number };
+
   constructor(env: ProcessEnv) {
     const {
       CONFIGURED_NETWORKS,
@@ -25,6 +34,7 @@ export class CommonConfig {
       MAX_TX_WAIT_DURATION,
       RELAYER_DISCOUNT,
       SEND_TRANSACTIONS,
+      MAX_SPOKE_CLIENT_LOOK_BACK,
     } = env;
     this.hubPoolChainId = HUB_CHAIN_ID ? Number(HUB_CHAIN_ID) : 1;
     this.spokePoolChains = CONFIGURED_NETWORKS ? JSON.parse(CONFIGURED_NETWORKS) : Constants.CHAIN_ID_LIST_INDICES;
@@ -38,5 +48,6 @@ export class CommonConfig {
     this.maxTxWait = MAX_TX_WAIT_DURATION ? Number(MAX_TX_WAIT_DURATION) : 180; // 3 minutes
     this.relayerDiscount = RELAYER_DISCOUNT ? toBNWei(RELAYER_DISCOUNT) : toBNWei(0);
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
+    this.maxSpokeClientLookBack = MAX_SPOKE_CLIENT_LOOK_BACK ? JSON.parse(MAX_SPOKE_CLIENT_LOOK_BACK) : {};
   }
 }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -37,7 +37,7 @@ import {
   updateUnfilledDepositsWithMatchedDeposit,
   getUniqueDepositsInRange,
 } from "./DepositUtils";
-import { constructSpokePoolClientsForBlockAndUpdate } from "../common/ClientHelper";
+import { constructSpokePoolClientsForBlockAndUpdate } from "./DataworkerClientHelper";
 import { BalanceAllocator } from "../clients/BalanceAllocator";
 
 // @notice Constructs roots to submit to HubPool on L1. Fetches all data synchronously from SpokePool/HubPool clients

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -31,8 +31,15 @@ export class DataworkerConfig extends CommonConfig {
       ? Number(MAX_POOL_REBALANCE_LEAF_SIZE_OVERRIDE)
       : undefined;
     this.spokeRootsLookbackCount = SPOKE_ROOTS_LOOKBACK_COUNT ? Number(SPOKE_ROOTS_LOOKBACK_COUNT) : undefined;
-    if (this.maxPoolRebalanceLeafSizeOverride !== undefined)
-      assert(this.maxPoolRebalanceLeafSizeOverride > 0, "Max leaf count set to 0");
+    // See note in CommonConfig why out of an abundance of caution we require that spokeRootsLookbackCount is set
+    // if `maxSpokeClientLookBack` is set.
+    assert(
+      !(this.spokeRootsLookbackCount === undefined && this.maxSpokeClientLookBack === {}),
+      "Must set a spokeRootsLookbackCount if maxSpokeClientLookBack is set to mitigate risk of building invalid roots"
+    );
+    if (this.spokeRootsLookbackCount === undefined && this.maxSpokeClientLookBack === {})
+      if (this.maxPoolRebalanceLeafSizeOverride !== undefined)
+        assert(this.maxPoolRebalanceLeafSizeOverride > 0, "Max leaf count set to 0");
     this.maxRelayerRepaymentLeafSizeOverride = MAX_RELAYER_REPAYMENT_LEAF_SIZE_OVERRIDE
       ? Number(MAX_RELAYER_REPAYMENT_LEAF_SIZE_OVERRIDE)
       : undefined;

--- a/src/finalizer/FinalizerClientHelper.ts
+++ b/src/finalizer/FinalizerClientHelper.ts
@@ -2,7 +2,7 @@ import winston from "winston";
 import { getSigner } from "../utils";
 import { SpokePoolClient } from "../clients";
 import { Clients, constructClients, updateClients, updateSpokePoolClients } from "../common";
-import { constructSpokePoolClientsWithLookback } from "../relayer/RelayerClientHelper";
+import { constructSpokePoolClientsWithLookback } from "../common/ClientHelper";
 import { FinalizerConfig } from "./FinalizerConfig";
 
 export interface FinalizerClients extends Clients {

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -1,64 +1,18 @@
 import winston from "winston";
-import { Contract, getDeployedContract, getDeploymentBlockNumber, getSigner, Wallet } from "../utils";
+import { getSigner } from "../utils";
 import { TokenClient, SpokePoolClient } from "../clients";
 import { RelayerConfig } from "./RelayerConfig";
-import { Clients, constructClients, updateClients, getSpokePoolSigners, updateSpokePoolClients } from "../common";
+import {
+  Clients,
+  constructClients,
+  constructSpokePoolClientsWithLookback,
+  updateClients,
+  updateSpokePoolClients,
+} from "../common";
 
 export interface RelayerClients extends Clients {
   spokePoolClients: { [chainId: number]: SpokePoolClient };
   tokenClient: TokenClient;
-}
-
-export interface SpokePoolClientsByChain {
-  [chainId: number]: SpokePoolClient;
-}
-
-export async function constructSpokePoolClientsWithLookback(
-  logger: winston.Logger,
-  clients: Clients,
-  config: RelayerConfig,
-  baseSigner: Wallet
-): Promise<SpokePoolClientsByChain> {
-  const spokePoolClients: SpokePoolClientsByChain = {};
-
-  // Set up Spoke signers and connect them to spoke pool contract objects:
-  const spokePoolSigners = getSpokePoolSigners(baseSigner, config);
-  const spokePools = config.spokePoolChains.map((networkId) => {
-    return { networkId, contract: getDeployedContract("SpokePool", networkId, spokePoolSigners[networkId]) };
-  });
-
-  // For each spoke chain, look up its latest block and adjust by lookback configuration to determine
-  // fromBlock. If no lookback is set, fromBlock will be set to spoke pool's deployment block.
-  const fromBlocks = {};
-  const l2BlockNumbers = await Promise.all(
-    spokePools.map((obj: { contract: Contract }) => obj.contract.provider.getBlockNumber())
-  );
-  spokePools.forEach((obj: { networkId: number; contract: Contract }, index) => {
-    if (config.maxRelayerLookBack[obj.networkId])
-      fromBlocks[obj.networkId] = l2BlockNumbers[index] - config.maxRelayerLookBack[obj.networkId];
-  });
-
-  // Create client for each spoke pool.
-  spokePools.forEach((obj: { networkId: number; contract: Contract }) => {
-    const spokePoolDeploymentBlock = getDeploymentBlockNumber("SpokePool", obj.networkId);
-    const spokePoolClientSearchSettings = {
-      fromBlock: fromBlocks[obj.networkId]
-        ? Math.max(fromBlocks[obj.networkId], spokePoolDeploymentBlock)
-        : spokePoolDeploymentBlock,
-      toBlock: null,
-      maxBlockLookBack: config.maxBlockLookBack[obj.networkId],
-    };
-    spokePoolClients[obj.networkId] = new SpokePoolClient(
-      logger,
-      obj.contract,
-      clients.configStoreClient,
-      obj.networkId,
-      spokePoolClientSearchSettings,
-      spokePoolDeploymentBlock
-    );
-  });
-
-  return spokePoolClients;
 }
 
 export async function constructRelayerClients(logger: winston.Logger, config: RelayerConfig): Promise<RelayerClients> {

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -1,10 +1,2 @@
-import { CommonConfig, ProcessEnv } from "../common";
-export class RelayerConfig extends CommonConfig {
-  readonly maxRelayerLookBack: { [chainId: number]: number };
-
-  constructor(env: ProcessEnv) {
-    const { MAX_RELAYER_DEPOSIT_LOOK_BACK } = env;
-    super(env);
-    this.maxRelayerLookBack = MAX_RELAYER_DEPOSIT_LOOK_BACK ? JSON.parse(MAX_RELAYER_DEPOSIT_LOOK_BACK) : {};
-  }
-}
+import { CommonConfig } from "../common";
+export class RelayerConfig extends CommonConfig {}


### PR DESCRIPTION
Certain functions in the dataworker like the leaf executor shouldn't have to keep looking back from the beginning of history. Instead, we can strategically set the `maxSpokeClientLookBack` per chain in combination with `spokeRootsLookbackCount` to limit the web3 requests per leaf executor run.

An example configuration would look back only ~48 hours of blocks and also only try to execute the most recent root bundle per chain.

```
MAX_SPOKE_CLIENT_LOOK_BACK='{ "1": 11500, "10": 400000, "137": 100000, "288": 5000, "42161": 150000 }'
SPOKE_ROOTS_LOOKBACK_COUNT=1
```

We could also strategically set the finalizer's (or even disputer's lookback) to a larger lookback but still very safe length of 7 days:

```
MAX_SPOKE_CLIENT_LOOK_BACK='{ "1": 46000, "10": 1600000, "137": 400000, "288": 20000, "42161": 600000 }'
```