### PR TITLE
fix: Fix pending refunds calculation in relayer report

### DIFF
--- a/src/interfaces/HubPool.ts
+++ b/src/interfaces/HubPool.ts
@@ -31,16 +31,6 @@ export interface ProposedRootBundle extends SortableEvent {
 }
 
 export interface CancelledRootBundle extends SortableEvent {
-  chainId: number;
-  bundleLpFees: BigNumber[];
-  netSendAmounts: BigNumber[];
-  runningBalances: BigNumber[];
-  leafId: number;
-  l1Tokens: string[];
-  proof: string[];
-}
-
-export interface CancelledRootBundle extends SortableEvent {
   disputer: string;
   requestTime: number;
 }


### PR DESCRIPTION
Current pending refunds calculation only checks if the bundle has been executed in HubPool (rebalance tree has been executed). This doesn't mean the actual refunds (leaves of relay refund tree) have been executed on destination chains.