### PR TITLE
feat: rudimentary partial fill logic

### DIFF
--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -60,6 +60,8 @@ export class TokenClient {
     return this.getBalance(deposit.destinationChainId, deposit.destinationToken).gte(toBN(1));
   }
 
+  // TODO: this will capture any token shortfalls, even if you have 0 of the token. The bot should
+  // be updated to ignore non-whitelisted (zero balance) tokens from this token shortfall log.
   // If the relayer tries to execute a relay but does not have enough tokens to fully fill it it will capture the
   // shortfall by calling this method. This will track the information for logging purposes and use in other clients.
   captureTokenShortfall(chainId: number, token: string, depositId: number, unfilledAmount: BigNumber) {

--- a/src/interfaces/InventoryManagement.ts
+++ b/src/interfaces/InventoryManagement.ts
@@ -6,6 +6,8 @@ export interface InventoryConfig {
       [chainId: string]: {
         targetPct: BigNumber; // The desired amount of the given token on the L2 chainId.
         thresholdPct: BigNumber; // Threshold, below which, we will execute a rebalance.
+        partialFillThresholdPct?: BigNumber; // Will partially fill deposits when relayer balance on this chain is below this % of total allocation
+        partialFillAmountPct?: BigNumber; // For partial fills, use this % of relayer balance for the current chain to submit partial fill.
       };
     };
   };

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -41,8 +41,8 @@ export class RelayerConfig extends CommonConfig {
           // Partial fill configs are optional:
           if (partialFillThresholdPct) {
             assert(
-              toBN(partialFillThresholdPct).lte(toBN(1)),
-              `Bad config. partialFillThresholdPct<=1 for ${l1Token} on ${chainId}`
+              toBN(partialFillThresholdPct).lte(toBN(100)),
+              `Bad config. partialFillThresholdPct<=100 for ${l1Token} on ${chainId}`
             );
           }
           this.inventoryConfig.tokenConfig[l1Token][chainId].partialFillThresholdPct = partialFillThresholdPct
@@ -52,11 +52,11 @@ export class RelayerConfig extends CommonConfig {
           // always attempt to send partial fills.
           if (partialFillAmountPct) {
             assert(
-              toBN(partialFillAmountPct).lte(toBN(1)),
-              `Bad config. partialFillAmountPct<=1 for ${l1Token} on ${chainId}`
+              toBN(partialFillAmountPct).lte(toBN(100)),
+              `Bad config. partialFillAmountPct<=100 for ${l1Token} on ${chainId}`
             );
           }
-          this.inventoryConfig.tokenConfig[l1Token][chainId].partialFillThresholdPct = partialFillAmountPct
+          this.inventoryConfig.tokenConfig[l1Token][chainId].partialFillAmountPct = partialFillAmountPct
             ? toBNWei(partialFillAmountPct).div(100)
             : toBNWei("0.25"); // By default, will use 25% of its balance to send partial fills.
         });

