### PR TITLE
improve: Make exchangeRateCurrent log more succinct

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -916,7 +916,7 @@ export class Dataworker {
             method: "exchangeRateCurrent",
             args: [l1Token],
             message: `Updated exchange rate ♻️!`,
-            mrkdwn: `Updated exchange rate for l1 token: ${l1Token}`,
+            mrkdwn: `Updated exchange rate for l1 token: ${this.clients.hubPoolClient.getTokenInfo(1, l1Token).symbol}`,
           });
         }
       });


### PR DESCRIPTION
Log the L1 token symbol we're triggering `exchangeRateCurrent()` for instead of token address