### PR TITLE
fix: Look at the right starting block when calculating pending refunds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ coverage.json
 typechain
 .DS_Store
 dump.rdb
+.idea
 
 #Hardhat files
 cache

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -60,7 +60,7 @@ export class BundleDataClient {
     // Use the same block range as the current pending bundle to ensure we look at the right refunds.
     const pendingBundleEvaluationBlockRanges: number[][] = latestBundle.bundleEvaluationBlockNumbers.map(
       (endBlock, i) => [
-        hubPoolClient.getNextBundleStartBlockNumber(chainIds, latestBlockNumber, chainIds[i]),
+        hubPoolClient.getNextBundleStartBlockNumber(chainIds, endBlock.toNumber(), chainIds[i]),
         endBlock.toNumber(),
       ]
     );


### PR DESCRIPTION
Currently the logic looks at the starting block of the next bundle, which only works if the current pending bundle has not been executed in HubPool. Once it has been executed, the starting block would be in the future while the ending block is still in the past.