### PR TITLE
fix: Deep clone data from cache before returning from loadData()

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -49,6 +49,12 @@ export class BundleDataClient {
     this.loadDataCache = {};
   }
 
+  loadDataFromCache(key: string) {
+    // Always return a deep cloned copy of object stored in cache. Since JS passes by reference instead of value, we
+    // want to minimize the risk that the programmer accidentally mutates data in the cache.
+    return _.cloneDeep(this.loadDataCache[key]);
+  }
+
   // Return refunds from latest bundle
   getPendingRefundsFromLatestBundle(): FillsToRefund {
     const hubPoolClient = this.clients.hubPoolClient;
@@ -148,9 +154,7 @@ export class BundleDataClient {
     const key = JSON.stringify(blockRangesForChains);
 
     if (this.loadDataCache[key]) {
-      // Always return a deep cloned copy of object stored in cache. Since JS passes by reference instead of value, we
-      // want to minimize the risk that the programmer accidentally mutates data in the cache.
-      return _.cloneDeep(this.loadDataCache[key]);
+      return this.loadDataFromCache(key);
     }
 
     if (!this.clients.hubPoolClient.isUpdated) throw new Error(`HubPoolClient not updated`);
@@ -292,8 +296,6 @@ export class BundleDataClient {
 
     this.loadDataCache[key] = { fillsToRefund, deposits, unfilledDeposits, allValidFills };
 
-    // Always return a deep cloned copy of object stored in cache. Since JS passes by reference instead of value, we
-    // want to minimize the risk that the programmer accidentally mutates data in the cache.
-    return _.cloneDeep(this.loadDataCache[key]);
+    return this.loadDataFromCache(key);
   }
 }

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -50,9 +50,10 @@ export class BundleDataClient {
   }
 
   // Return refunds from latest bundle
-  getPendingRefundsFromLatestBundle(latestMainnetBlock: number): FillsToRefund {
+  getPendingRefundsFromLatestBundle(): FillsToRefund {
     const hubPoolClient = this.clients.hubPoolClient;
-    const latestBundle = hubPoolClient.getMostRecentProposedRootBundle(latestMainnetBlock);
+    const latestBlockNumber = hubPoolClient.latestBlockNumber;
+    const latestBundle = hubPoolClient.getMostRecentProposedRootBundle(latestBlockNumber);
     // Look for the latest fully executed root bundle before the current last bundle.
     // This ensures that we skip over any disputed (invalid) bundles.
     const previousValidBundle = hubPoolClient.getLatestFullyExecutedRootBundle(latestBundle.blockNumber);

--- a/src/clients/InventoryClient/InventoryClient.ts
+++ b/src/clients/InventoryClient/InventoryClient.ts
@@ -141,7 +141,7 @@ export class InventoryClient {
     const cumulativeVirtualBalance = this.getCumulativeBalance(l1Token);
     let cumulativeVirtualBalanceWithShortfall = cumulativeVirtualBalance.sub(chainShortfall);
 
-    // Consider any refunds from both latest bundle (even if its pending liveness) and the next bundle.
+    // Consider any refunds from both latest bundle (regardless if its excecuted or pending) and the next bundle.
     // TODO: This will not count any refunds older than the latest bundle that are unexecuted on the spoke pools,
     // so a future implementation should add in this feature as an option, to look back at refunds up to X bundles
     // old. The downside to ignoring these potentially older unexecuted refunds is that the virtual balance will be

--- a/src/clients/InventoryClient/InventoryClient.ts
+++ b/src/clients/InventoryClient/InventoryClient.ts
@@ -150,8 +150,7 @@ export class InventoryClient {
     const latestBundleRefunds = this.bundleDataClient.getPendingRefundsFromLatestBundle();
     const nextBundleRefunds = this.bundleDataClient.getNextBundleRefunds();
     const totalRefundsPerChain = Object.fromEntries(
-      this.getEnabledChains()
-        .map((chainId) => {
+      this.getEnabledChains().map((chainId) => {
         const destinationToken = this.getDestinationTokenForL1Token(l1Token, chainId);
         return [
           chainId,
@@ -160,7 +159,8 @@ export class InventoryClient {
             .add(
               this.bundleDataClient.getRefundsFor(nextBundleRefunds, this.relayer, Number(chainId), destinationToken)
             ),
-        ]})
+        ];
+      })
     );
 
     // Add upcoming refunds going to this destination chain.

--- a/src/clients/InventoryClient/InventoryClient.ts
+++ b/src/clients/InventoryClient/InventoryClient.ts
@@ -148,7 +148,6 @@ export class InventoryClient {
     // lower than it should be, meaning that we'll send more refunds to the spoke pool. However, these unexecuted refunds
     // should be rare in practice since leaves are usually executed immediately.
     const latestBundleRefunds = this.bundleDataClient.getPendingRefundsFromLatestBundle(
-      this.hubPoolClient.latestBlockNumber
     );
     const nextBundleRefunds = this.bundleDataClient.getNextBundleRefunds();
     const totalRefundsPerChain = Object.fromEntries(

--- a/src/clients/InventoryClient/InventoryClient.ts
+++ b/src/clients/InventoryClient/InventoryClient.ts
@@ -147,8 +147,7 @@ export class InventoryClient {
     // old. The downside to ignoring these potentially older unexecuted refunds is that the virtual balance will be
     // lower than it should be, meaning that we'll send more refunds to the spoke pool. However, these unexecuted refunds
     // should be rare in practice since leaves are usually executed immediately.
-    const latestBundleRefunds = this.bundleDataClient.getPendingRefundsFromLatestBundle(
-    );
+    const latestBundleRefunds = this.bundleDataClient.getPendingRefundsFromLatestBundle();
     const nextBundleRefunds = this.bundleDataClient.getNextBundleRefunds();
     const totalRefundsPerChain = Object.fromEntries(
       this.getEnabledChains()

--- a/src/clients/InventoryClient/InventoryClient.ts
+++ b/src/clients/InventoryClient/InventoryClient.ts
@@ -151,15 +151,16 @@ export class InventoryClient {
     const nextBundleRefunds = this.bundleDataClient.getNextBundleRefunds();
     const totalRefundsPerChain = Object.fromEntries(
       this.getEnabledChains()
-        .map((chainId) => [this.getDestinationTokenForL1Token(l1Token, chainId), chainId])
-        .map(([tokenId, chainId]) => [
+        .map((chainId) => {
+        const destinationToken = this.getDestinationTokenForL1Token(l1Token, chainId);
+        return [
           chainId,
           this.bundleDataClient
-            .getRefundsFor(latestBundleRefunds, this.relayer, Number(chainId), String(tokenId))
+            .getRefundsFor(latestBundleRefunds, this.relayer, Number(chainId), destinationToken)
             .add(
-              this.bundleDataClient.getRefundsFor(nextBundleRefunds, this.relayer, Number(chainId), String(tokenId))
+              this.bundleDataClient.getRefundsFor(nextBundleRefunds, this.relayer, Number(chainId), destinationToken)
             ),
-        ])
+        ]})
     );
 
     // Add upcoming refunds going to this destination chain.

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -309,9 +309,7 @@ export class Monitor {
   }
 
   updateLatestAndFutureRelayerRefunds(relayerBalanceReport: RelayerBalanceReport) {
-    const latestBundleRefunds = this.clients.bundleDataClient.getPendingRefundsFromLatestBundle(
-      this.clients.hubPoolClient.latestBlockNumber
-    );
+    const latestBundleRefunds = this.clients.bundleDataClient.getPendingRefundsFromLatestBundle();
     const nextBundleRefunds = this.clients.bundleDataClient.getNextBundleRefunds();
 
     // Calculate which fills have not yet been refunded for each monitored relayer.

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -170,7 +170,7 @@ export class Monitor {
       const chainId = deposit.deposit.destinationChainId;
       const tokenAddress = deposit.deposit.destinationToken;
       if (!unfilledAmountByChainAndToken[chainId] || !unfilledAmountByChainAndToken[chainId][tokenAddress]) {
-        assign(unfilledAmountByChainAndToken, [chainId, tokenAddress], BigNumber.from(0));
+        assign(unfilledAmountByChainAndToken, [chainId, tokenAddress], toBN(0));
       }
       unfilledAmountByChainAndToken[chainId][tokenAddress] = unfilledAmountByChainAndToken[chainId][tokenAddress].add(
         deposit.unfilledAmount
@@ -205,21 +205,21 @@ export class Monitor {
     const reports = this.initializeBalanceReports(relayers, allL1Tokens, allChainNames);
 
     await this.updateCurrentRelayerBalances(reports);
-    this.updatePendingAndFutureRelayerRefunds(reports);
+    this.updateLatestAndFutureRelayerRefunds(reports);
     this.updateUnknownTransfers(reports);
 
     for (const relayer of relayers) {
       const report = reports[relayer];
       let summaryMrkdwn = "*[Summary]*\n";
-      let mrkdwn = "Token amounts: current, in liveness, next bundle, total\n";
+      let mrkdwn = "Token amounts: current, latest bundle, next bundle, total\n";
       for (const token of allL1Tokens) {
         let tokenMrkdwn = "";
         for (const chainName of allChainNames) {
           const balancesBN = Object.values(report[token.symbol][chainName]);
-          if (balancesBN.find((b) => b.gt(BigNumber.from(0)))) {
+          if (balancesBN.find((b) => b.gt(toBN(0)))) {
             // Human-readable balances
             const balances = balancesBN.map((balance) =>
-              balance.gt(BigNumber.from(0)) ? convertFromWei(balance.toString(), token.decimals) : "0"
+              balance.gt(toBN(0)) ? convertFromWei(balance.toString(), token.decimals) : "0"
             );
             tokenMrkdwn += `${chainName}: ${balances.join(", ")}\n`;
           } else {
@@ -230,7 +230,7 @@ export class Monitor {
 
         const totalBalance = report[token.symbol][ALL_CHAINS_NAME][BalanceType.TOTAL];
         // Update corresponding summary section for current token.
-        if (totalBalance.gt(BigNumber.from(0))) {
+        if (totalBalance.gt(toBN(0))) {
           mrkdwn += `*[${token.symbol}]*\n` + tokenMrkdwn;
           summaryMrkdwn += `${token.symbol}: ${convertFromWei(totalBalance.toString(), token.decimals)}\n`;
         } else {
@@ -308,13 +308,15 @@ export class Monitor {
     }
   }
 
-  updatePendingAndFutureRelayerRefunds(relayerBalanceReport: RelayerBalanceReport) {
-    const pendingBundleRefunds = this.clients.bundleDataClient.getPendingBundleRefunds();
+  updateLatestAndFutureRelayerRefunds(relayerBalanceReport: RelayerBalanceReport) {
+    const latestBundleRefunds = this.clients.bundleDataClient.getPendingRefundsFromLatestBundle(
+      this.clients.hubPoolClient.latestBlockNumber
+    );
     const nextBundleRefunds = this.clients.bundleDataClient.getNextBundleRefunds();
 
     // Calculate which fills have not yet been refunded for each monitored relayer.
     for (const relayer of this.monitorConfig.monitoredRelayers) {
-      this.updateRelayerRefunds(pendingBundleRefunds, relayerBalanceReport[relayer], relayer, BalanceType.PENDING);
+      this.updateRelayerRefunds(latestBundleRefunds, relayerBalanceReport[relayer], relayer, BalanceType.PENDING);
       this.updateRelayerRefunds(nextBundleRefunds, relayerBalanceReport[relayer], relayer, BalanceType.NEXT);
     }
   }
@@ -341,7 +343,7 @@ export class Monitor {
           // Skip if there has been no transfers of this token.
           if (!transfers) continue;
 
-          let totalOutgoingAmount = BigNumber.from(0);
+          let totalOutgoingAmount = toBN(0);
           // Filter v2 fills and bond payments from outgoing transfers.
           const fillTransactionHashes = spokePoolClient
             .getFillsWithBlockForDestinationChainAndRelayer(chainId, relayer)
@@ -353,7 +355,7 @@ export class Monitor {
             currentTokenMrkdwn += this.formatCategorizedTransfers(outgoingTransfers, tokenInfo.decimals, chainId);
           }
 
-          let totalIncomingAmount = BigNumber.from(0);
+          let totalIncomingAmount = toBN(0);
           // Filter v2 refunds and bond repayments from incoming transfers.
           const refundTransactionHashes = spokePoolClient
             .getRelayerRefundExecutions()
@@ -367,7 +369,7 @@ export class Monitor {
 
           // Record if there are net outgoing transfers.
           const netTransfersAmount = totalIncomingAmount.sub(totalOutgoingAmount);
-          if (!netTransfersAmount.eq(BigNumber.from(0))) {
+          if (!netTransfersAmount.eq(toBN(0))) {
             const netAmount = convertFromWei(netTransfersAmount.toString(), tokenInfo.decimals);
             currentTokenMrkdwn = `*${tokenInfo.symbol}: Net ${netAmount}*\n` + currentTokenMrkdwn;
             currentChainMrkdwn += currentTokenMrkdwn;
@@ -385,7 +387,7 @@ export class Monitor {
               tokenInfo.symbol,
               UNKNOWN_TRANSFERS_NAME,
               BalanceType.PENDING,
-              totalOutgoingAmount.mul(BigNumber.from(-1))
+              totalOutgoingAmount.mul(toBN(-1))
             );
             this.incrementBalance(
               report,
@@ -476,7 +478,7 @@ export class Monitor {
         for (const chainName of allChainNames) {
           reports[relayer][token.symbol][chainName] = {};
           for (const balanceType of ALL_BALANCE_TYPES) {
-            reports[relayer][token.symbol][chainName][balanceType] = BigNumber.from(0);
+            reports[relayer][token.symbol][chainName][balanceType] = toBN(0);
           }
         }
       }
@@ -498,7 +500,7 @@ export class Monitor {
       for (const tokenAddress of Object.keys(fillsToRefund)) {
         const totalRefundAmount = fillsToRefund[tokenAddress].refunds[relayer];
         const tokenInfo = this.clients.hubPoolClient.getL1TokenInfoForL2Token(tokenAddress, chainId);
-        const amount = totalRefundAmount || BigNumber.from(0);
+        const amount = totalRefundAmount || toBN(0);
         this.updateRelayerBalanceTable(
           relayerBalanceTable,
           tokenInfo.symbol,

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -123,7 +123,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       await updateAllClients();
     });
     it("Latest bundle is pending", async function () {
-      const refunds = await bundleDataClient.getPendingRefundsFromLatestBundle(hubPoolClient.latestBlockNumber);
+      const refunds = await bundleDataClient.getPendingRefundsFromLatestBundle();
       expect(bundleDataClient.getRefundsFor(refunds, relayer.address, destinationChainId, erc20_2.address)).to.equal(
         getRefundForFills([fill1])
       );
@@ -166,7 +166,7 @@ describe("Dataworker: Load data used in all functions", async function () {
 
       // Before relayer refund leaves are executed, should have pending refunds:
       await updateAllClients();
-      const refunds = await bundleDataClient.getPendingRefundsFromLatestBundle(hubPoolClient.latestBlockNumber);
+      const refunds = await bundleDataClient.getPendingRefundsFromLatestBundle();
       expect(bundleDataClient.getRefundsFor(refunds, relayer.address, destinationChainId, erc20_2.address)).to.equal(
         getRefundForFills([fill1])
       );
@@ -182,9 +182,7 @@ describe("Dataworker: Load data used in all functions", async function () {
 
       // Should now have zero pending refunds
       await updateAllClients();
-      const postExecutionRefunds = await bundleDataClient.getPendingRefundsFromLatestBundle(
-        hubPoolClient.latestBlockNumber
-      );
+      const postExecutionRefunds = await bundleDataClient.getPendingRefundsFromLatestBundle();
       expect(
         bundleDataClient.getRefundsFor(postExecutionRefunds, relayer.address, destinationChainId, erc20_2.address)
       ).to.equal(toBN(0));

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -119,7 +119,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
       await multiCallerClient.executeTransactionQueue();
       await updateAllClients();
-      
+
       const refunds = await bundleDataClient.getPendingRefundsFromLatestBundle();
       expect(bundleDataClient.getRefundsFor(refunds, relayer.address, destinationChainId, erc20_2.address)).to.equal(
         getRefundForFills([fill1])
@@ -149,7 +149,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       await l1Token_1.approve(hubPool.address, MAX_UINT_VAL);
       await multiCallerClient.executeTransactionQueue();
       await updateAllClients();
-      
+
       const latestBlock = await hubPool.provider.getBlockNumber();
       const blockRange = CHAIN_ID_TEST_LIST.map((_) => [0, latestBlock]);
       const expectedPoolRebalanceRoot = dataworkerInstance.buildPoolRebalanceRoot(blockRange, spokePoolClients);
@@ -185,17 +185,17 @@ describe("Dataworker: Load data used in all functions", async function () {
 
       // Should now have zero pending refunds
       await updateAllClients();
-      // If we call `getPendingRefundsFromLatestBundle` multiple times, there should be no error. If there is an error, 
-      // then it means that `getPendingRefundsFromLatestBundle` is mutating the return value of `.loadData` which is 
-      // stored in the bundle data client's cache. `getPendingRefundsFromLatestBundle` should instead be using a 
+      // If we call `getPendingRefundsFromLatestBundle` multiple times, there should be no error. If there is an error,
+      // then it means that `getPendingRefundsFromLatestBundle` is mutating the return value of `.loadData` which is
+      // stored in the bundle data client's cache. `getPendingRefundsFromLatestBundle` should instead be using a
       // deep cloned copy of `.loadData`'s output.
-      await bundleDataClient.getPendingRefundsFromLatestBundle()
+      await bundleDataClient.getPendingRefundsFromLatestBundle();
       const postExecutionRefunds = await bundleDataClient.getPendingRefundsFromLatestBundle();
       expect(
         bundleDataClient.getRefundsFor(postExecutionRefunds, relayer.address, destinationChainId, erc20_2.address)
       ).to.equal(toBN(0));
     });
-    it("Refunds in next bundle", async function() {
+    it("Refunds in next bundle", async function () {
       // When this is the first root bundle:
       const refunds = bundleDataClient.getNextBundleRefunds();
       expect(bundleDataClient.getRefundsFor(refunds, relayer.address, destinationChainId, erc20_2.address)).to.equal(
@@ -235,11 +235,15 @@ describe("Dataworker: Load data used in all functions", async function () {
         erc20_2.address
       );
       await updateAllClients();
-      expect(bundleDataClient.getRefundsFor(bundleDataClient.getNextBundleRefunds(), relayer.address, destinationChainId, erc20_2.address)).to.equal(
-        getRefundForFills([fill2])
-      );
-
-    })
+      expect(
+        bundleDataClient.getRefundsFor(
+          bundleDataClient.getNextBundleRefunds(),
+          relayer.address,
+          destinationChainId,
+          erc20_2.address
+        )
+      ).to.equal(getRefundForFills([fill2]));
+    });
   });
   it("Returns unfilled deposits", async function () {
     await updateAllClients();

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -204,7 +204,7 @@ describe("Monitor", async function () {
       monitorInstance.clients.hubPoolClient.getL1Tokens(),
       TEST_NETWORK_NAMES
     );
-    monitorInstance.updatePendingAndFutureRelayerRefunds(reports);
+    monitorInstance.updateLatestAndFutureRelayerRefunds(reports);
     expect(reports[depositor.address]["L1"][ALL_CHAINS_NAME]["pending"].toString()).to.be.equal("49958233892200285050");
 
     reports = monitorInstance.initializeBalanceReports(
@@ -225,7 +225,7 @@ describe("Monitor", async function () {
       relayerRefundRoot: hubPoolClient.getMostRecentProposedRootBundle(hubPoolClient.latestBlockNumber)
         .relayerRefundRoot,
     } as any);
-    monitorInstance.updatePendingAndFutureRelayerRefunds(reports);
+    monitorInstance.updateLatestAndFutureRelayerRefunds(reports);
     expect(reports[depositor.address]["L1"][ALL_CHAINS_NAME]["pending"].toString()).to.be.equal("10000000000000000000");
   });
 

--- a/test/mocks/MockBundleDataClient.ts
+++ b/test/mocks/MockBundleDataClient.ts
@@ -5,7 +5,7 @@ export class MockBundleDataClient extends BundleDataClient {
   private pendingBundleRefunds: FillsToRefund = {};
   private nextBundleRefunds: FillsToRefund = {};
 
-  getPendingBundleRefunds() {
+  getPendingRefundsFromLatestBundle() {
     return this.pendingBundleRefunds;
   }
 


### PR DESCRIPTION
JS passes objects by reference, so when we changed `loadData` to return data from the cache (when possible), we sometimes run into bugs when we mutate that return value, causing corrupted data to be loaded from the cache on the next run.

This PR changes `loadData` to always return a deep cloned data from the cache