### PR TITLE
improve: Consolidate bundle refund calculations and look up to N root bundles into past for pending refunds

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -61,7 +61,8 @@ export class BundleDataClient {
     let latestBlock = this.clients.hubPoolClient.latestBlockNumber;
     for (let i = 0; i < bundleLookback; i++) {
       const bundle = this.clients.hubPoolClient.getLatestFullyExecutedRootBundle(latestBlock);
-      if (bundle === undefined) {
+      if (bundle !== undefined) {
+        // Update latest block so next iteration can get the next oldest bundle:
         latestBlock = bundle.blockNumber;
         refunds.push(this.getPendingRefundsFromBundle(bundle));
       } else break; // No more valid bundles in history!

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -1,4 +1,4 @@
-import { winston, BigNumber } from "../utils";
+import { winston, BigNumber, toBN } from "../utils";
 import * as _ from "lodash";
 import {
   Deposit,
@@ -55,48 +55,51 @@ export class BundleDataClient {
     return _.cloneDeep(this.loadDataCache[key]);
   }
 
-  // Return refunds from latest bundle
-  getPendingRefundsFromLatestBundle(): FillsToRefund {
+  getPendingRefundsFromValidBundles(bundleLookback: number): FillsToRefund[] {
+    const refunds = [];
+
+    let latestBlock = this.clients.hubPoolClient.latestBlockNumber;
+    for (let i = 0; i < bundleLookback; i++) {
+      const bundle = this.clients.hubPoolClient.getLatestFullyExecutedRootBundle(latestBlock);
+      if (bundle) {
+        latestBlock = bundle.blockNumber;
+        const bundleRefunds = this.getPendingRefundsFromBundle(bundle);
+        refunds.push(bundleRefunds);
+      } else break; // No more valid bundles in history!
+    }
+    return refunds;
+  }
+
+  // Return refunds from input bundle.
+  getPendingRefundsFromBundle(bundle: ProposedRootBundle): FillsToRefund {
     const hubPoolClient = this.clients.hubPoolClient;
-    const latestBlockNumber = hubPoolClient.latestBlockNumber;
-    const latestBundle = hubPoolClient.getMostRecentProposedRootBundle(latestBlockNumber);
-    // Look for the latest fully executed root bundle before the current last bundle.
+    // Look for the latest fully executed root bundle before the input bundle.
     // This ensures that we skip over any disputed (invalid) bundles.
-    const previousValidBundle = hubPoolClient.getLatestFullyExecutedRootBundle(latestBundle.blockNumber);
+    const previousValidBundle = hubPoolClient.getLatestFullyExecutedRootBundle(bundle.blockNumber);
 
     // Reconstruct latest bundle block range.
-    const latestBundleEvaluationBlockRanges: number[][] = latestBundle.bundleEvaluationBlockNumbers.map(
-      (endBlock, i) => {
-        const fromBlock = previousValidBundle?.bundleEvaluationBlockNumbers?.[i]
-          ? previousValidBundle.bundleEvaluationBlockNumbers[i].toNumber() + 1
-          : 0;
-        return [fromBlock, endBlock.toNumber()];
-      }
-    );
-    const { fillsToRefund: latestFillsToRefund } = this.loadData(
-      latestBundleEvaluationBlockRanges,
-      this.spokePoolClients,
-      false
-    );
+    const bundleEvaluationBlockRanges: number[][] = bundle.bundleEvaluationBlockNumbers.map((endBlock, i) => {
+      const fromBlock = previousValidBundle?.bundleEvaluationBlockNumbers?.[i]
+        ? previousValidBundle.bundleEvaluationBlockNumbers[i].toNumber() + 1
+        : 0;
+      return [fromBlock, endBlock.toNumber()];
+    });
+    const { fillsToRefund } = this.loadData(bundleEvaluationBlockRanges, this.spokePoolClients, false);
 
     // The latest proposed bundle's refund leaves might have already been partially or entirely executed.
     // We have to deduct the executed amounts from the total refund amounts.
-    return this.deductExecutedRefunds(latestFillsToRefund, latestBundle);
+    return this.deductExecutedRefunds(fillsToRefund, bundle);
   }
 
   // Return refunds from the next bundle.
   getNextBundleRefunds(): FillsToRefund {
-    const latestProposedBundle = this.clients.hubPoolClient.getMostRecentProposedRootBundle(
-      this.clients.hubPoolClient.latestBlockNumber
-    );
-    // The future bundle covers block range from the ending of the last proposed bundle (might still be pending liveness)
-    // to the latest block on that chain.
     const chainIds = Object.keys(this.spokePoolClients).map(Number);
-    const latestProposalEndBlocks = latestProposedBundle
-      ? latestProposedBundle.bundleEvaluationBlockNumbers.map((block) => block.toNumber() + 1)
-      : Array(chainIds.length).fill(0);
-    const futureBundleEvaluationBlockRanges: number[][] = latestProposalEndBlocks.map((endingBlock, i) => [
-      endingBlock,
+    const futureBundleEvaluationBlockRanges: number[][] = chainIds.map((chainId, i) => [
+      this.clients.hubPoolClient.getNextBundleStartBlockNumber(
+        this.chainIdListForBundleEvaluationBlockNumbers,
+        this.clients.hubPoolClient.latestBlockNumber,
+        chainId
+      ),
       this.spokePoolClients[chainIds[i]].latestBlockNumber,
     ]);
     // Refunds that will be processed in the next bundle that will be proposed after the current pending bundle
@@ -136,6 +139,12 @@ export class BundleDataClient {
     if (!bundleRefunds[chainId] || !bundleRefunds[chainId][token]) return BigNumber.from(0);
     const allRefunds = bundleRefunds[chainId][token].refunds;
     return allRefunds && allRefunds[relayer] ? allRefunds[relayer] : BigNumber.from(0);
+  }
+
+  getTotalRefund(refunds: FillsToRefund[], relayer: string, chainId: number, refundToken: string): BigNumber {
+    return refunds.reduce((totalRefund, refunds) => {
+      return totalRefund.add(this.getRefundsFor(refunds, relayer, chainId, refundToken));
+    }, toBN(0));
   }
 
   // Common data re-formatting logic shared across all data worker public functions.

--- a/src/clients/InventoryClient/InventoryClient.ts
+++ b/src/clients/InventoryClient/InventoryClient.ts
@@ -141,24 +141,21 @@ export class InventoryClient {
     const cumulativeVirtualBalance = this.getCumulativeBalance(l1Token);
     let cumulativeVirtualBalanceWithShortfall = cumulativeVirtualBalance.sub(chainShortfall);
 
-    // Consider any refunds from both latest bundle (regardless if its excecuted or pending) and the next bundle.
-    // TODO: This will not count any refunds older than the latest bundle that are unexecuted on the spoke pools,
-    // so a future implementation should add in this feature as an option, to look back at refunds up to X bundles
-    // old. The downside to ignoring these potentially older unexecuted refunds is that the virtual balance will be
-    // lower than it should be, meaning that we'll send more refunds to the spoke pool. However, these unexecuted refunds
-    // should be rare in practice since leaves are usually executed immediately.
-    const latestBundleRefunds = this.bundleDataClient.getPendingRefundsFromLatestBundle();
+    // Increase virtual balance by pending relayer refunds from the latest valid bundles.
+    // TODO: Allow caller to set how many bundles to look back for refunds. For now its set to 2 which means
+    // we'll look back only at the two latest valid bundle.
+    const refundsToConsider: FillsToRefund[] = this.bundleDataClient.getPendingRefundsFromValidBundles(2);
+
+    // Consider refunds from next bundle to be proposed:
     const nextBundleRefunds = this.bundleDataClient.getNextBundleRefunds();
+    refundsToConsider.push(nextBundleRefunds);
+
     const totalRefundsPerChain = Object.fromEntries(
       this.getEnabledChains().map((chainId) => {
         const destinationToken = this.getDestinationTokenForL1Token(l1Token, chainId);
         return [
           chainId,
-          this.bundleDataClient
-            .getRefundsFor(latestBundleRefunds, this.relayer, Number(chainId), destinationToken)
-            .add(
-              this.bundleDataClient.getRefundsFor(nextBundleRefunds, this.relayer, Number(chainId), destinationToken)
-            ),
+          this.bundleDataClient.getTotalRefund(refundsToConsider, this.relayer, Number(chainId), destinationToken),
         ];
       })
     );

--- a/src/clients/InventoryClient/InventoryClient.ts
+++ b/src/clients/InventoryClient/InventoryClient.ts
@@ -19,7 +19,8 @@ export class InventoryClient {
     readonly chainIdList: number[],
     readonly hubPoolClient: HubPoolClient,
     readonly bundleDataClient: BundleDataClient,
-    readonly adapterManager: AdapterManager
+    readonly adapterManager: AdapterManager,
+    readonly bundleRefundLookback = 2
   ) {}
 
   // Get the total balance across all chains, considering any outstanding cross chain transfers as a virtual balance on that chain.
@@ -142,9 +143,11 @@ export class InventoryClient {
     let cumulativeVirtualBalanceWithShortfall = cumulativeVirtualBalance.sub(chainShortfall);
 
     // Increase virtual balance by pending relayer refunds from the latest valid bundles.
-    // TODO: Allow caller to set how many bundles to look back for refunds. For now its set to 2 which means
-    // we'll look back only at the two latest valid bundle.
-    const refundsToConsider: FillsToRefund[] = this.bundleDataClient.getPendingRefundsFromValidBundles(2);
+    // Allow caller to set how many bundles to look back for refunds. The default is set to 2 which means
+    // we'll look back only at the two latest valid bundle unless the caller overrides.
+    const refundsToConsider: FillsToRefund[] = this.bundleDataClient.getPendingRefundsFromValidBundles(
+      this.bundleRefundLookback
+    );
 
     // Consider refunds from next bundle to be proposed:
     const nextBundleRefunds = this.bundleDataClient.getNextBundleRefunds();

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -14,6 +14,7 @@ export class CommonConfig {
   readonly maxTxWait: number;
   readonly sendingTransactionsEnabled: boolean;
   readonly redisUrl: string | undefined;
+  readonly bundleRefundLookback: number;
 
   constructor(env: ProcessEnv) {
     const {
@@ -25,6 +26,7 @@ export class CommonConfig {
       MAX_TX_WAIT_DURATION,
       SEND_TRANSACTIONS,
       REDIS_URL,
+      BUNDLE_REFUND_LOOKBACK,
     } = env;
     this.hubPoolChainId = HUB_CHAIN_ID ? Number(HUB_CHAIN_ID) : 1;
     this.spokePoolChains = CONFIGURED_NETWORKS ? JSON.parse(CONFIGURED_NETWORKS) : Constants.CHAIN_ID_LIST_INDICES;
@@ -38,5 +40,6 @@ export class CommonConfig {
     this.maxTxWait = MAX_TX_WAIT_DURATION ? Number(MAX_TX_WAIT_DURATION) : 180; // 3 minutes
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
     this.redisUrl = REDIS_URL;
+    this.bundleRefundLookback = BUNDLE_REFUND_LOOKBACK ? Number(BUNDLE_REFUND_LOOKBACK) : 2;
   }
 }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -309,12 +309,16 @@ export class Monitor {
   }
 
   updateLatestAndFutureRelayerRefunds(relayerBalanceReport: RelayerBalanceReport) {
-    const latestBundleRefunds = this.clients.bundleDataClient.getPendingRefundsFromLatestBundle();
+    const validatedBundleRefunds: FillsToRefund[] = this.clients.bundleDataClient.getPendingRefundsFromValidBundles(2);
     const nextBundleRefunds = this.clients.bundleDataClient.getNextBundleRefunds();
 
     // Calculate which fills have not yet been refunded for each monitored relayer.
+    for (const refunds of validatedBundleRefunds) {
+      for (const relayer of this.monitorConfig.monitoredRelayers) {
+        this.updateRelayerRefunds(refunds, relayerBalanceReport[relayer], relayer, BalanceType.PENDING);
+      }
+    }
     for (const relayer of this.monitorConfig.monitoredRelayers) {
-      this.updateRelayerRefunds(latestBundleRefunds, relayerBalanceReport[relayer], relayer, BalanceType.PENDING);
       this.updateRelayerRefunds(nextBundleRefunds, relayerBalanceReport[relayer], relayer, BalanceType.NEXT);
     }
   }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -309,7 +309,9 @@ export class Monitor {
   }
 
   updateLatestAndFutureRelayerRefunds(relayerBalanceReport: RelayerBalanceReport) {
-    const validatedBundleRefunds: FillsToRefund[] = this.clients.bundleDataClient.getPendingRefundsFromValidBundles(2);
+    const validatedBundleRefunds: FillsToRefund[] = this.clients.bundleDataClient.getPendingRefundsFromValidBundles(
+      this.monitorConfig.bundleRefundLookback
+    );
     const nextBundleRefunds = this.clients.bundleDataClient.getNextBundleRefunds();
 
     // Calculate which fills have not yet been refunded for each monitored relayer.

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -41,7 +41,8 @@ export async function constructRelayerClients(logger: winston.Logger, config: Re
     config.spokePoolChains,
     commonClients.hubPoolClient,
     bundleDataClient,
-    adapterManager
+    adapterManager,
+    config.bundleRefundLookback
   );
 
   return { ...commonClients, spokePoolClients, tokenClient, profitClient, inventoryClient };

--- a/test/mocks/MockBundleDataClient.ts
+++ b/test/mocks/MockBundleDataClient.ts
@@ -5,8 +5,8 @@ export class MockBundleDataClient extends BundleDataClient {
   private pendingBundleRefunds: FillsToRefund = {};
   private nextBundleRefunds: FillsToRefund = {};
 
-  getPendingRefundsFromLatestBundle() {
-    return this.pendingBundleRefunds;
+  getPendingRefundsFromValidBundles() {
+    return [this.pendingBundleRefunds];
   }
 
   getNextBundleRefunds() {


### PR DESCRIPTION
There are now two types of possible pending refunds:
- Those contained in validated root bundles (i.e. the root bundle passed liveness and all root bundle leaves were executed)
- Those contained in unvalidated root bundles (i.e. the next potential root bundle to be proposed or contained in a pending liveness)

This makes it a bit easier to look up N validated root bundles into the past to find pending refunds. The main change with this is that refunds in the next potential root bundle are now grouped together with those in a pending bundle that has not passed liveness.