### PR TITLE
feat: Reduce number of events searched per bot

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { delay, Logger, winston } from "./src/utils";
 import { runRelayer } from "./src/relayer";
 import { runDataworker } from "./src/dataworker";
 import { runMonitor } from "./src/monitor";
+import { runFinalizer } from "./src/finalizer";
 
 let logger: winston.Logger;
 
@@ -10,6 +11,7 @@ export async function run(): Promise<void> {
   logger = Logger;
   if (process.argv.includes("--relayer")) await runRelayer(Logger);
   else if (process.argv.includes("--dataworker")) await runDataworker(Logger);
+  else if (process.argv.includes("--finalizer")) await runFinalizer(Logger);
   else if (process.argv.includes("--monitor")) await runMonitor(Logger);
   else console.log("Select either relayer, dataworker, or monitor to run!");
 }

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -34,7 +34,8 @@ export async function constructSpokePoolClientsForBlockAndUpdate(
   chainIdListForBundleEvaluationBlockNumbers: number[],
   clients: DataworkerClients,
   logger: winston.Logger,
-  latestMainnetBlock: number
+  latestMainnetBlock: number,
+  eventsToQuery?: string[]
 ): Promise<{ [chainId: number]: SpokePoolClient }> {
   const spokePoolClients = Object.fromEntries(
     chainIdListForBundleEvaluationBlockNumbers.map((chainId) => {
@@ -54,7 +55,7 @@ export async function constructSpokePoolClientsForBlockAndUpdate(
       return [chainId, client];
     })
   );
-  await updateSpokePoolClients(spokePoolClients);
+  await updateSpokePoolClients(spokePoolClients, eventsToQuery);
   return spokePoolClients;
 }
 
@@ -110,7 +111,7 @@ export async function constructSpokePoolClientsWithLookback(
 
 export async function updateSpokePoolClients(
   spokePoolClients: { [chainId: number]: SpokePoolClient },
-  eventsToQuery: string[] = []
+  eventsToQuery?: string[]
 ) {
   await Promise.all(Object.values(spokePoolClients).map((client: SpokePoolClient) => client.update(eventsToQuery)));
 }

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -108,8 +108,11 @@ export async function constructSpokePoolClientsWithLookback(
   return spokePoolClients;
 }
 
-export async function updateSpokePoolClients(spokePoolClients: { [chainId: number]: SpokePoolClient }) {
-  await Promise.all(Object.values(spokePoolClients).map((client: SpokePoolClient) => client.update()));
+export async function updateSpokePoolClients(
+  spokePoolClients: { [chainId: number]: SpokePoolClient },
+  eventsToQuery: string[] = []
+) {
+  await Promise.all(Object.values(spokePoolClients).map((client: SpokePoolClient) => client.update(eventsToQuery)));
 }
 
 export async function constructClients(logger: winston.Logger, config: CommonConfig): Promise<Clients> {

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -51,7 +51,15 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
           dataworker.chainIdListForBundleEvaluationBlockNumbers,
           clients,
           logger,
-          clients.hubPoolClient.latestBlockNumber
+          clients.hubPoolClient.latestBlockNumber,
+          [
+            "FundsDeposited",
+            "RequestedSpeedUpDeposit",
+            "FilledRelay",
+            "EnabledDepositRoute",
+            "RelayedRootBundle",
+            "ExecutedRelayerRefundRoot",
+          ]
         );
       else
         await updateSpokePoolClients(spokePoolClients, [

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -1,4 +1,4 @@
-import { processEndPollingLoop, winston, config, startupLogLevel, processCrash, getSigner } from "../utils";
+import { processEndPollingLoop, winston, config, startupLogLevel, processCrash } from "../utils";
 import * as Constants from "../common";
 import { Dataworker } from "./Dataworker";
 import { DataworkerConfig } from "./DataworkerConfig";
@@ -53,7 +53,15 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
           logger,
           clients.hubPoolClient.latestBlockNumber
         );
-      else await updateSpokePoolClients(spokePoolClients);
+      else
+        await updateSpokePoolClients(spokePoolClients, [
+          "FundsDeposited",
+          "RequestedSpeedUpDeposit",
+          "FilledRelay",
+          "EnabledDepositRoute",
+          "RelayedRootBundle",
+          "ExecutedRelayerRefundRoot",
+        ]);
 
       // Validate and dispute pending proposal before proposing a new one
       if (config.disputerEnabled)
@@ -87,10 +95,6 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
       } else logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Executor disabled" });
 
       await clients.multiCallerClient.executeTransactionQueue();
-
-      if (config.finalizerEnabled)
-        await finalize(logger, clients.hubSigner, clients.hubPoolClient, spokePoolClients, config.finalizerChains);
-      else logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Finalizer disabled" });
 
       if (await processEndPollingLoop(logger, "Dataworker", config.pollingDelay)) break;
     }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -15,7 +15,13 @@ import {
 import { SpokePoolClientsByChain } from "../interfaces";
 import { HubPoolClient } from "../clients";
 import { DataworkerConfig } from "../dataworker/DataworkerConfig";
-import { constructClients, constructSpokePoolClientsWithLookback, updateSpokePoolClients, Clients, ProcessEnv } from "../common";
+import {
+  constructClients,
+  constructSpokePoolClientsWithLookback,
+  updateSpokePoolClients,
+  Clients,
+  ProcessEnv,
+} from "../common";
 config();
 let logger: winston.Logger;
 

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -62,7 +62,7 @@ export async function finalize(
       // Unlike the rollups, withdrawals process very quickly on polygon, so we can conservatively remove any events
       // that are older than 1 day old:
       const recentTokensBridgedEvents = tokensBridged.filter(
-        (e) => e.blockNumber > client.latestBlockNumber - polygonFinalizationWindow
+        (e) => e.blockNumber >= client.latestBlockNumber - polygonFinalizationWindow
       );
       const canWithdraw = await getFinalizableTransactions(logger, recentTokensBridgedEvents, posClient, hubPoolClient);
       for (const event of canWithdraw) {

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -15,21 +15,23 @@ import {
 import { SpokePoolClientsByChain } from "../interfaces";
 import { HubPoolClient } from "../clients";
 import { DataworkerConfig } from "../dataworker/DataworkerConfig";
-import {
-  constructClients,
-  constructSpokePoolClientsWithLookback,
-  updateClients,
-  updateSpokePoolClients,
-} from "../common";
+import { constructClients, constructSpokePoolClientsWithLookback, updateSpokePoolClients, Clients, ProcessEnv } from "../common";
 config();
 let logger: winston.Logger;
+
+// Filter for optimistic rollups
+const fiveDaysOfBlocks = 5 * 24 * 60 * 60; // Assuming a slow 1s/block rate for Arbitrum and Optimism.
+// Filter for polygon
+const oneDayOfBlocks = (24 * 60 * 60) / 2; // Assuming 2s/block
 
 export async function finalize(
   logger: winston.Logger,
   hubSigner: Wallet,
   hubPoolClient: HubPoolClient,
   spokePoolClients: SpokePoolClientsByChain,
-  configuredChainIds: number[]
+  configuredChainIds: number[],
+  optimisticRollupFinalizationWindow: number = fiveDaysOfBlocks,
+  polygonFinalizationWindow: number = oneDayOfBlocks
 ): Promise<void> {
   // For each chain, look up any TokensBridged events emitted by SpokePool client that we'll attempt to finalize
   // on L1.
@@ -38,22 +40,45 @@ export async function finalize(
     const tokensBridged = client.getTokensBridged();
 
     if (chainId === 42161) {
-      const finalizableMessages = await getFinalizableMessages(logger, tokensBridged, hubSigner);
+      // Skip events that are definitely not past the seven day challenge period, and those that are really
+      // old and have already been finalized.
+      const olderTokensBridgedEvents = tokensBridged.filter(
+        (e) =>
+          e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow &&
+          e.blockNumber >= client.latestBlockNumber - 2 * optimisticRollupFinalizationWindow
+      );
+      const finalizableMessages = await getFinalizableMessages(logger, olderTokensBridgedEvents, hubSigner);
       for (const l2Message of finalizableMessages) {
         await finalizeArbitrum(logger, l2Message.message, l2Message.proofInfo, l2Message.info, hubPoolClient);
       }
     } else if (chainId === 137) {
       const posClient = await getPosClient(hubSigner);
-      const canWithdraw = await getFinalizableTransactions(logger, tokensBridged, posClient, hubPoolClient);
+      // Unlike the rollups, withdrawals process very quickly on polygon, so we can conservatively remove any events
+      // that are older than 1 day old:
+      const recentTokensBridgedEvents = tokensBridged.filter(
+        (e) => e.blockNumber > client.latestBlockNumber - polygonFinalizationWindow
+      );
+      const canWithdraw = await getFinalizableTransactions(logger, recentTokensBridgedEvents, posClient, hubPoolClient);
       for (const event of canWithdraw) {
         await finalizePolygon(posClient, hubPoolClient, event, logger);
       }
-      for (const l2Token of getL2TokensToFinalize(tokensBridged)) {
+      for (const l2Token of getL2TokensToFinalize(recentTokensBridgedEvents)) {
         await retrieveTokenFromMainnetTokenBridger(logger, l2Token, hubSigner, hubPoolClient);
       }
     } else if (chainId === 10) {
+      // Skip events that are definitely not past the seven day challenge period, and those that are really
+      // old and have already been finalized.
+      const olderTokensBridgedEvents = tokensBridged.filter(
+        (e) =>
+          e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow &&
+          e.blockNumber >= client.latestBlockNumber - 2 * optimisticRollupFinalizationWindow
+      );
       const crossChainMessenger = getOptimismClient(hubSigner);
-      const finalizableMessages = await getOptimismFinalizableMessages(logger, tokensBridged, crossChainMessenger);
+      const finalizableMessages = await getOptimismFinalizableMessages(
+        logger,
+        olderTokensBridgedEvents,
+        crossChainMessenger
+      );
       for (const message of finalizableMessages) {
         await finalizeOptimismMessage(hubPoolClient, crossChainMessenger, message, logger);
       }
@@ -80,10 +105,33 @@ export async function constructFinalizerClients(_logger: winston.Logger, config)
   };
 }
 
+async function updateFinalizerClients(clients: Clients) {
+  await Promise.all([clients.hubPoolClient.update(), clients.configStoreClient.update()]);
+}
+
+export class FinalizerConfig extends DataworkerConfig {
+  readonly optimisticRollupFinalizationWindow: number;
+  readonly polygonFinalizationWindow: number;
+
+  constructor(env: ProcessEnv) {
+    const { FINALIZER_OROLLUP_FINALIZATION_WINDOW, FINALIZER_POLYGON_FINALIZATION_WINDOW } = env;
+    super(env);
+
+    // By default, filters out any TokensBridged events younger than 5 days old and older than 10 days old.
+    this.optimisticRollupFinalizationWindow = FINALIZER_OROLLUP_FINALIZATION_WINDOW
+      ? Number(FINALIZER_OROLLUP_FINALIZATION_WINDOW)
+      : fiveDaysOfBlocks;
+    // By default, filters out any TokensBridged events younger than 1 days old and older than 2 days old.
+    this.polygonFinalizationWindow = FINALIZER_POLYGON_FINALIZATION_WINDOW
+      ? Number(FINALIZER_POLYGON_FINALIZATION_WINDOW)
+      : oneDayOfBlocks;
+  }
+}
+
 export async function runFinalizer(_logger: winston.Logger): Promise<void> {
   logger = _logger;
   // Same config as Dataworker for now.
-  const config = new DataworkerConfig(process.env);
+  const config = new FinalizerConfig(process.env);
 
   const { commonClients, spokePoolClients } = await constructFinalizerClients(logger, config);
 
@@ -91,7 +139,7 @@ export async function runFinalizer(_logger: winston.Logger): Promise<void> {
     logger[startupLogLevel(config)]({ at: "Finalizer#index", message: "Finalizer started 🏋🏿‍♀️", config });
 
     for (;;) {
-      await updateClients(commonClients);
+      await updateFinalizerClients(commonClients);
       await updateSpokePoolClients(spokePoolClients, ["TokensBridged", "EnabledDepositRoute"]);
 
       if (config.finalizerEnabled)
@@ -100,7 +148,9 @@ export async function runFinalizer(_logger: winston.Logger): Promise<void> {
           commonClients.hubSigner,
           commonClients.hubPoolClient,
           spokePoolClients,
-          config.finalizerChains
+          config.finalizerChains,
+          config.optimisticRollupFinalizationWindow,
+          config.polygonFinalizationWindow
         );
       else logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Finalizer disabled" });
 

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -126,13 +126,12 @@ export interface RunningBalances {
   };
 }
 
-export interface TokensBridged {
+export interface TokensBridged extends SortableEvent {
   amountToReturn: BigNumber;
   chainId: number;
   leafId: number;
   l2TokenAddress: string;
   caller: string;
-  transactionHash: string;
 }
 
 export interface SpokePoolClientsByChain {

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -40,5 +40,12 @@ export async function constructMonitorClients(config: MonitorConfig, logger: win
 export async function updateMonitorClients(clients: MonitorClients) {
   await updateClients(clients);
   // SpokePoolClient client requires up to date HubPoolClient and ConfigStore client.
-  await updateSpokePoolClients(clients.spokePoolClients);
+  await updateSpokePoolClients(clients.spokePoolClients, [
+    "FundsDeposited",
+    "RequestedSpeedUpDeposit",
+    "FilledRelay",
+    "EnabledDepositRoute",
+    "RelayedRootBundle",
+    "ExecutedRelayerRefundRoot",
+  ]);
 }

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -56,7 +56,14 @@ export async function updateRelayerClients(clients: RelayerClients) {
   // dependencies of the clients. some clients need to be updated before others. when doing this refactor consider
   // having a "first run" update and then a "normal" update that considers this. see previous implementation here
   // https://github.com/across-protocol/relayer-v2/pull/37/files#r883371256 as a reference.
-  await updateSpokePoolClients(clients.spokePoolClients);
+  await updateSpokePoolClients(clients.spokePoolClients, [
+    "FundsDeposited",
+    "RequestedSpeedUpDeposit",
+    "FilledRelay",
+    "EnabledDepositRoute",
+    "RelayedRootBundle",
+    "ExecutedRelayerRefundRoot",
+  ]);
 
   // Update the token client first so that inventory client has latest balances.
 


### PR DESCRIPTION
- Finalizer shouldn't have to load Fill/Deposit events for example, while Relayer and Dataworker shouldn't have to load TokensBridged events
- This PR allows bots to define which events to lookup per SpokePoolClient update.

This PR also limits number of events searched in Finalizer, which is very slow since there is an async request per TokensBridged event to check on its finalization status