### PR TITLE
fix: Add cushion to enable MAX_RELAYER_DEPOSIT_LOOK_BACK to work

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -126,10 +126,10 @@ export class MultiCallerClient {
           mrkdwn += `*Transaction excluded from batches because it contained value:*\n`;
           mrkdwn += `  ${i + 1}. ${transaction.message || "0 message"}: ` + `${transaction.mrkdwn || "0 mrkdwn"}\n`;
         });
-        Object.keys(groupedTransactions).forEach((chainId) => {
+        Object.keys(chunkedTransactions).forEach((chainId) => {
           mrkdwn += `*Transactions sent in batch on ${getNetworkName(chainId)}:*\n`;
-          groupedTransactions[chainId].forEach((transactionChunks, groupIndex) => {
-            transactionChunks.forEach((transaction, chunkTxIndex) => {
+          chunkedTransactions[chainId].forEach((chunk, groupIndex) => {
+            chunk.forEach((transaction, chunkTxIndex) => {
               mrkdwn +=
                 `  ${groupIndex + 1}-${chunkTxIndex + 1}. ${transaction.message || "0 message"}: ` +
                 `${transaction.mrkdwn || "0 mrkdwn"}\n`;
@@ -204,7 +204,7 @@ export class MultiCallerClient {
         }
       });
       let flatIndex = 0;
-      Object.keys(chunkedTransactions).forEach((chainId, chainIndex) => {
+      Object.keys(chunkedTransactions).forEach((chainId) => {
         mrkdwn += `*Transactions sent in batch on ${getNetworkName(chainId)}:*\n`;
         chunkedTransactions[chainId].forEach((chunk, chunkIndex) => {
           const settledPromise = multiCallTransactionsResult[flatIndex++];

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -2,7 +2,7 @@ import { BigNumber, winston, buildFillRelayProps, getNetworkName, getUnfilledDep
 import { createFormatFunction, etherscanLink, toBN } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
 
-import { Deposit, DepositWithBlock } from "../interfaces/SpokePool";
+import { Deposit } from "../interfaces/SpokePool";
 
 export class Relayer {
   constructor(

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -117,18 +117,26 @@ export class Relayer {
         // validates that the deposit is filled "correctly" for the given deposit information. This includes validation
         // of the all deposit -> relay props, the realizedLpFeePct and the origin->destination token mapping.
         const destinationClient = this.clients.spokePoolClients[destinationChain];
-        const depositsForDestinationChain: DepositWithBlock[] = originClient.getDepositsForDestinationChain(destinationChain, true);
-        const unfilledDepositsForDestinationChain: { fillCount: number; unfilledAmount: BigNumber; deposit: DepositWithBlock }[] = depositsForDestinationChain.map((deposit) => {
+        const depositsForDestinationChain: DepositWithBlock[] = originClient.getDepositsForDestinationChain(
+          destinationChain,
+          true
+        );
+        const unfilledDepositsForDestinationChain: {
+          fillCount: number;
+          unfilledAmount: BigNumber;
+          deposit: DepositWithBlock;
+        }[] = depositsForDestinationChain.map((deposit) => {
           return { ...destinationClient.getValidUnfilledAmountForDeposit(deposit), deposit };
         });
         // Remove any deposits that have no unfilled amount and append the remaining deposits to unfilledDeposits array.
-        unfilledDeposits.push(...unfilledDepositsForDestinationChain.filter((deposit) => {
-          // If deposit is older than unfilled deposit lookback, ignore it
-          const lookback = this.maxUnfilledDepositLookBack[deposit.deposit.originChainId]
-          const latestBlockForOriginChain = originClient.latestBlockNumber;
-          if (lookback && deposit.deposit.blockNumber < latestBlockForOriginChain - lookback) return false;
-          return deposit.unfilledAmount.gt(0)
-        })
+        unfilledDeposits.push(
+          ...unfilledDepositsForDestinationChain.filter((deposit) => {
+            // If deposit is older than unfilled deposit lookback, ignore it
+            const lookback = this.maxUnfilledDepositLookBack[deposit.deposit.originChainId];
+            const latestBlockForOriginChain = originClient.latestBlockNumber;
+            if (lookback && deposit.deposit.blockNumber < latestBlockForOriginChain - lookback) return false;
+            return deposit.unfilledAmount.gt(0);
+          })
         );
       }
     }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -15,8 +15,9 @@ export class Relayer {
     // Fetch all unfilled deposits, order by total earnable fee.
     // TODO: Note this does not consider the price of the token which will be added once the profitability module is
     // added to this bot.
-    const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients).sort((a, b) =>
-      a.unfilledAmount.mul(a.deposit.relayerFeePct).lt(b.unfilledAmount.mul(b.deposit.relayerFeePct)) ? 1 : -1
+    const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.maxUnfilledDepositLookBack).sort(
+      (a, b) =>
+        a.unfilledAmount.mul(a.deposit.relayerFeePct).lt(b.unfilledAmount.mul(b.deposit.relayerFeePct)) ? 1 : -1
     );
     if (unfilledDeposits.length > 0)
       this.logger.debug({ at: "Relayer", message: "Filling deposits", number: unfilledDeposits.length });
@@ -102,53 +103,6 @@ export class Relayer {
         notificationPath: "across-error",
       });
     }
-  }
-
-  // Returns all unfilled deposits over all spokePoolClients. Return values include the amount of the unfilled deposit.
-  getUnfilledDeposits(): { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number }[] {
-    let unfilledDeposits: { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number }[] = [];
-    // Iterate over each chainId and check for unfilled deposits.
-    const chainIds = Object.keys(this.clients.spokePoolClients);
-    for (const originChain of chainIds) {
-      const originClient = this.clients.spokePoolClients[originChain];
-      for (const destinationChain of chainIds) {
-        if (originChain === destinationChain) continue;
-        // Find all unfilled deposits for the current loops originChain -> destinationChain. Note that this also
-        // validates that the deposit is filled "correctly" for the given deposit information. This includes validation
-        // of the all deposit -> relay props, the realizedLpFeePct and the origin->destination token mapping.
-        const destinationClient = this.clients.spokePoolClients[destinationChain];
-        const depositsForDestinationChain: DepositWithBlock[] = originClient.getDepositsForDestinationChain(
-          destinationChain,
-          true
-        );
-        console.log(`!!!Fetching unfilledDepositsForDestinationChain`)
-        const unfilledDepositsForDestinationChain: {
-          fillCount: number;
-          unfilledAmount: BigNumber;
-          deposit: DepositWithBlock;
-        }[] = depositsForDestinationChain
-          .filter((deposit) => {
-            // If deposit is older than unfilled deposit lookback, ignore it
-            const lookback = this.maxUnfilledDepositLookBack[deposit.originChainId];
-            const latestBlockForOriginChain = originClient.latestBlockNumber;
-            console.log(lookback, latestBlockForOriginChain, originChain, deposit.blockNumber)
-            if (lookback && deposit.blockNumber < latestBlockForOriginChain - lookback) return false;
-            return true;
-          })
-          .map((deposit) => {
-            return { ...destinationClient.getValidUnfilledAmountForDeposit(deposit), deposit };
-          })
-        
-        // Remove any deposits that have no unfilled amount and append the remaining deposits to unfilledDeposits array.
-        unfilledDeposits.push(
-          ...unfilledDepositsForDestinationChain.filter((deposit) => {
-            return deposit.unfilledAmount.gt(0);
-          })
-        );
-      }
-    }
-
-    return unfilledDeposits;
   }
 
   private handleTokenShortfall() {

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -23,7 +23,7 @@ export class RelayerConfig extends CommonConfig {
     // amount of time looking back on the chains, so you might produce some deposits that look like they weren't filled.
     this.maxRelayerUnfilledDepositLookBack = { ...this.maxRelayerLookBack };
     Object.keys(this.maxRelayerUnfilledDepositLookBack).forEach((chain) => {
-      this.maxRelayerUnfilledDepositLookBack[chain] = Number(this.maxRelayerLookBack[chain]) / 2; // TODO: Allow caller
+      this.maxRelayerUnfilledDepositLookBack[chain] = Number(this.maxRelayerLookBack[chain]) / 4; // TODO: Allow caller
       // to modify what we divide `maxRelayerLookBack` values by.
     });
 

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -4,6 +4,7 @@ import { InventoryConfig } from "../interfaces";
 
 export class RelayerConfig extends CommonConfig {
   readonly maxRelayerLookBack: { [chainId: number]: number };
+  readonly maxRelayerUnfilledDepositLookBack: { [chainId: number]: number };
   readonly inventoryConfig: InventoryConfig;
   readonly relayerDiscount: BigNumber;
   readonly sendingRelaysEnabled: Boolean;
@@ -13,7 +14,19 @@ export class RelayerConfig extends CommonConfig {
     const { RELAYER_DISCOUNT, MAX_RELAYER_DEPOSIT_LOOK_BACK, RELAYER_INVENTORY_CONFIG, SEND_RELAYS, SEND_SLOW_RELAYS } =
       env;
     super(env);
+
+    // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
     this.maxRelayerLookBack = MAX_RELAYER_DEPOSIT_LOOK_BACK ? JSON.parse(MAX_RELAYER_DEPOSIT_LOOK_BACK) : {};
+    // `maxRelayerUnfilledDepositLookBack` informs relayer to ignore any unfilled deposits older than this amount of
+    // of blocks from latest. This allows us to ignore any false positive unfilled deposits that occur because of how
+    // `maxRelayerLookBack` is set. This can happen because block lookback per chain is not exactly equal to the same
+    // amount of time looking back on the chains, so you might produce some deposits that look like they weren't filled.
+    this.maxRelayerUnfilledDepositLookBack = { ...this.maxRelayerLookBack }
+    Object.keys(this.maxRelayerUnfilledDepositLookBack).forEach((chain) => {
+      this.maxRelayerUnfilledDepositLookBack[chain] = Number(this.maxRelayerLookBack[chain]) / 2; // TODO: Allow caller
+      // to modify what we divide `maxRelayerLookBack` values by.
+    });
+
     this.inventoryConfig = RELAYER_INVENTORY_CONFIG ? JSON.parse(RELAYER_INVENTORY_CONFIG) : {};
 
     if (Object.keys(this.inventoryConfig).length > 0) {

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -21,7 +21,7 @@ export class RelayerConfig extends CommonConfig {
     // of blocks from latest. This allows us to ignore any false positive unfilled deposits that occur because of how
     // `maxRelayerLookBack` is set. This can happen because block lookback per chain is not exactly equal to the same
     // amount of time looking back on the chains, so you might produce some deposits that look like they weren't filled.
-    this.maxRelayerUnfilledDepositLookBack = { ...this.maxRelayerLookBack }
+    this.maxRelayerUnfilledDepositLookBack = { ...this.maxRelayerLookBack };
     Object.keys(this.maxRelayerUnfilledDepositLookBack).forEach((chain) => {
       this.maxRelayerUnfilledDepositLookBack[chain] = Number(this.maxRelayerLookBack[chain]) / 2; // TODO: Allow caller
       // to modify what we divide `maxRelayerLookBack` values by.

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -13,7 +13,7 @@ export async function runRelayer(_logger: winston.Logger): Promise<void> {
 
     const relayerClients = await constructRelayerClients(logger, config);
 
-    const relayer = new Relayer(logger, relayerClients);
+    const relayer = new Relayer(logger, relayerClients, config.maxRelayerUnfilledDepositLookBack);
 
     logger.debug({ at: "Relayer#index", message: "Relayer components initialized. Starting execution loop" });
 

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -175,7 +175,9 @@ export function getUnfilledDeposits(
           return lookback === undefined || deposit.originBlockNumber >= latestBlockForOriginChain - lookback;
         })
         .map((deposit) => {
-          return { ...destinationClient.getValidUnfilledAmountForDeposit(deposit), deposit };
+          // Remove block number that we don't need anymore and because function expects to return a Deposit type.
+          const { blockNumber, originBlockNumber, ...depositData } = deposit;
+          return { ...destinationClient.getValidUnfilledAmountForDeposit(deposit), deposit: depositData };
         });
       // Remove any deposits that have no unfilled amount and append the remaining deposits to unfilledDeposits array.
       unfilledDeposits.push(...unfilledDepositsForDestinationChain.filter((deposit) => deposit.unfilledAmount.gt(0)));

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -172,7 +172,7 @@ export function getUnfilledDeposits(
           // If deposit is older than unfilled deposit lookback, ignore it
           const lookback = maxUnfilledDepositLookBack[deposit.originChainId];
           const latestBlockForOriginChain = originClient.latestBlockNumber;
-          return lookback !== undefined || deposit.originBlockNumber >= latestBlockForOriginChain - lookback;
+          return lookback === undefined || deposit.originBlockNumber >= latestBlockForOriginChain - lookback;
         })
         .map((deposit) => {
           return { ...destinationClient.getValidUnfilledAmountForDeposit(deposit), deposit };

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -172,8 +172,7 @@ export function getUnfilledDeposits(
           // If deposit is older than unfilled deposit lookback, ignore it
           const lookback = maxUnfilledDepositLookBack[deposit.originChainId];
           const latestBlockForOriginChain = originClient.latestBlockNumber;
-          if (lookback !== undefined && deposit.originBlockNumber < latestBlockForOriginChain - lookback) return false;
-          return true;
+          return lookback !== undefined || deposit.originBlockNumber >= latestBlockForOriginChain - lookback;
         })
         .map((deposit) => {
           return { ...destinationClient.getValidUnfilledAmountForDeposit(deposit), deposit };


### PR DESCRIPTION
MAX_RELAYER_DEPOSIT_LOOK_BACK sets how far we look events up from, but this is a fixed number of blocks per chain, not a fixed number of time per chain. So, assuming the block lookback !== time lookback, there will be some false positive unfilled deposits seen by the relayer. Imagine a deposit on a chain that looks back 2 hours is filled by a relay on a destination chain that only looks back 1 hour, the relayer will think that deposit is unfilled when in fact it is.

This PR adds a cushion to the relayer to throw away any unfilled deposits older than half the block length of the `MAX_RELAYER_DEPOSIT_LOOK_BACK` value. This is a bit hacky but it works empirically for now and will allow us to speed up the bot a lot by limiting its lookback