### PR TITLE
fix: Construct pool rebalance leaves from partially empty realizedLpFees/runningBalances

### DIFF
--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -268,7 +268,7 @@ export function constructPoolRebalanceLeaves(
           else return toBN(0);
         });
         const leafRunningBalances = l1TokensToIncludeInThisLeaf.map((l1Token, index) => {
-          if (runningBalances[chainId] && runningBalances[chainId][l1Token])
+          if (runningBalances[chainId]?.[l1Token])
             return getRunningBalanceForL1Token(transferThresholds[index], runningBalances[chainId][l1Token]);
           else return toBN(0);
         });

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -259,7 +259,7 @@ export function constructPoolRebalanceLeaves(
         // Build leaves using running balances and realized lp fees data for l1Token + chain, or default to
         // zero if undefined.
         const leafBundleLpFees = l1TokensToIncludeInThisLeaf.map((l1Token) => {
-          if (realizedLpFees[chainId] && realizedLpFees[chainId][l1Token]) return realizedLpFees[chainId][l1Token];
+          if (realizedLpFees[chainId]?.[l1Token]) return realizedLpFees[chainId][l1Token];
           else return toBN(0);
         });
         const leafNetSendAmounts = l1TokensToIncludeInThisLeaf.map((l1Token, index) => {

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -256,21 +256,28 @@ export function constructPoolRebalanceLeaves(
             configStoreClient.getTokenTransferThresholdForBlock(l1Token, latestMainnetBlock)
         );
 
+        // Build leaves using running balances and realized lp fees data for l1Token + chain, or default to
+        // zero if undefined.
+        const leafBundleLpFees = l1TokensToIncludeInThisLeaf.map((l1Token) => {
+          if (realizedLpFees[chainId] && realizedLpFees[chainId][l1Token]) return realizedLpFees[chainId][l1Token];
+          else return toBN(0);
+        });
+        const leafNetSendAmounts = l1TokensToIncludeInThisLeaf.map((l1Token, index) => {
+          if (runningBalances[chainId] && runningBalances[chainId][l1Token])
+            return getNetSendAmountForL1Token(transferThresholds[index], runningBalances[chainId][l1Token]);
+          else return toBN(0);
+        });
+        const leafRunningBalances = l1TokensToIncludeInThisLeaf.map((l1Token, index) => {
+          if (runningBalances[chainId] && runningBalances[chainId][l1Token])
+            return getRunningBalanceForL1Token(transferThresholds[index], runningBalances[chainId][l1Token]);
+          else return toBN(0);
+        });
+
         leaves.push({
           chainId: Number(chainId),
-          bundleLpFees: realizedLpFees[chainId]
-            ? l1TokensToIncludeInThisLeaf.map((l1Token) => realizedLpFees[chainId][l1Token])
-            : Array(l1TokensToIncludeInThisLeaf.length).fill(toBN(0)),
-          netSendAmounts: runningBalances[chainId]
-            ? l1TokensToIncludeInThisLeaf.map((l1Token, index) =>
-                getNetSendAmountForL1Token(transferThresholds[index], runningBalances[chainId][l1Token])
-              )
-            : Array(l1TokensToIncludeInThisLeaf.length).fill(toBN(0)),
-          runningBalances: runningBalances[chainId]
-            ? l1TokensToIncludeInThisLeaf.map((l1Token, index) =>
-                getRunningBalanceForL1Token(transferThresholds[index], runningBalances[chainId][l1Token])
-              )
-            : Array(l1TokensToIncludeInThisLeaf.length).fill(toBN(0)),
+          bundleLpFees: leafBundleLpFees,
+          netSendAmounts: leafNetSendAmounts,
+          runningBalances: leafRunningBalances,
           groupIndex: groupIndexForChainId++,
           leafId: leaves.length,
           l1Tokens: l1TokensToIncludeInThisLeaf,


### PR DESCRIPTION
`constructPoolRebalanceLeaves()` does not currently handle case where 1 L1 token has realizedLpFees but the others are empty.