### PR TITLE
feat: Report categorized non-v2 transfers from relayers

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -68,7 +68,13 @@ export class SpokePoolClient {
   }
 
   getFillsWithBlockForOriginChain(originChainId: number): FillWithBlock[] {
-    return this.fillsWithBlockNumbers.filter((fill: Fill) => fill.originChainId === originChainId);
+    return this.fillsWithBlockNumbers.filter((fill: FillWithBlock) => fill.originChainId === originChainId);
+  }
+
+  getFillsWithBlockForDestinationChainAndRelayer(chainId: number, relayer: string): FillWithBlock[] {
+    return this.fillsWithBlockNumbers.filter(
+      (fill: FillWithBlock) => fill.relayer === relayer && fill.destinationChainId === chainId
+    );
   }
 
   getFillsWithBlockInRange(startingBlock: number, endingBlock: number): FillWithBlock[] {

--- a/src/clients/TokenTransferClient.ts
+++ b/src/clients/TokenTransferClient.ts
@@ -1,0 +1,95 @@
+import {
+  EventSearchConfig,
+  winston,
+  assign,
+  ERC20,
+  Event,
+  Contract,
+  paginatedEventQuery,
+  spreadEventWithBlockNumber,
+} from "../utils";
+import { TokenTransfer, TransfersByChain } from "../interfaces";
+import { Provider } from "@ethersproject/abstract-provider";
+
+export class TokenTransferClient {
+  private tokenTransfersByAddress: { [address: string]: TransfersByChain } = {};
+
+  constructor(
+    readonly logger: winston.Logger,
+    // We can accept spokePoolClients here instead, but just accepting providers makes it very clear that we dont
+    // rely on SpokePoolClient and its cached state.
+    readonly providerByChainIds: { [chainId: number]: Provider },
+    readonly monitoredAddresses: string[]
+  ) {}
+
+  getTokenTransfers(address: string) {
+    return this.tokenTransfersByAddress[address];
+  }
+
+  async update(
+    searchConfigByChainIds: { [chainId: number]: EventSearchConfig },
+    tokenByChainIds: { [chainId: number]: string[] }
+  ) {
+    this.logger.debug({ at: "TokenTransferClient", message: "Updating TokenTransferClient client" });
+    const tokenContractsByChainId = Object.fromEntries(
+      Object.entries(tokenByChainIds).map(([chainId, tokens]) => [
+        chainId,
+        tokens.map((token: string) => new Contract(token, ERC20.abi, this.providerByChainIds[chainId])),
+      ])
+    );
+
+    const chainIds = Object.keys(this.providerByChainIds).map(Number);
+    for (const chainId of chainIds) {
+      const tokenContracts = tokenContractsByChainId[chainId];
+      for (const monitoredAddress of this.monitoredAddresses) {
+        const transferEventsList = await Promise.all(
+          tokenContracts.map((tokenContract) =>
+            this.querySendAndReceiveEvents(tokenContract, monitoredAddress, searchConfigByChainIds[chainId])
+          )
+        );
+        const transferEventsPerToken: { [tokenAddress: string]: Event[][] } = Object.fromEntries(
+          transferEventsList.map((transferEvents, i) => [tokenContracts[i].address, transferEvents])
+        );
+
+        // Create an entry in the cache if not initialized.
+        const tokenTransfers = this.tokenTransfersByAddress[monitoredAddress];
+        if (tokenTransfers === undefined || tokenTransfers[chainId] === undefined) {
+          assign(this.tokenTransfersByAddress, [monitoredAddress, chainId], {});
+        }
+
+        // Update outgoing and incoming transfers for current relayer in the cache.
+        const transferCache = this.tokenTransfersByAddress[monitoredAddress][chainId];
+        for (const [tokenAddress, events] of Object.entries(transferEventsPerToken)) {
+          if (transferCache[tokenAddress] === undefined) {
+            transferCache[tokenAddress] = {
+              incoming: [],
+              outgoing: [],
+            };
+          }
+
+          for (const event of events[0]) {
+            const outgoingTransfer = spreadEventWithBlockNumber(event) as TokenTransfer;
+            transferCache[tokenAddress].outgoing.push(outgoingTransfer);
+          }
+
+          for (const event of events[1]) {
+            const incomingTransfer = spreadEventWithBlockNumber(event) as TokenTransfer;
+            transferCache[tokenAddress].incoming.push(incomingTransfer);
+          }
+        }
+      }
+    }
+
+    this.logger.debug({ at: "TokenTransferClient", message: "TokenTransfer client updated!" });
+  }
+
+  // Returns outgoing and incoming transfers for the specified tokenContract and address.
+  querySendAndReceiveEvents(tokenContract: Contract, address: string, config: EventSearchConfig): Promise<Event[][]> {
+    const eventFilters = [[address], [undefined, address]];
+    return Promise.all(
+      eventFilters.map((eventFilter) =>
+        paginatedEventQuery(tokenContract, tokenContract.filters.Transfer(...eventFilter), config)
+      )
+    );
+  }
+}

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -6,4 +6,5 @@ export * from "./ConfigStoreClient";
 export * from "./MultiCallerClient";
 export * from "./ProfitClient";
 export * from "./TokenClient";
+export * from "./TokenTransferClient";
 export * from "./InventoryClient";

--- a/src/interfaces/Token.ts
+++ b/src/interfaces/Token.ts
@@ -1,0 +1,19 @@
+import { SortableEvent } from "./Common";
+import { BigNumber } from "../utils";
+
+export interface TokenTransfer extends SortableEvent {
+  value: BigNumber;
+  from: string;
+  to: string;
+}
+
+export interface TransfersByTokens {
+  [token: string]: {
+    incoming: TokenTransfer[];
+    outgoing: TokenTransfer[];
+  };
+}
+
+export interface TransfersByChain {
+  [chainId: number]: TransfersByTokens;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -4,3 +4,4 @@ export * from "./ConfigStore";
 export * from "./HubPool";
 export * from "./Report";
 export * from "./SpokePool";
+export * from "./Token";

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -20,6 +20,7 @@ export class MonitorConfig extends CommonConfig {
   readonly monitoredRelayers: string[];
   readonly whitelistedDataworkers: string[];
   readonly whitelistedRelayers: string[];
+  readonly knownV1Addresses: string[];
   readonly botModes: BotModes;
 
   constructor(env: ProcessEnv) {
@@ -36,6 +37,7 @@ export class MonitorConfig extends CommonConfig {
       UTILIZATION_THRESHOLD,
       WHITELISTED_DATA_WORKERS,
       WHITELISTED_RELAYERS,
+      KNOWN_V1_ADDRESSES,
     } = env;
 
     this.botModes = {
@@ -51,6 +53,7 @@ export class MonitorConfig extends CommonConfig {
 
     // Used to monitor balances, activities, etc. from the specified relayers.
     this.monitoredRelayers = parseAddressesOptional(MONITORED_RELAYERS);
+    this.knownV1Addresses = parseAddressesOptional(KNOWN_V1_ADDRESSES);
 
     // Default pool utilization threshold at 90%.
     this.utilizationThreshold = UTILIZATION_THRESHOLD ? Number(UTILIZATION_THRESHOLD) : 90;

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -87,3 +87,7 @@ export function sortEventsDescending<T extends SortableEvent>(events: T[]): T[] 
     return ey.logIndex - ex.logIndex;
   });
 }
+
+export function getTransactionHashes(events: SortableEvent[]) {
+  return [...new Set(events.map((e) => e.transactionHash))];
+}

--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -22,6 +22,10 @@ import { createEtherscanLinkMarkdown } from "@uma/common";
 export const etherscanLink = (txHashOrAddress: string, chainId: number | string) =>
   createEtherscanLinkMarkdown(txHashOrAddress, Number(chainId));
 
+export const etherscanLinks = (txHashesOrAddresses: string[], chainId: number | string) => {
+  return txHashesOrAddresses.map((hash) => `${etherscanLink(hash, chainId)}\n`).join("");
+};
+
 export const utf8ToHex = (input: string) => ethers.utils.formatBytes32String(input);
 
 export const hexToUtf8 = (input: string) => ethers.utils.toUtf8String(input);


### PR DESCRIPTION
Currently the monitoring report only takes into account Across V2 relays/refunds. This leads to unexplained changes in relayer balances from to time due to:

1. Interactions with Across V1 (relays, refunds)
2. Automated and manual inventory management.
3. V2 bond payments/refunds.

This PR adds logic to report the above interactions.

Notes: This can create noise when the monitor bot runs in non-looping mode (POLLING_DELAY = 0) because if there are mismatching v1 relays/refunds for example in the 30m window (current monitoring bot interval), the net transfer balance within that window would not be 0 (we lost some v1 relays or refunds from before the window). This problem should go away once we switch to looping mode as the TokenTransferClient's transfer cache would then contain all transfers since the start of the bot run.