--- a/test/InventoryClient.PartialFill.ts
+++ b/test/InventoryClient.PartialFill.ts
@@ -1,0 +1,123 @@
+import { expect, ethers, SignerWithAddress, createSpyLogger, winston, BigNumber } from "./utils";
+import { toBN, toWei, randomAddress } from "./utils";
+
+import { InventoryConfig, Deposit } from "../src/interfaces";
+import { MockBundleDataClient, MockHubPoolClient, MockAdapterManager, MockTokenClient } from "./mocks";
+import { InventoryClient } from "../src/clients"; // Tested
+
+let hubPoolClient: MockHubPoolClient, adapterManager: MockAdapterManager, tokenClient: MockTokenClient;
+let bundleDataClient: MockBundleDataClient;
+let owner: SignerWithAddress, spyLogger: winston.Logger;
+let inventoryClient: InventoryClient; // tested
+let sampleDepositData: Deposit;
+
+const enabledChainIds = [1, 10, 137, 42161];
+
+const mainnetWeth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const mainnetUsdc = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+
+// construct two mappings of chainId to token address. Set the l1 token address to the "real" token address.
+const l2TokensForWeth = { 1: mainnetWeth };
+const l2TokensForUsdc = { 1: mainnetUsdc };
+enabledChainIds.slice(1).forEach((chainId) => {
+  l2TokensForWeth[chainId] = randomAddress();
+  l2TokensForUsdc[chainId] = randomAddress();
+});
+
+// Configure thresholds percentages as 10% optimism, 5% polygon and 5% Arbitrum with a target being threshold +2%.
+const inventoryConfig: InventoryConfig = {
+  tokenConfig: {
+    [mainnetWeth]: {
+      10: {
+        targetPct: toWei(0.12),
+        thresholdPct: toWei(0.1),
+        partialFillAmountPct: toWei(0.5),
+        partialFillThresholdPct: toWei(0.3),
+      },
+      137: {
+        targetPct: toWei(0.07),
+        thresholdPct: toWei(0.05),
+        partialFillAmountPct: toWei(0.5),
+        partialFillThresholdPct: toWei(0.3),
+      },
+      42161: { targetPct: toWei(0.07), thresholdPct: toWei(0.05) },
+    },
+  },
+  wrapEtherThreshold: toWei(1),
+};
+
+// Construct an initial distribution that keeps these values within the above thresholds.
+const initialAllocation = {
+  1: { [mainnetWeth]: toWei(100) },
+  10: { [mainnetWeth]: toWei(20) },
+  137: { [mainnetWeth]: toWei(10) },
+  42161: { [mainnetWeth]: toWei(10) },
+};
+
+describe("InventoryClient: Partial fill parameters", async function () {
+  beforeEach(async function () {
+    [owner] = await ethers.getSigners();
+    ({ spyLogger } = createSpyLogger());
+
+    hubPoolClient = new MockHubPoolClient(null, null);
+    adapterManager = new MockAdapterManager(null, null, null, null);
+    tokenClient = new MockTokenClient(null, null, null, null);
+    bundleDataClient = new MockBundleDataClient(null, null, null, null);
+
+    inventoryClient = new InventoryClient(
+      owner.address,
+      spyLogger,
+      inventoryConfig,
+      tokenClient,
+      enabledChainIds,
+      hubPoolClient,
+      bundleDataClient,
+      adapterManager
+    );
+    seedMocks(initialAllocation);
+
+    sampleDepositData = {
+      depositId: 0,
+      depositor: owner.address,
+      recipient: owner.address,
+      originToken: mainnetWeth,
+      destinationToken: l2TokensForWeth[10],
+      realizedLpFeePct: toWei(0),
+      amount: toWei(200),
+      originChainId: 1,
+      destinationChainId: 10,
+      relayerFeePct: toBN(1337),
+      quoteTimestamp: 1234,
+    };
+    hubPoolClient.setReturnedL1TokenForDeposit(mainnetWeth);
+  });
+
+  it("Inventory config not set for token", async function () {
+    sampleDepositData.destinationChainId = 42161; // Chain with no partial fill config set
+    const result = inventoryClient.getPartialFillAmount(sampleDepositData, sampleDepositData.amount);
+    expect(result).to.equal(toBN(0));
+  });
+  it("Allocation % including unfilled amount is above partial fill trigger %", async function () {
+    // Initial allocation to chain 10 is 20 out of 140 WETH
+    // If we set the relayer allocation on chain 10 equal to 100, then a 10 WETH unfilled amount will still keep it
+    // over the threshold 30% < ( 100 - 10 ) / (100+100+10+10) ~= 40%
+    tokenClient.setTokenData(sampleDepositData.destinationChainId, sampleDepositData.destinationToken, toWei(100));
+    expect(inventoryClient.getPartialFillAmount(sampleDepositData, toWei(10))).to.equal(toBN(0));
+  });
+  it("Allocation % including unfilled amount is below partial fill trigger %", async function () {
+    // With the allocation for chain 10 = 20, if the unfilled amount is 5, then the new allocation %
+    // will be below the threshold 30% > (20 - 5) / (140) ~= 10%. So, we'll send the partial fill amount %
+    // of the relayer's balance: 50% of 20 = 10.
+    expect(inventoryClient.getPartialFillAmount(sampleDepositData, toWei(5))).to.equal(toWei(10));
+  });
+});
+
+function seedMocks(seedBalances: { [chainId: string]: { [token: string]: BigNumber } }) {
+  hubPoolClient.addL1Token({ address: mainnetWeth, decimals: 18, symbol: "WETH" });
+  enabledChainIds.forEach((chainId) => {
+    adapterManager.setMockedOutstandingCrossChainTransfers(chainId, mainnetWeth, toBN(0));
+    tokenClient.setTokenData(chainId, l2TokensForWeth[chainId], seedBalances[chainId][mainnetWeth], toBN(0));
+  });
+
+  hubPoolClient.setL1TokensToDestinationTokens({ [mainnetWeth]: l2TokensForWeth });
+}

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -97,21 +97,21 @@ describe("InventoryClient: Refund chain selection", async function () {
     // Construct a small mock deposit of side 1 WETH. Post relay Optimism should have (20-1)/(140-1)=13.6%. This is still
     // above the threshold of 12 and so the bot should choose to be refunded on L1.
     sampleDepositData.amount = toWei(1);
-    expect(inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(1);
+    expect(inventoryClient.determineRefundChainId(sampleDepositData, sampleDepositData.amount)).to.equal(1);
     expect(lastSpyLogIncludes(spy, `expectedPostRelayAllocation":"136690647482014388"`)).to.be.true; // (20-1)/(140-1)=0.136
 
     // Now consider a case where the relayer is filling a marginally larger relay of size 5 WETH. Now the post relay
     // allocation on optimism would be (20-5)/(140-5)=11%. This now below the target plus buffer of 12%. Relayer should
     // choose to refund on the L2.
     sampleDepositData.amount = toWei(5);
-    expect(inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(10);
+    expect(inventoryClient.determineRefundChainId(sampleDepositData, sampleDepositData.amount)).to.equal(10);
     expect(lastSpyLogIncludes(spy, `expectedPostRelayAllocation":"111111111111111111"`)).to.be.true; // (20-5)/(140-5)=0.11
 
     // Now consider a bigger relay that should force refunds on the L2 chain. Set the relay size to 10 WETH. now post
     // relay allocation would be (20-10)/(140-10)=0.076. This is below the target threshold of 10% and so the bot should
     // set the refund on L2.
     sampleDepositData.amount = toWei(10);
-    expect(inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(10);
+    expect(inventoryClient.determineRefundChainId(sampleDepositData, sampleDepositData.amount)).to.equal(10);
     expect(lastSpyLogIncludes(spy, `expectedPostRelayAllocation":"76923076923076923"`)).to.be.true; // (20-10)/(140-10)=0.076
   });
 
@@ -148,7 +148,7 @@ describe("InventoryClient: Refund chain selection", async function () {
 
     sampleDepositData.destinationChainId = 42161;
     sampleDepositData.amount = toWei(1.69);
-    expect(inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(42161);
+    expect(inventoryClient.determineRefundChainId(sampleDepositData, sampleDepositData.amount)).to.equal(42161);
     expect(lastSpyLogIncludes(spy, `chainShortfall":"15000000000000000000"`)).to.be.true;
     expect(lastSpyLogIncludes(spy, `chainVirtualBalance":"24800000000000000000"`)).to.be.true; // (10+14.8)=24.8
     expect(lastSpyLogIncludes(spy, `chainVirtualBalanceWithShortfall":"9800000000000000000"`)).to.be.true; // 24.8-15=9.8
@@ -164,7 +164,7 @@ describe("InventoryClient: Refund chain selection", async function () {
     // post relay is 9.8 - 5 = 4.8. cumulative virtual balance with shortfall post relay is 125 - 5 = 120. Expected post
     // relay allocation is 4.8/120 = 0.04. This is below the threshold of 0.05 so the bot should refund on the target.
     sampleDepositData.amount = toWei(5);
-    expect(inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(42161);
+    expect(inventoryClient.determineRefundChainId(sampleDepositData, sampleDepositData.amount)).to.equal(42161);
     // Check only the final step in the computation.
     expect(lastSpyLogIncludes(spy, `expectedPostRelayAllocation":"40000000000000000"`)).to.be.true; // 4.8/120 = 0.04
 
@@ -175,7 +175,7 @@ describe("InventoryClient: Refund chain selection", async function () {
     // post relay is 125 - 5 + 10 = 130. Expected post relay allocation is 14.8/130 = 0.11. This is above the threshold
     // of 0.05 so the bot should refund on L1.
     tokenClient.setTokenData(42161, l2TokensForWeth[42161], initialAllocation[42161][mainnetWeth].add(toWei(10)));
-    expect(inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(1);
+    expect(inventoryClient.determineRefundChainId(sampleDepositData, sampleDepositData.amount)).to.equal(1);
   });
 
   it("Correctly decides where to refund based on upcoming refunds", async function () {
@@ -192,7 +192,7 @@ describe("InventoryClient: Refund chain selection", async function () {
     bundleDataClient.setReturnedNextBundleRefunds({
       10: createRefunds(5, l2TokensForWeth[10]),
     });
-    expect(inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(1);
+    expect(inventoryClient.determineRefundChainId(sampleDepositData, sampleDepositData.amount)).to.equal(1);
     expect(lastSpyLogIncludes(spy, `expectedPostRelayAllocation":"166666666666666666"`)).to.be.true; // (20-5)/(140-5)=0.11
   });
 });

--- a/test/Relayer.PartialFill.ts
+++ b/test/Relayer.PartialFill.ts
@@ -1,0 +1,221 @@
+import {
+  expect,
+  deposit,
+  ethers,
+  Contract,
+  SignerWithAddress,
+  setupTokensForWallet,
+  getLastBlockTime,
+  lastSpyLogIncludes,
+} from "./utils";
+import { createSpyLogger, deployConfigStore, deployAndConfigureHubPool, winston } from "./utils";
+import { deploySpokePoolWithToken, enableRoutesOnHubPool, destinationChainId, spyLogIncludes } from "./utils";
+import { originChainId, sinon, toBNWei } from "./utils";
+import { amountToLp, defaultTokenConfig, amountToDeposit } from "./constants";
+import { SpokePoolClient, HubPoolClient, AcrossConfigStoreClient, MultiCallerClient } from "../src/clients";
+import { TokenClient, ProfitClient } from "../src/clients";
+import { MockInventoryClient } from "./mocks";
+
+import { Relayer } from "../src/relayer/Relayer"; // Tested
+import { toBN } from "../src/utils";
+
+let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
+let hubPool: Contract, configStore: Contract, l1Token: Contract;
+let owner: SignerWithAddress, depositor: SignerWithAddress, relayer: SignerWithAddress;
+let spy: sinon.SinonSpy, spyLogger: winston.Logger;
+
+let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
+let configStoreClient: AcrossConfigStoreClient, hubPoolClient: HubPoolClient, tokenClient: TokenClient;
+let relayerInstance: Relayer;
+let multiCallerClient: MultiCallerClient, profitClient: ProfitClient, inventoryClient: MockInventoryClient;
+
+describe("Relayer: Partial fills", async function () {
+  beforeEach(async function () {
+    [owner, depositor, relayer] = await ethers.getSigners();
+    ({ spokePool: spokePool_1, erc20: erc20_1 } = await deploySpokePoolWithToken(originChainId, destinationChainId));
+    ({ spokePool: spokePool_2, erc20: erc20_2 } = await deploySpokePoolWithToken(destinationChainId, originChainId));
+    ({ hubPool, l1Token_1: l1Token } = await deployAndConfigureHubPool(owner, [
+      { l2ChainId: destinationChainId, spokePool: spokePool_2 },
+    ]));
+
+    await enableRoutesOnHubPool(hubPool, [
+      { destinationChainId: originChainId, l1Token, destinationToken: erc20_1 },
+      { destinationChainId: destinationChainId, l1Token, destinationToken: erc20_2 },
+    ]);
+
+    ({ spy, spyLogger } = createSpyLogger());
+    ({ configStore } = await deployConfigStore(owner, [l1Token]));
+    hubPoolClient = new HubPoolClient(spyLogger, hubPool);
+    configStoreClient = new AcrossConfigStoreClient(spyLogger, configStore, hubPoolClient);
+
+    multiCallerClient = new MultiCallerClient(spyLogger, null); // leave out the gasEstimator for now.
+
+    spokePoolClient_1 = new SpokePoolClient(spyLogger, spokePool_1.connect(relayer), configStoreClient, originChainId);
+    spokePoolClient_2 = new SpokePoolClient(
+      spyLogger,
+      spokePool_2.connect(relayer),
+      configStoreClient,
+      destinationChainId
+    );
+    const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
+    tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
+    profitClient = new ProfitClient(spyLogger, hubPoolClient, toBNWei(1)); // Set relayer discount to 100%.
+    inventoryClient = new MockInventoryClient();
+    relayerInstance = new Relayer(spyLogger, {
+      spokePoolClients,
+      hubPoolClient,
+      configStoreClient,
+      tokenClient,
+      profitClient,
+      multiCallerClient,
+      inventoryClient,
+    });
+
+    await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // Seed owner to LP.
+    await setupTokensForWallet(spokePool_1, depositor, [erc20_1], null, 10);
+    await setupTokensForWallet(spokePool_2, depositor, [erc20_2], null, 10);
+    await setupTokensForWallet(spokePool_1, relayer, [erc20_1, erc20_2], null, 10);
+    await setupTokensForWallet(spokePool_2, relayer, [erc20_1, erc20_2], null, 10);
+
+    await l1Token.approve(hubPool.address, amountToLp);
+    await hubPool.addLiquidity(l1Token.address, amountToLp);
+    await configStore.updateTokenConfig(l1Token.address, defaultTokenConfig);
+
+    await updateAllClients();
+  });
+
+  // Unfilled amount <= partial fill threshold: sends either 100% fill or 1 wei fill
+  // Unfilled amount > partial fill threshold:
+  //     - If unfilled amount > partial fill amount, then send partial fill and record shortfall. Run again and test that no other fills are sent.
+  //     - If unfilled amount <= partial fill amount, then we can just fill rest of deposit
+  it("Partial fill amount is non 0 and < unfilled amount", async function () {
+    // Unfilled amount > partial fill amount, so there is a shortfall and relayer will partially fill relay.
+    inventoryClient.setPartialFillAmount(amountToDeposit.div(4));
+    await spokePool_1.setCurrentTime(await getLastBlockTime(spokePool_1.provider));
+    const deposit1 = await deposit(
+      spokePool_1,
+      erc20_1,
+      depositor,
+      depositor,
+      destinationChainId,
+      amountToDeposit // Needs to be >= partial fill amount we set above
+    );
+    await updateAllClients();
+    const startingRelayerBalance = await erc20_2.balanceOf(relayer.address);
+    await relayerInstance.checkForUnfilledDepositsAndFill();
+
+    expect(spyLogIncludes(spy, -2, "Partially filling")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "Insufficient balance to fill all deposits")).to.be.true;
+    expect(multiCallerClient.transactionCount()).to.equal(1);
+
+    const tx = await multiCallerClient.executeTransactionQueue();
+    expect(tx.length).to.equal(1); // There should have been exactly one transaction.
+
+    // Check the state change happened correctly on the smart contract. There should be exactly one fill on spokePool_2.
+    const fillEvents2 = await spokePool_2.queryFilter(spokePool_2.filters.FilledRelay());
+    expect(fillEvents2.length).to.equal(1);
+    expect(fillEvents2[0].args.depositId).to.equal(deposit1.depositId);
+    expect(fillEvents2[0].args.amount).to.equal(deposit1.amount);
+    expect(fillEvents2[0].args.fillAmount).to.equal("27803583276807944721");
+    // Partial fill amount returned by inventory client, which should be a bit more than the actual amount sent.
+    expect(fillEvents2[0].args.destinationChainId).to.equal(Number(deposit1.destinationChainId));
+    expect(fillEvents2[0].args.originChainId).to.equal(Number(deposit1.originChainId));
+    expect(fillEvents2[0].args.relayerFeePct).to.equal(deposit1.relayerFeePct);
+    expect(fillEvents2[0].args.depositor).to.equal(deposit1.depositor);
+    expect(fillEvents2[0].args.recipient).to.equal(deposit1.recipient);
+
+    // Expect a shortfall:
+    expect(tokenClient.getTokenShortfall()).to.deep.equal({
+      [destinationChainId]: {
+        [erc20_2.address]: {
+          deposits: [0],
+          balance: startingRelayerBalance.sub(amountToDeposit.div(4)),
+          needed: amountToDeposit.sub(amountToDeposit.div(4)),
+          shortfall: amountToDeposit
+            .sub(amountToDeposit.div(4))
+            .sub(startingRelayerBalance.sub(amountToDeposit.div(4))),
+        },
+      },
+    });
+
+    // Re-run the execution loop and validate that no additional relays are sent.
+    multiCallerClient.clearTransactionQueue();
+    await Promise.all([spokePoolClient_1.update(), spokePoolClient_2.update(), hubPoolClient.update()]);
+    await relayerInstance.checkForUnfilledDepositsAndFill();
+    expect(multiCallerClient.transactionCount()).to.equal(0);
+  });
+  it("Partial fill amount is non 0 and >= unfilled amount", async function () {
+    // Unfilled amount <= partial fill amount, send full relay
+    inventoryClient.setPartialFillAmount(amountToDeposit);
+    await spokePool_1.setCurrentTime(await getLastBlockTime(spokePool_1.provider));
+    const deposit1 = await deposit(
+      spokePool_1,
+      erc20_1,
+      depositor,
+      depositor,
+      destinationChainId,
+      amountToDeposit // Needs to be >= partial fill amount we set above
+    );
+    await updateAllClients();
+    await relayerInstance.checkForUnfilledDepositsAndFill();
+
+    expect(spyLogIncludes(spy, -1, "Filling deposit")).to.be.true;
+    expect(multiCallerClient.transactionCount()).to.equal(1);
+
+    const tx = await multiCallerClient.executeTransactionQueue();
+    expect(tx.length).to.equal(1); // There should have been exactly one transaction.
+
+    // Check the state change happened correctly on the smart contract. There should be exactly one fill on spokePool_2.
+    const fillEvents2 = await spokePool_2.queryFilter(spokePool_2.filters.FilledRelay());
+    expect(fillEvents2.length).to.equal(1);
+    expect(fillEvents2[0].args.depositId).to.equal(deposit1.depositId);
+    expect(fillEvents2[0].args.amount).to.equal(deposit1.amount);
+    expect(fillEvents2[0].args.fillAmount).to.equal(deposit1.amount);
+    expect(fillEvents2[0].args.destinationChainId).to.equal(Number(deposit1.destinationChainId));
+    expect(fillEvents2[0].args.originChainId).to.equal(Number(deposit1.originChainId));
+    expect(fillEvents2[0].args.relayerFeePct).to.equal(deposit1.relayerFeePct);
+    expect(fillEvents2[0].args.depositor).to.equal(deposit1.depositor);
+    expect(fillEvents2[0].args.recipient).to.equal(deposit1.recipient);
+  });
+  it("Partial fill is 0", async function () {
+    // send full relay if balance can full amount
+    inventoryClient.setPartialFillAmount(toBN(0));
+    await spokePool_1.setCurrentTime(await getLastBlockTime(spokePool_1.provider));
+    const deposit1 = await deposit(
+      spokePool_1,
+      erc20_1,
+      depositor,
+      depositor,
+      destinationChainId,
+      amountToDeposit // Needs to be >= partial fill amount we set above
+    );
+    await updateAllClients();
+    await relayerInstance.checkForUnfilledDepositsAndFill();
+
+    expect(spyLogIncludes(spy, -1, "Filling deposit")).to.be.true;
+    expect(multiCallerClient.transactionCount()).to.equal(1);
+
+    const tx = await multiCallerClient.executeTransactionQueue();
+    expect(tx.length).to.equal(1); // There should have been exactly one transaction.
+
+    // Check the state change happened correctly on the smart contract. There should be exactly one fill on spokePool_2.
+    const fillEvents2 = await spokePool_2.queryFilter(spokePool_2.filters.FilledRelay());
+    expect(fillEvents2.length).to.equal(1);
+    expect(fillEvents2[0].args.depositId).to.equal(deposit1.depositId);
+    expect(fillEvents2[0].args.amount).to.equal(deposit1.amount);
+    expect(fillEvents2[0].args.fillAmount).to.equal(deposit1.amount);
+    expect(fillEvents2[0].args.destinationChainId).to.equal(Number(deposit1.destinationChainId));
+    expect(fillEvents2[0].args.originChainId).to.equal(Number(deposit1.originChainId));
+    expect(fillEvents2[0].args.relayerFeePct).to.equal(deposit1.relayerFeePct);
+    expect(fillEvents2[0].args.depositor).to.equal(deposit1.depositor);
+    expect(fillEvents2[0].args.recipient).to.equal(deposit1.recipient);
+  });
+});
+
+async function updateAllClients() {
+  await hubPoolClient.update();
+  await configStoreClient.update();
+  await tokenClient.update();
+  await spokePoolClient_1.update();
+  await spokePoolClient_2.update();
+}

--- a/test/mocks/MockInventoryClient.ts
+++ b/test/mocks/MockInventoryClient.ts
@@ -1,10 +1,22 @@
 import { Deposit } from "../../src/interfaces";
 import { InventoryClient } from "../../src/clients";
+import { BigNumber, toBN } from "../utils";
 export class MockInventoryClient extends InventoryClient {
+  partialFillAmount: BigNumber;
   constructor() {
     super(null, null, null, null, null, null, null, null);
+    this.partialFillAmount = toBN(0);
   }
+
   determineRefundChainId(deposit: Deposit) {
     return 1;
+  }
+
+  setPartialFillAmount(amount: BigNumber) {
+    this.partialFillAmount = amount;
+  }
+
+  getPartialFillAmount(deposit: Deposit, unfilledAmount: BigNumber) {
+    return this.partialFillAmount;
   }
 }


### PR DESCRIPTION
Implements a pretty simple partial fill logic that is easily backwards compatible:
- Two new config variables: "partialFillThresholdPct" and "partialFillAmountPct"
- If relayer's current allocation % for a chain (including the deposit's unfilled amount in question) falls below `partialFillThresholdPct`, then we should partial fill
- The partial fill amount is `partialFillAmountPct * relayer's current balance`.

In plain english: the goal of this strategy is to be enable the relayer to earn some relayer fees on any deposits that are much larger than its current balance. For example,
if the relayer has 10 WETH and there is a deposit of 200 WETH, currently the relayer will "1 wei" fill it earning no fees. This strategy could allow the relayer
to detect this 200 WETH deposit as a partial fill candidate, and then send, for example, 50% of 10WETH = 5 WETH as a partial fill. The relayer could set `partialFillThresholdPct = 1` and `partialFillAmountPct = 0.25` in this example to tell the bot to ALWAYS try to partial fill if it can't fully fill, and always use up to 25% of its balance.

The backwards compatible way of using this config is to set `partialFillThresholdPct = 0`, which instructs the bot: "never partially fill deposits since the current allocation for this chain can never fall below 0"

Signed-off-by: nicholaspai <npai.nyc@gmail.com>
