### PR TITLE
feat: Add startingRunningBalance to TokenConfig

### DIFF
--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -4,7 +4,11 @@ import { RelayerRefundLeafWithGroup, RunningBalances, UnfilledDeposit } from "..
 import { buildPoolRebalanceLeafTree, buildRelayerRefundTree, buildSlowRelayTree } from "../utils";
 import { getDepositPath, getFillsInRange, groupObjectCountsByProp, groupObjectCountsByTwoProps, toBN } from "../utils";
 import { DataworkerClients } from "./DataworkerClientHelper";
-import { addSlowFillsToRunningBalances, initializeRunningBalancesFromRelayerRepayments } from "./PoolRebalanceUtils";
+import {
+  addSlowFillsToRunningBalances,
+  addStartingRunningBalance,
+  initializeRunningBalancesFromRelayerRepayments,
+} from "./PoolRebalanceUtils";
 import { addLastRunningBalance, constructPoolRebalanceLeaves } from "./PoolRebalanceUtils";
 import { updateRunningBalanceForDeposit } from "./PoolRebalanceUtils";
 import { subtractExcessFromPreviousSlowFillsFromRunningBalances } from "./PoolRebalanceUtils";
@@ -269,6 +273,12 @@ export function _buildPoolRebalanceRoot(
   // Add to the running balance value from the last valid root bundle proposal for {chainId, l1Token}
   // combination if found.
   addLastRunningBalance(endBlockForMainnet, runningBalances, clients.hubPoolClient);
+
+  // Add a configurable starting running balance for each L1 token. The user can set this value to have a
+  // bias towards keeping more funds on the L2s. Negative starting values are discouraged since often times
+  // there won't be enough funds on the spoke pools to return to mainnet until more deposits come in,
+  // resulting in temporarily frozen funds.
+  addStartingRunningBalance(endBlockForMainnet, runningBalances, clients.configStoreClient);
 
   const leaves: PoolRebalanceLeaf[] = constructPoolRebalanceLeaves(
     endBlockForMainnet,

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -6,10 +6,10 @@ import { getDepositPath, getFillsInRange, groupObjectCountsByProp, groupObjectCo
 import { DataworkerClients } from "./DataworkerClientHelper";
 import {
   addSlowFillsToRunningBalances,
-  addStartingRunningBalance,
+  addToRunningBalance,
   initializeRunningBalancesFromRelayerRepayments,
 } from "./PoolRebalanceUtils";
-import { addLastRunningBalance, constructPoolRebalanceLeaves } from "./PoolRebalanceUtils";
+import { constructPoolRebalanceLeaves } from "./PoolRebalanceUtils";
 import { updateRunningBalanceForDeposit } from "./PoolRebalanceUtils";
 import { subtractExcessFromPreviousSlowFillsFromRunningBalances } from "./PoolRebalanceUtils";
 import { getAmountToReturnForRelayerRefundLeaf } from "./RelayerRefundUtils";
@@ -271,14 +271,8 @@ export function _buildPoolRebalanceRoot(
   });
 
   // Add to the running balance value from the last valid root bundle proposal for {chainId, l1Token}
-  // combination if found.
-  addLastRunningBalance(endBlockForMainnet, runningBalances, clients.hubPoolClient);
-
-  // Add a configurable starting running balance for each L1 token. The user can set this value to have a
-  // bias towards keeping more funds on the L2s. Negative starting values are discouraged since often times
-  // there won't be enough funds on the spoke pools to return to mainnet until more deposits come in,
-  // resulting in temporarily frozen funds.
-  addStartingRunningBalance(endBlockForMainnet, runningBalances, clients.configStoreClient);
+  // combination if found. This will add a configurable bias value if there is no prior running balance.
+  addToRunningBalance(endBlockForMainnet, runningBalances, clients.hubPoolClient, clients.configStoreClient);
 
   const leaves: PoolRebalanceLeaf[] = constructPoolRebalanceLeaves(
     endBlockForMainnet,

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -66,6 +66,24 @@ export function updateRunningBalanceForDeposit(
   updateRunningBalance(runningBalances, deposit.originChainId, l1TokenCounterpart, updateAmount);
 }
 
+export function addStartingRunningBalance(
+  latestMainnetBlock: number,
+  runningBalances: interfaces.RunningBalances,
+  configClient: AcrossConfigStoreClient
+) {
+  Object.keys(runningBalances).forEach((repaymentChainId) => {
+    Object.keys(runningBalances[repaymentChainId]).forEach((l1TokenAddress) => {
+      const startingRunningBalance = configClient.getStartingRunningBalanceForBlock(
+        Number(repaymentChainId),
+        l1TokenAddress,
+        latestMainnetBlock
+      );
+      if (!toBN(startingRunningBalance).eq(toBN(0)))
+        updateRunningBalance(runningBalances, Number(repaymentChainId), l1TokenAddress, startingRunningBalance);
+    });
+  });
+}
+
 export function addLastRunningBalance(
   latestMainnetBlock: number,
   runningBalances: interfaces.RunningBalances,

--- a/src/interfaces/ConfigStore.ts
+++ b/src/interfaces/ConfigStore.ts
@@ -5,6 +5,11 @@ export interface L1TokenTransferThreshold extends SortableEvent {
   l1Token: string;
 }
 
+export interface L1TokenStartingRunningBalance extends SortableEvent {
+  startingRunningBalance: { [chainId: number]: BigNumber };
+  l1Token: string;
+}
+
 export interface TokenConfig extends SortableEvent {
   key: string;
   value: string;

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -14,6 +14,8 @@ export const MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF = 3;
 // balances to transfer tokens to the spoke pool.
 export const DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD = toWei(1000);
 
+export const DEFAULT_STARTING_RUNNING_BALANCE = toWei(5000);
+
 export const BUNDLE_END_BLOCK_BUFFER = 5;
 
 // DAI's Rate model.


### PR DESCRIPTION
Allows admin to “bias” the running balances on a chain for a particular L1 token. This would allow admin to start all running balances for a particular SpokePool for a particular L1 token at a certain value. For example, we want WETH on Optimism to start with 100 WETH running balance. This would mean that if 50 WETH of deposits occurred during a root bundle period, then the HubPool would send 50 WETH (100 - 50 = +50) to the OptimismSpokePool. Currently, the system would return 50 WETH (0 - 50 = -50) WETH from the OptimismSpokePool to the HubPool.

The goal of this feature is to reduce gas costs for the dataworker (the one executing pool rebalance leaves) which would have to send fewer tokens from L1 --> L2 to pay refunds
