### PR TITLE
fix: Always populate spokePoolBlocks in monitor config

### DIFF
--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -65,17 +65,16 @@ export class MonitorConfig extends CommonConfig {
     this.hubPoolStartingBlock = STARTING_BLOCK_NUMBER ? Number(STARTING_BLOCK_NUMBER) : undefined;
     this.hubPoolEndingBlock = ENDING_BLOCK_NUMBER ? Number(ENDING_BLOCK_NUMBER) : undefined;
 
-    if (UNKNOWN_RELAYER_CALLERS_ENABLED)
-      this.spokePoolChains.forEach((chainId) => {
-        this.spokePoolsBlocks[chainId] = {
-          startingBlock: process.env[`STARTING_BLOCK_NUMBER_${chainId}`]
-            ? Number(process.env[`STARTING_BLOCK_NUMBER_${chainId}`])
-            : undefined,
-          endingBlock: process.env[`ENDING_BLOCK_NUMBER_${chainId}`]
-            ? Number(process.env[`ENDING_BLOCK_NUMBER_${chainId}`])
-            : undefined,
-        };
-      });
+    this.spokePoolChains.forEach((chainId) => {
+      this.spokePoolsBlocks[chainId] = {
+        startingBlock: process.env[`STARTING_BLOCK_NUMBER_${chainId}`]
+          ? Number(process.env[`STARTING_BLOCK_NUMBER_${chainId}`])
+          : undefined,
+        endingBlock: process.env[`ENDING_BLOCK_NUMBER_${chainId}`]
+          ? Number(process.env[`ENDING_BLOCK_NUMBER_${chainId}`])
+          : undefined,
+      };
+    });
   }
 }
 


### PR DESCRIPTION
The relayer balance report depends on spokePoolBlocks but it's run in a separate bot that does not have unknown relayer alert enabled.