### PR TITLE
fix: correctly pass back provider errors when all providers fail

### DIFF
--- a/src/utils/TypeGuards.ts
+++ b/src/utils/TypeGuards.ts
@@ -3,3 +3,9 @@ export function isPromiseFulfulled<T>(
 ): promiseSettledResult is PromiseFulfilledResult<T> {
   return promiseSettledResult.status === "fulfilled";
 }
+
+export function isPromiseRejected<T>(
+  promiseSettledResult: PromiseSettledResult<T>
+): promiseSettledResult is PromiseRejectedResult {
+  return promiseSettledResult.status === "rejected";
+}


### PR DESCRIPTION
In the case where not enough providers succeed, this PR includes all error data from one of the errors so ethers can decode the information returned by the contract.

In the cases where the quorum is not met despite enough successful providers, this _does not_ change the behavior. In those cases, the assumption is that the error is primarily related to quorum and not related to an on-chain revert message.