### PR TITLE
Limit lookback

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -253,6 +253,16 @@ export class HubPoolClient {
     });
   }
 
+  // Return the nth fully executed bundle from the last.
+  getNthToLastFullyExecutedRootBundle(index: number, latestMainnetBlock: number): ProposedRootBundle | undefined {
+    const fullyExecutedBundles = sortEventsDescending(this.proposedRootBundles).filter(
+      (rootBundle: ProposedRootBundle) => {
+        return this.isRootBundleValid(rootBundle, latestMainnetBlock);
+      }
+    );
+    return fullyExecutedBundles[index];
+  }
+
   getNextBundleStartBlockNumber(chainIdList: number[], latestMainnetBlock: number, chainId: number): number {
     const latestFullyExecutedPoolRebalanceRoot = this.getLatestFullyExecutedRootBundle(latestMainnetBlock);
 

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -14,7 +14,7 @@ export class CommonConfig {
   readonly maxTxWait: number;
   readonly sendingTransactionsEnabled: boolean;
   readonly redisUrl: string | undefined;
-  readonly bundleRefundLookback: number;
+  readonly bundleLookback: number;
 
   constructor(env: ProcessEnv) {
     const {
@@ -26,7 +26,7 @@ export class CommonConfig {
       MAX_TX_WAIT_DURATION,
       SEND_TRANSACTIONS,
       REDIS_URL,
-      BUNDLE_REFUND_LOOKBACK,
+      BUNDLE_LOOKBACK,
     } = env;
     this.hubPoolChainId = HUB_CHAIN_ID ? Number(HUB_CHAIN_ID) : 1;
     this.spokePoolChains = CONFIGURED_NETWORKS ? JSON.parse(CONFIGURED_NETWORKS) : Constants.CHAIN_ID_LIST_INDICES;
@@ -40,6 +40,6 @@ export class CommonConfig {
     this.maxTxWait = MAX_TX_WAIT_DURATION ? Number(MAX_TX_WAIT_DURATION) : 180; // 3 minutes
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
     this.redisUrl = REDIS_URL;
-    this.bundleRefundLookback = BUNDLE_REFUND_LOOKBACK ? Number(BUNDLE_REFUND_LOOKBACK) : 2;
+    this.bundleLookback = BUNDLE_LOOKBACK ? Number(BUNDLE_LOOKBACK) : 2;
   }
 }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -310,7 +310,7 @@ export class Monitor {
 
   updateLatestAndFutureRelayerRefunds(relayerBalanceReport: RelayerBalanceReport) {
     const validatedBundleRefunds: FillsToRefund[] = this.clients.bundleDataClient.getPendingRefundsFromValidBundles(
-      this.monitorConfig.bundleRefundLookback
+      this.monitorConfig.bundleLookback
     );
     const nextBundleRefunds = this.clients.bundleDataClient.getNextBundleRefunds();
 

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -20,12 +20,8 @@ export interface MonitorClients extends Clients {
 export async function constructMonitorClients(config: MonitorConfig, logger: winston.Logger): Promise<MonitorClients> {
   const baseSigner = await getSigner(); // todo: add getVoidSigner
   const commonClients = await constructClients(logger, config);
-  const spokePoolClients = await constructSpokePoolClientsWithLookback(
-    logger,
-    commonClients.configStoreClient,
-    config,
-    baseSigner
-  );
+  await commonClients.hubPoolClient.update();
+  const spokePoolClients = await constructSpokePoolClientsWithLookback(logger, commonClients, config, baseSigner);
   const bundleDataClient = new BundleDataClient(logger, commonClients, spokePoolClients, config.spokePoolChains);
 
   // Need to update HubPoolClient to get latest tokens.

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -17,14 +17,9 @@ export async function constructRelayerClients(logger: winston.Logger, config: Re
   const baseSigner = await getSigner();
 
   const commonClients = await constructClients(logger, config);
+  await commonClients.hubPoolClient.update();
 
-  const spokePoolClients = await constructSpokePoolClientsWithLookback(
-    logger,
-    commonClients.configStoreClient,
-    config,
-    baseSigner,
-    config.maxRelayerLookBack
-  );
+  const spokePoolClients = await constructSpokePoolClientsWithLookback(logger, commonClients, config, baseSigner);
 
   const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);
 
@@ -42,7 +37,7 @@ export async function constructRelayerClients(logger: winston.Logger, config: Re
     commonClients.hubPoolClient,
     bundleDataClient,
     adapterManager,
-    config.bundleRefundLookback
+    config.bundleLookback
   );
 
   return { ...commonClients, spokePoolClients, tokenClient, profitClient, inventoryClient };

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -75,6 +75,7 @@ describe("Monitor", async function () {
       MONITOR_REPORT_INTERVAL: "10",
       MONITORED_RELAYERS: `["${depositor.address}"]`,
       CONFIGURED_NETWORKS: `[1, ${repaymentChainId}, ${originChainId}, ${destinationChainId}]`,
+      BUNDLE_LOOKBACK: "1",
     });
 
     bundleDataClient = new BundleDataClient(


### PR DESCRIPTION
## Context:

All bots currently always load all deposits/fills events since the beginning of time. This makes them really slow, especially during the first few runs when the redis cache has not caught up. Even when caching kicks in, the bots always have to process all events, which is very slow. There are two options:
1. We can allow configuring the number of blocks to look back, similar to MAX_RELAYER_LOOKBACK. However this can lead to problems in areas where bundle boundaries need to be respected. For example refund calculation where we compare the refunds in a bundle with executed leave refunds because we could have missed fills due to the arbitrary block cutoff.
2. Look at the nth to last fully executed bundles and only fetch deposits and fills since then. This is the cleanest approach as it respects bundle boundaries and would not lead to missing deposits/fills that can result in problems.

## Solution
This PR goes with approach (2). It reuses the bundle lookback already used to calculate refunds in the monitor and relayer bots to limit the lookback window of SpokePoolClients.

## Testing
1. Unit test coverage
2. Running in simulation mode in a VM instance. Empirically this has visibly sped up the relayer bot.

