### PR TITLE
feat: dataworker should send ETH to hub pool when executing arb transactions

### DIFF
--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -1,4 +1,4 @@
-import { BigNumber, ERC20, ethers } from "../utils";
+import { BigNumber, ERC20, ethers, ZERO_ADDRESS } from "../utils";
 
 // This type is used to map used and current balances of different users.
 interface BalanceMap {
@@ -49,7 +49,10 @@ export class BalanceAllocator {
 
   async getBalance(chainId: number, token: string, holder: string) {
     if (!this.balances?.[chainId]?.[token]?.[holder]) {
-      const balance = await ERC20.connect(token, this.providers[chainId]).balanceOf(holder);
+      const balance =
+        token === ZERO_ADDRESS
+          ? await this.providers[chainId].getBalance(holder)
+          : await ERC20.connect(token, this.providers[chainId]).balanceOf(holder);
 
       // Note: cannot use assign because it breaks the BigNumber object.
       if (!this.balances[chainId]) this.balances[chainId] = {};

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -19,7 +19,7 @@ export interface Clients {
   configStoreClient: AcrossConfigStoreClient;
   multiCallerClient: MultiCallerClient;
   profitClient: ProfitClient;
-  hubSigner?: Wallet;
+  hubSigner: Wallet;
 }
 
 export function getSpokePoolSigners(baseSigner: Wallet, config: CommonConfig): { [chainId: number]: Wallet } {

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -19,7 +19,7 @@ export interface Clients {
   configStoreClient: AcrossConfigStoreClient;
   multiCallerClient: MultiCallerClient;
   profitClient: ProfitClient;
-  hubSigner: Wallet;
+  hubSigner?: Wallet;
 }
 
 export function getSpokePoolSigners(baseSigner: Wallet, config: CommonConfig): { [chainId: number]: Wallet } {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1,5 +1,5 @@
 import { winston, EMPTY_MERKLE_ROOT, sortEventsDescending, BigNumber, getRefund, MerkleTree, toBN } from "../utils";
-import { toBNWei, getFillsInRange } from "../utils";
+import { toBNWei, getFillsInRange, ZERO_ADDRESS } from "../utils";
 import { DepositWithBlock, FillsToRefund, FillWithBlock, UnfilledDeposit } from "../interfaces";
 import {
   PendingRootBundle,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1,5 +1,5 @@
 import { winston, EMPTY_MERKLE_ROOT, sortEventsDescending, BigNumber, getRefund, MerkleTree, toBN } from "../utils";
-import { toBNWei } from "../utils";
+import { toBNWei, getFillsInRange } from "../utils";
 import { DepositWithBlock, FillsToRefund, FillWithBlock, UnfilledDeposit } from "../interfaces";
 import {
   PendingRootBundle,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -860,7 +860,7 @@ export class Dataworker {
             requests.push({
               token: ZERO_ADDRESS,
               amount: this._getRequiredEthForArbitrumPoolRebalanceLeaf(leaf),
-              holder: await this.clients.hubSigner.getAddress(),
+              holder: await this.clients.spokePoolSigners[hubPoolChainId].getAddress(),
               chainId: hubPoolChainId,
             });
           }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1,4 +1,14 @@
-import { winston, EMPTY_MERKLE_ROOT, sortEventsDescending, BigNumber, getRefund, MerkleTree } from "../utils";
+import {
+  winston,
+  EMPTY_MERKLE_ROOT,
+  sortEventsDescending,
+  BigNumber,
+  getRefund,
+  MerkleTree,
+  ZERO_ADDRESS,
+  toWei,
+  toBNWei,
+, getFillsInRange } from "../utils";
 import { DepositWithBlock, FillsToRefund, FillWithBlock, UnfilledDeposit } from "../interfaces";
 import {
   PendingRootBundle,
@@ -12,7 +22,6 @@ import {
 import { DataworkerClients, spokePoolClientsToProviders } from "./DataworkerClientHelper";
 import { SpokePoolClient } from "../clients";
 import * as PoolRebalanceUtils from "./PoolRebalanceUtils";
-import { getFillsInRange } from "../utils";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 import {
   getEndBlockBuffers,
@@ -856,6 +865,15 @@ export class Dataworker {
             chainId: hubPoolChainId,
           }));
 
+          if (leaf.chainId === 42161) {
+            requests.push({
+              token: ZERO_ADDRESS,
+              amount: this._getRequiredEthForArbitrumPoolRebalanceLeaf(leaf),
+              holder: await this.clients.hubSigner.getAddress(),
+              chainId: hubPoolChainId,
+            });
+          }
+
           const success = await balanceAllocator.requestBalanceAllocations(requests);
 
           if (!success) {
@@ -882,7 +900,20 @@ export class Dataworker {
       const mrkdwn = `Root hash: ${expectedTrees.poolRebalanceTree.tree.getHexRoot()}\nLeaf: ${leaf.leafId}\nChain: ${
         leaf.chainId
       }`;
-      if (submitExecution)
+      if (submitExecution) {
+        if (leaf.chainId === 42161) {
+          const amount = this._getRequiredEthForArbitrumPoolRebalanceLeaf(leaf);
+          if (amount.gt(0))
+            this.clients.multiCallerClient.enqueueTransaction({
+              contract: this.clients.hubPoolClient.hubPool,
+              chainId: hubPoolChainId,
+              method: "loadEthForL2Calls",
+              args: [],
+              message: "Executed PoolRebalanceLeaf 🌿!",
+              mrkdwn,
+              value: amount,
+            });
+        }
         this.clients.multiCallerClient.enqueueTransaction({
           contract: this.clients.hubPoolClient.hubPool,
           chainId: hubPoolChainId,
@@ -900,7 +931,7 @@ export class Dataworker {
           message: "Executed PoolRebalanceLeaf 🌿!",
           mrkdwn,
         });
-      else this.logger.debug({ at: "Dataworker#executePoolRebalanceLeaves", message: mrkdwn });
+      } else this.logger.debug({ at: "Dataworker#executePoolRebalanceLeaves", message: mrkdwn });
     });
   }
 
@@ -1167,5 +1198,20 @@ export class Dataworker {
     }
 
     return _.cloneDeep(this.rootCache[key]);
+  }
+
+  _getRequiredEthForArbitrumPoolRebalanceLeaf(leaf: PoolRebalanceLeaf) {
+    // For arbitrum, the bot needs enough ETH to pay for each L1 -> L2 message.
+    // The following executions trigger an L1 -> L2 message:
+    // 1. The first arbitrum leaf for a particular set of roots. This means the roots must be sent and is
+    //    signified by groupIndex === 0.
+    // 2. Any netSendAmount > 0 triggers an L1 -> L2 token send, which costs 0.02 ETH.
+    let requiredAmount = leaf.netSendAmounts.reduce(
+      (acc, curr) => (curr.gt(0) ? acc.add(toBNWei("0.02")) : acc),
+      BigNumber.from(0)
+    );
+
+    if (leaf.groupIndex === 0) requiredAmount = requiredAmount.add(toBNWei("0.02"));
+    return requiredAmount;
   }
 }

--- a/src/utils/ExecutionUtils.ts
+++ b/src/utils/ExecutionUtils.ts
@@ -30,7 +30,7 @@ export function startupLogLevel(config: { pollingDelay: number }) {
 }
 
 export const rejectAfterDelay = (seconds: number, message: string = "") =>
-  new Promise((_, reject) => {
+  new Promise<never>((_, reject) => {
     setTimeout(reject, seconds * 1000, {
       status: "timeout",
       message: `Execution took longer than ${seconds}s. ${message}`,

--- a/src/utils/SignerUtils.ts
+++ b/src/utils/SignerUtils.ts
@@ -3,9 +3,9 @@ const args = require("minimist")(process.argv.slice(2));
 
 export async function getSigner(): Promise<Wallet> {
   if (!Object.keys(args).includes("wallet")) throw new Error("Must define mnemonic, privatekey or gckms for wallet");
-  if (args.wallet == "mnemonic") return getMnemonicSigner();
-  if (args.wallet == "privateKey") return getPrivateKeySigner();
-  if (args.wallet == "gckms") return await getGckmsSigner();
+  if (args.wallet === "mnemonic") return getMnemonicSigner();
+  if (args.wallet === "privateKey") return getPrivateKeySigner();
+  if (args.wallet === "gckms") return await getGckmsSigner();
 }
 
 function getPrivateKeySigner() {

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -1,6 +1,6 @@
 import { AugmentedTransaction } from "../clients";
 import { winston, Contract, getContractInfoFromAddress, fetch, ethers } from "../utils";
-import { toBNWei, BigNumber, toBN, toGWei } from "../utils";
+import { toBNWei, BigNumber, toBN, toGWei, TransactionResponse } from "../utils";
 
 // Note that this function will throw if the call to the contract on method for given args reverts. Implementers
 // of this method should be considerate of this and catch the response to deal with the error accordingly.
@@ -11,7 +11,7 @@ export async function runTransaction(
   args: any,
   value: BigNumber = toBN(0),
   gasLimit: BigNumber | null = null
-): Promise<any> {
+): Promise<TransactionResponse> {
   try {
     const gas = await getGasPrice(contract.provider);
     logger.debug({ at: "TxUtil", message: "Send tx", target: getTarget(contract.address), method, args, value, gas });
@@ -49,7 +49,8 @@ export async function willSucceed(
   transaction: AugmentedTransaction
 ): Promise<{ transaction: AugmentedTransaction; succeed: boolean; reason: string }> {
   try {
-    await transaction.contract.callStatic[transaction.method](...transaction.args);
+    const args = transaction.value ? [...transaction.args, { value: transaction.value }] : transaction.args;
+    await transaction.contract.callStatic[transaction.method](...args);
     return { transaction, succeed: true, reason: null };
   } catch (error) {
     console.error(error);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,7 +8,7 @@ export { delay, Logger } from "@uma/financial-templates-lib";
 export { BigNumber, Signer, Contract, ContractFactory, Transaction } from "ethers";
 export { utils, EventFilter, BaseContract, Event, Wallet } from "ethers";
 export { ethers, providers } from "ethers";
-export type { Block } from "@ethersproject/abstract-provider";
+export type { Block, TransactionResponse, TransactionReceipt } from "@ethersproject/abstract-provider";
 export { config } from "dotenv";
 export { Promise } from "bluebird";
 

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -1,7 +1,7 @@
 import { buildFillForRepaymentChain } from "./utils";
 import { SignerWithAddress, expect, ethers, Contract, buildDeposit } from "./utils";
 import { HubPoolClient, AcrossConfigStoreClient, MultiCallerClient, SpokePoolClient } from "../src/clients";
-import { amountToDeposit, destinationChainId } from "./constants";
+import { amountToDeposit } from "./constants";
 import { MAX_REFUNDS_PER_RELAYER_REFUND_LEAF, MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF } from "./constants";
 import { DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD } from "./constants";
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
@@ -42,11 +42,14 @@ describe("Dataworker: Execute pool rebalances", async function () {
       MAX_REFUNDS_PER_RELAYER_REFUND_LEAF,
       MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF,
       DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD,
-      0
+      0,
+      42161
     ));
   });
   it("Simple lifecycle", async function () {
     await updateAllClients();
+
+    const destinationChainId = 42161;
 
     // Send a deposit and a fill so that dataworker builds simple roots.
     const deposit = await buildDeposit(
@@ -79,9 +82,9 @@ describe("Dataworker: Execute pool rebalances", async function () {
     await updateAllClients();
     await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, new BalanceAllocator(providers));
 
-    // Should be 2 transactions: 1 for the to chain and 1 for the from chain. Should NOT be 3 since not enough time has
-    // passed since the last lp fee update.
-    expect(multiCallerClient.transactionCount()).to.equal(2);
+    // Should be 3 transactions: 1 for the to chain, 1 for the from chain, and 1 for the extra ETH sent to cover
+    // arbitrum gas fees.Should NOT be 3 since not enough time has passed since the last lp fee update.
+    expect(multiCallerClient.transactionCount()).to.equal(3);
     await multiCallerClient.executeTransactionQueue();
 
     // TEST 3:
@@ -111,7 +114,8 @@ describe("Dataworker: Execute pool rebalances", async function () {
     await dataworkerInstance.executePoolRebalanceLeaves(spokePoolClients, new BalanceAllocator(providers));
 
     // Should be 1 leaf since this is _only_ a second partial fill repayment and doesn't involve the deposit chain.
-    expect(multiCallerClient.transactionCount()).to.equal(1);
+    // This sends 2 transactions, 1 to add ETH to the hub and a second to send the transaction to mocked arbitrum.
+    expect(multiCallerClient.transactionCount()).to.equal(2);
     await multiCallerClient.executeTransactionQueue();
   });
 });


### PR DESCRIPTION
This adds a way to include a value to a transaction sent to the multicaller client. Any value transactions are sent (in parallel) _before_ the multicall batches are sent.