### PR TITLE
feat: Consider upcoming refunds when calculating relayer fund rebalancing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ typechain
 dump.rdb
 .idea
 
-#Hardhat files
+# Hardhat files
 cache
 artifacts
 dist

--- a/src/clients/InventoryClient/InventoryClient.ts
+++ b/src/clients/InventoryClient/InventoryClient.ts
@@ -64,19 +64,21 @@ export class InventoryClient {
     return distributionPerL1Token;
   }
 
-  // Get the allocation of a given token, considering the shortfall. This number will be negative if there is a shortfall!
-  // A shortfall, by definition, is the amount of tokens that are needed to to fill a given outstanding relay that the
-  // relayer could not fill. For example of the relayer has 10 WETH and needs to fill a relay of size 18 WETH then the
-  // shortfall will be 18. If there are 140 WETH across the whole ecosystem then this method will return (10-18)/140=-0.057
-  // This number is then used to inform how many tokens need to be sent to the chain to: a) cover the shortfall and
-  // b bring the balance back over the defined target.
-  getCurrentAllocationPctConsideringShortfall(l1Token: string, chainId: number): BigNumber {
-    const cumulativeBalance = this.getCumulativeBalance(l1Token); // If there is nothing over all chains, return early.
+  // Get the balance of a given token on a given chain, including shortfalls, any pending cross chain transfers and
+  // upcoming refunds.
+  getCurrentAllocationPct(l1Token: string, chainId: number): BigNumber {
+    const totalRefundsPerChain = this.getBundleRefunds(l1Token);
+    const cumulativeRefunds = Object.values(totalRefundsPerChain).reduce((acc, curr) => acc.add(curr), toBN(0));
+    // If there is nothing over all chains, return early.
+    const cumulativeBalance = this.getCumulativeBalance(l1Token).add(cumulativeRefunds);
     if (cumulativeBalance.eq(0)) return toBN(0);
-    const currentBalanceConsideringTransfers = this.getBalanceOnChainForL1Token(chainId, l1Token);
+
     const shortfall = this.getTokenShortFall(l1Token, chainId) || toBN(0);
-    const numerator = currentBalanceConsideringTransfers.sub(shortfall).mul(scalar);
-    return numerator.div(cumulativeBalance);
+    const currentBalance = this.getBalanceOnChainForL1Token(chainId, l1Token)
+      .add(totalRefundsPerChain[chainId])
+      .sub(shortfall);
+    // Multiply by scalar to avoid rounding errors.
+    return currentBalance.mul(scalar).div(cumulativeBalance);
   }
 
   // Find how short a given chain is for a desired L1Token.
@@ -113,35 +115,8 @@ export class InventoryClient {
       : rebalance;
   }
 
-  // Work out where a relay should be refunded to optimally manage the bots inventory. If the inventory management logic
-  // not enabled then return funds on the chain the deposit was filled on Else, use the following algorithm:
-  // a) Find the chain virtual balance (current balance + pending relays) minus the current shortfall.
-  // b) find the cumulative virtual balance minus the current shortfall.
-  // c) consider the size of a and b post relay (i.e after the relay is paid and all current transfers are settled what
-  // will the balances be on the target chain and the overall cumulative balance).
-  // d) use c to compute what the post relay post current in-flight transactions allocation would be. Compare this
-  // number to the target threshold and:
-  //     If this number of more than the target for the designation chain + rebalance overshoot then refund on L1.
-  //     Else, the post fill amount is within the target, so refund on the destination chain.
-  determineRefundChainId(deposit: Deposit): number {
-    const destinationChainId = deposit.destinationChainId;
-    if (!this.isInventoryManagementEnabled()) return destinationChainId;
-    if (destinationChainId === 1) return 1; // Always refund on L1 if the transfer is to L1.
-    const l1Token = this.hubPoolClient.getL1TokenForDeposit(deposit);
-
-    // If there is no inventory config for this token or this token and destination chain the return the destination chain.
-    if (
-      this.inventoryConfig.tokenConfig[l1Token] == undefined ||
-      this.inventoryConfig.tokenConfig?.[l1Token]?.[destinationChainId] == undefined
-    )
-      return destinationChainId;
-    const chainShortfall = this.getTokenShortFall(l1Token, destinationChainId);
-    const chainVirtualBalance = this.getBalanceOnChainForL1Token(destinationChainId, l1Token);
-    const chainVirtualBalanceWithShortfall = chainVirtualBalance.sub(chainShortfall);
-    let chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfall.sub(deposit.amount);
-    const cumulativeVirtualBalance = this.getCumulativeBalance(l1Token);
-    let cumulativeVirtualBalanceWithShortfall = cumulativeVirtualBalance.sub(chainShortfall);
-
+  // Return the upcoming refunds (in pending and next bundles) on each chain.
+  getBundleRefunds(l1Token: string): { [chainId: string]: BigNumber } {
     // Increase virtual balance by pending relayer refunds from the latest valid bundles.
     // Allow caller to set how many bundles to look back for refunds. The default is set to 2 which means
     // we'll look back only at the two latest valid bundle unless the caller overrides.
@@ -153,7 +128,7 @@ export class InventoryClient {
     const nextBundleRefunds = this.bundleDataClient.getNextBundleRefunds();
     refundsToConsider.push(nextBundleRefunds);
 
-    const totalRefundsPerChain = Object.fromEntries(
+    return Object.fromEntries(
       this.getEnabledChains().map((chainId) => {
         const destinationToken = this.getDestinationTokenForL1Token(l1Token, chainId);
         return [
@@ -162,6 +137,39 @@ export class InventoryClient {
         ];
       })
     );
+  }
+
+  // Work out where a relay should be refunded to optimally manage the bots inventory. If the inventory management logic
+  // not enabled then return funds on the chain the deposit was filled on Else, use the following algorithm:
+  // a) Find the chain virtual balance (current balance + pending relays + pending refunds) minus current shortfall.
+  // b) Find the cumulative virtual balance, including the total refunds on all chains and excluding current shortfall.
+  // c) Consider the size of a and b post relay (i.e after the relay is paid and all current transfers are settled what
+  // will the balances be on the target chain and the overall cumulative balance).
+  // d) Use c to compute what the post relay post current in-flight transactions allocation would be. Compare this
+  // number to the target threshold and:
+  //     If this number of more than the target for the designation chain + rebalance overshoot then refund on L1.
+  //     Else, the post fill amount is within the target, so refund on the destination chain.
+  determineRefundChainId(deposit: Deposit): number {
+    const destinationChainId = deposit.destinationChainId;
+    if (!this.isInventoryManagementEnabled()) return destinationChainId;
+    if (destinationChainId === 1) return 1; // Always refund on L1 if the transfer is to L1.
+    const l1Token = this.hubPoolClient.getL1TokenForDeposit(deposit);
+
+    // If there is no inventory config for this token or this token and destination chain the return the destination chain.
+    if (
+      this.inventoryConfig.tokenConfig[l1Token] === undefined ||
+      this.inventoryConfig.tokenConfig?.[l1Token]?.[destinationChainId] === undefined
+    )
+      return destinationChainId;
+    const chainShortfall = this.getTokenShortFall(l1Token, destinationChainId);
+    const chainVirtualBalance = this.getBalanceOnChainForL1Token(destinationChainId, l1Token);
+    const chainVirtualBalanceWithShortfall = chainVirtualBalance.sub(chainShortfall);
+    let chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfall.sub(deposit.amount);
+    const cumulativeVirtualBalance = this.getCumulativeBalance(l1Token);
+    let cumulativeVirtualBalanceWithShortfall = cumulativeVirtualBalance.sub(chainShortfall);
+
+    // Consider any refunds from executed and to-be executed bundles.
+    const totalRefundsPerChain = this.getBundleRefunds(l1Token);
 
     // Add upcoming refunds going to this destination chain.
     chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfallPostRelay.add(
@@ -200,6 +208,14 @@ export class InventoryClient {
     return refundChainId;
   }
 
+  // A rebalance is triggered in the following 2 cases:
+  // 1. There's a shortfall. We'll send the entire shortfall amount to cover the deposit in timely manner.
+  // This amount likely will get refunded on L1 later on as determineRefundChainId already considers upcoming refunds
+  // and would see this amount as not needed to meet the target allocation.
+  // Example: Current balance on Polygon is 5 WETH, there's an unfilled deposit (shortfall) of 10 WETH. We'll send
+  // 10 WETH from L1 over to cover the shortfall. This 10 WETH later will get refunded on L1 directly.
+  // 2. If there's no shortfall, but allocation is below target. This in theory should almost never happen unless we
+  // manually move funds away from the L2 chain or if we increase the allocation targets.
   async rebalanceInventoryIfNeeded() {
     const rebalancesRequired: { [chainId: number]: { [l1Token: string]: BigNumber } } = {};
     const possibleRebalances: { [chainId: number]: { [l1Token: string]: BigNumber } } = {};
@@ -214,17 +230,27 @@ export class InventoryClient {
       for (const l1Token of Object.keys(tokenDistributionPerL1Token)) {
         const cumulativeBalance = this.getCumulativeBalance(l1Token);
         if (cumulativeBalance.eq(0)) continue;
+
         for (const chainId of this.getEnabledL2Chains()) {
-          const currentAllocPct = this.getCurrentAllocationPctConsideringShortfall(l1Token, chainId);
-          const thresholdPct = toBN(this.inventoryConfig.tokenConfig[l1Token][chainId].thresholdPct);
-          if (currentAllocPct.lt(thresholdPct)) {
-            const deltaPct = toBN(this.inventoryConfig.tokenConfig[l1Token][chainId].targetPct).sub(currentAllocPct);
-            assign(rebalancesRequired, [chainId, l1Token], deltaPct.mul(cumulativeBalance).div(scalar));
+          const currentBalanceConsideringTransfers = this.getBalanceOnChainForL1Token(chainId, l1Token);
+          const shortfall = this.getTokenShortFall(l1Token, chainId) || toBN(0);
+          // Rebalance if there's a shortfall (current balance + transfers cannot cover) or if allocation is below
+          // target.
+          if (currentBalanceConsideringTransfers.lt(shortfall)) {
+            assign(rebalancesRequired, [chainId, l1Token], shortfall);
+          } else {
+            const currentAllocPct = this.getCurrentAllocationPct(l1Token, chainId);
+            const thresholdPct = toBN(this.inventoryConfig.tokenConfig[l1Token][chainId].thresholdPct);
+            if (currentAllocPct.lt(thresholdPct)) {
+              const deltaPct = toBN(this.inventoryConfig.tokenConfig[l1Token][chainId].targetPct).sub(currentAllocPct);
+              // Divide by scalar because allocation percent was multiplied by it to avoid rounding errors.
+              assign(rebalancesRequired, [chainId, l1Token], deltaPct.mul(cumulativeBalance).div(scalar));
+            }
           }
         }
       }
 
-      if (Object.keys(rebalancesRequired).length == 0) {
+      if (Object.keys(rebalancesRequired).length === 0) {
         this.log("No rebalances required");
         return;
       }
@@ -320,12 +346,12 @@ export class InventoryClient {
   constructConsideringRebalanceDebugLog(tokenDistributionPerL1Token: {
     [l1Token: string]: { [chainId: number]: BigNumber };
   }) {
-    let tokenDistribution = {};
+    const tokenDistribution = {};
     Object.keys(tokenDistributionPerL1Token).forEach((l1Token) => {
       const { symbol, decimals } = this.hubPoolClient.getTokenInfoForL1Token(l1Token);
       if (!tokenDistribution[symbol]) tokenDistribution[symbol] = {};
       const formatter = createFormatFunction(2, 4, false, decimals);
-      tokenDistribution[symbol]["cumulativeBalance"] = formatter(this.getCumulativeBalance(l1Token).toString());
+      tokenDistribution[symbol].cumulativeBalance = formatter(this.getCumulativeBalance(l1Token).toString());
       Object.keys(tokenDistributionPerL1Token[l1Token]).forEach((chainId) => {
         if (!tokenDistribution[symbol][chainId]) tokenDistribution[symbol][chainId] = {};
 

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -21,11 +21,6 @@ export class TokenClient {
     return this.tokenData;
   }
 
-  getDataForToken(chainId: number, token: string) {
-    if (!this._hasTokenPairData(chainId, token)) return {};
-    return this.tokenData[chainId][token];
-  }
-
   getBalance(chainId: number | string, token: string) {
     if (!this._hasTokenPairData(chainId, token)) return toBN(0);
     return this.tokenData[chainId][token].balance;

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -11,7 +11,7 @@ import { amountToDeposit, depositRelayerFeePct, l1TokenTransferThreshold, zeroAd
 import { MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF, MAX_REFUNDS_PER_RELAYER_REFUND_LEAF } from "../constants";
 import { HubPoolClient, AcrossConfigStoreClient, GLOBAL_CONFIG_STORE_KEYS } from "../../src/clients";
 import { SpokePoolClient } from "../../src/clients";
-import { deposit, Contract, SignerWithAddress, fillRelay, BigNumber } from "./index";
+import { deposit, Contract, SignerWithAddress, fillRelay, BigNumber, toWei } from "./index";
 import { Deposit, Fill, RunningBalances } from "../../src/interfaces";
 import { buildRelayerRefundTree, toBN, toBNWei, utf8ToHex } from "../../src/utils";
 
@@ -616,4 +616,15 @@ export async function buildSlowFill(
 
 export function getDefaultBlockRange(toBlockOffset: number) {
   return DEFAULT_BLOCK_RANGE_FOR_CHAIN.map((range) => [range[0], range[1] + toBlockOffset]);
+}
+
+export function createRefunds(address: string, refundAmount: BigNumber, token: string) {
+  return {
+    [token]: {
+      refunds: { [address]: refundAmount },
+      fills: [],
+      totalRefundAmount: toBN(0),
+      realizedLpFees: toBN(0),
+    },
+  };
 }


### PR DESCRIPTION
Context: Currently inventory management can oversend funds to meet a shortfall. Consider the following scenario:

1. Polygon currently has a balance of 5 WETH with 20 WETH coming. The target allocation is 25 WETH so once refunds come in a few hours, the target allocation is still met.
2. There's a deposit of 10 WETH that needs to be filled on Polygon. This is a shortfall as we currently only have 5 WETH standing.
3. Currently inventory management would send 20 WETH total (triggered by the shortfall) to also meet the target alloc of 25 WETH. This means that after refunds, the final balance would be 45 WETH, which is almost double the target alloc.
4. This PR updates the logic so that it would only send 10 WETH over (exactly enough to cover the shortfall deposit). This will get refunded on L1 later as the repayment logic already knows of the 20 WETH coming. At the end, Polygon would only have 25 WETH remaining, which is perfectly at target.