### PR TITLE
improve: Only set allowances for tokens with non zero balances

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -105,12 +105,15 @@ export class TokenClient {
     const tokensToApprove: { chainId: string; token: string }[] = [];
     Object.keys(this.tokenData).forEach((chainId) => {
       Object.keys(this.tokenData[chainId]).forEach((token) => {
-        if (this.tokenData[chainId][token].allowance.lt(toBN(MAX_SAFE_ALLOWANCE)))
+        if (
+          this.tokenData[chainId][token].balance.gt(toBN(0)) &&
+          this.tokenData[chainId][token].allowance.lt(toBN(MAX_SAFE_ALLOWANCE))
+        )
           tokensToApprove.push({ chainId, token });
       });
     });
     if (tokensToApprove.length === 0) {
-      this.logger.debug({ at: "TokenBalanceClient", message: `All token approvals set` });
+      this.logger.debug({ at: "TokenBalanceClient", message: `All token approvals set for non-zero balances` });
       return;
     }
 

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -22,7 +22,6 @@ export class RelayerConfig extends CommonConfig {
         ? toBNWei(this.inventoryConfig.wrapEtherThreshold)
         : toBNWei(1); // default to keeping 2 Eth on the target chains and wrapping the rest to WETH.
 
-      this;
       Object.keys(this.inventoryConfig.tokenConfig).forEach((l1Token) => {
         Object.keys(this.inventoryConfig.tokenConfig[l1Token]).forEach((chainId) => {
           const { targetPct, thresholdPct } = this.inventoryConfig.tokenConfig[l1Token][chainId];

--- a/test/TokenClient.Approval.ts
+++ b/test/TokenClient.Approval.ts
@@ -52,10 +52,10 @@ describe("TokenClient: Origin token approval", async function () {
     expect(lastSpyLogIncludes(spy, "All token approvals set for non-zero balances")).to.be.true;
 
     // Mint token client account some tokens and check that approvals are sent
-    await erc20_1.connect(owner).mint(owner.address, "1")
-    await erc20_2.connect(owner).mint(owner.address, "1")
-    await weth_1.connect(owner).deposit({ value: "1" })
-    await weth_2.connect(owner).deposit({ value: "1" })
+    await erc20_1.connect(owner).mint(owner.address, "1");
+    await erc20_2.connect(owner).mint(owner.address, "1");
+    await weth_1.connect(owner).deposit({ value: "1" });
+    await weth_2.connect(owner).deposit({ value: "1" });
     await updateAllClients();
     await tokenClient.setOriginTokenApprovals();
 

--- a/test/TokenClient.Approval.ts
+++ b/test/TokenClient.Approval.ts
@@ -47,7 +47,18 @@ describe("TokenClient: Origin token approval", async function () {
   it("Executes expected L2 token approvals and produces logs", async function () {
     await updateAllClients();
 
+    // Token client will not set allowances for tokens with zero balance.
     await tokenClient.setOriginTokenApprovals();
+    expect(lastSpyLogIncludes(spy, "All token approvals set for non-zero balances")).to.be.true;
+
+    // Mint token client account some tokens and check that approvals are sent
+    await erc20_1.connect(owner).mint(owner.address, "1")
+    await erc20_2.connect(owner).mint(owner.address, "1")
+    await weth_1.connect(owner).deposit({ value: "1" })
+    await weth_2.connect(owner).deposit({ value: "1" })
+    await updateAllClients();
+    await tokenClient.setOriginTokenApprovals();
+
     // logs should contain expected text and the addresses of all 4 tokens approved.
     expect(lastSpyLogIncludes(spy, "Approval transactions")).to.be.true;
     expect(lastSpyLogIncludes(spy, erc20_1.address)).to.be.true;


### PR DESCRIPTION
Current case will have bot runner send out a token allowance for each token for each chain, suboptimal