### PR TITLE
improve: Only use HEAD buffers when proposing a new bundle

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -463,7 +463,8 @@ export class Dataworker {
 
     const widestPossibleExpectedBlockRange = await PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       this.chainIdListForBundleEvaluationBlockNumbers,
-      getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
+      Array(this.chainIdListForBundleEvaluationBlockNumbers.length).fill(0), // Use 0 buffer when validating
+      // past bundles
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber
     );
@@ -947,7 +948,8 @@ export class Dataworker {
 
     const widestPossibleExpectedBlockRange = await PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       this.chainIdListForBundleEvaluationBlockNumbers,
-      getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
+      Array(this.chainIdListForBundleEvaluationBlockNumbers.length).fill(0), // Use 0 buffer when validating
+      // past bundles
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber
     );


### PR DESCRIPTION
We shouldn't have to apply the buffer when evaluating proposed bundles, only when constructing a new one. This is because the proposed ones should already be following HEAD by some time, so there shouldn't be any discrepency in events that SHOULD be in the bundle. This also assumes that the proposed root bundle followed HEAD by some time