### PR TITLE
fix: fix trace-agent issue by renaming package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@uma/financial-templates-lib": "^2.27.4",
     "bluebird": "^3.7.2",
     "hardhat": "^2.9.0",
-    "redis": "^4.1.0",
+    "redis4": "npm:redis@^4.1.0",
     "ts-node": "^10.1.0"
   },
   "files": [

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -15,7 +15,7 @@ import { L1TokenTransferThreshold, Deposit, TokenConfig, GlobalConfigUpdate } fr
 import { lpFeeCalculator } from "@across-protocol/sdk-v2";
 import { BlockFinder, across } from "@uma/sdk";
 import { HubPoolClient } from "./HubPoolClient";
-import { createClient } from "redis";
+import { createClient } from "redis4";
 
 export const GLOBAL_CONFIG_STORE_KEYS = {
   MAX_RELAYER_REPAYMENT_LEAF_SIZE: "MAX_RELAYER_REPAYMENT_LEAF_SIZE",

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -11,7 +11,7 @@ import {
 import { HubPoolClient, MultiCallerClient, AcrossConfigStoreClient, SpokePoolClient, ProfitClient } from "../clients";
 import { CommonConfig } from "./Config";
 import { DataworkerClients } from "../dataworker/DataworkerClientHelper";
-import { createClient } from "redis";
+import { createClient } from "redis4";
 
 export interface Clients {
   hubPoolClient: HubPoolClient;

--- a/yarn.lock
+++ b/yarn.lock
@@ -13135,7 +13135,7 @@ recursive-readdir@^2.2.2:
   dependencies:
     minimatch "3.0.4"
 
-redis@^4.1.0:
+"redis4@npm:redis@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/redis/-/redis-4.1.0.tgz#6e400e8edf219e39281afe95e66a3d5f7dcf7289"
   integrity sha512-5hvJ8wbzpCCiuN1ges6tx2SAh2XXCY0ayresBmu40/SGusWHFW86TAlIPpbimMX2DFHOX7RN34G2XlPA1Z43zg==


### PR DESCRIPTION
Signed-off-by: Matt Rice <matthewcrice32@gmail.com>

THis error shows up if you install redis alongside @google-cloud/trace-agent.

```
uncaughtException: Cannot read property 'prototype' of undefined
TypeError: Cannot read property 'prototype' of undefined
    at wrapCreateStream (/across-relayer/node_modules/@google-cloud/trace-agent/build/src/plugins/plugin-redis.js:145:36)
    at Object.patch (/across-relayer/node_modules/@google-cloud/trace-agent/build/src/plugins/plugin-redis.js:167:13)
    at /across-relayer/node_modules/@google-cloud/trace-agent/build/src/trace-plugin-loader.js:93:23
    at Array.reduce (<anonymous>)
    at ModulePluginWrapper.applyPlugin (/across-relayer/node_modules/@google-cloud/trace-agent/build/src/trace-plugin-loader.js:87:33)
    at /across-relayer/node_modules/@google-cloud/trace-agent/build/src/trace-plugin-loader.js:278:64
    at Module.Hook._require.Module.require (/across-relayer/node_modules/require-in-the-middle/index.js:154:32)
    at require (internal/modules/cjs/helpers.js:101:18)
    at Object.<anonymous> (/across-relayer/dist/src/common/ClientHelper.js:6:17)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Module.require (internal/modules/cjs/loader.js:974:19)
    at Module.Hook._require.Module.require (/across-relayer/node_modules/require-in-the-middle/index.js:80:39)
    at require (internal/modules/cjs/helpers.js:101:18)
```

