### PR TITLE
fix: fix error in eth funding transaction

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -130,7 +130,7 @@ export class MultiCallerClient {
           const result = await runTransaction(
             this.logger,
             transaction.contract,
-            "multicall",
+            transaction.method,
             transaction.args,
             transaction.value
           );


### PR DESCRIPTION
Right now, the bot is set up to pre-fund the hub pool with ETH for the arbitrum calls that it's about to make. However, this transaction is reverting due to a typo in the MulticallerClient. This was not caught in the tests because this error is caught and logged, so the tests don't see it as an error.