### PR TITLE
refactor: finalizer

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -29,7 +29,7 @@ export async function finalize(
     const tokensBridged = client.getTokensBridged();
 
     if (chainId === 42161) {
-      const finalizableMessages = await getFinalizableMessages(logger, tokensBridged, hubSigner, hubPoolClient);
+      const finalizableMessages = await getFinalizableMessages(logger, tokensBridged, hubSigner);
       for (const l2Message of finalizableMessages) {
         await finalizeArbitrum(logger, l2Message.message, l2Message.proofInfo, l2Message.info, hubPoolClient);
       }

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -14,7 +14,7 @@ import {
   winston,
 } from "../../utils";
 import { TokensBridged } from "../../interfaces";
-import { HubPoolClient, MultiCallerClient } from "../../clients";
+import { HubPoolClient } from "../../clients";
 
 // Note!!: This client will only work for PoS tokens. Matic also has Plasma tokens which have a different finalization
 // process entirely.


### PR DESCRIPTION
Makes arbitrum finalizer logs consistent with optimism and polygon logs that do not log "there are X messages to finalize"﻿
