### PR TITLE
improve: Use configurable follow distance in SpokePoolClient

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -27,7 +27,8 @@ export class SpokePoolClient {
     readonly configStoreClient: AcrossConfigStoreClient | null, // Can be excluded. This disables some deposit validation.
     readonly chainId: number,
     readonly eventSearchConfig: EventSearchConfig = { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 },
-    readonly spokePoolDeploymentBlock: number = 0
+    readonly spokePoolDeploymentBlock: number = 0,
+    readonly followDistance: number = 0
   ) {
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
   }
@@ -191,10 +192,16 @@ export class SpokePoolClient {
   async update(eventsToQuery?: string[]) {
     if (this.configStoreClient !== null && !this.configStoreClient.isUpdated) throw new Error("RateModel not updated");
 
-    this.latestBlockNumber = await this.spokePool.provider.getBlockNumber();
+    // If follow distance exists, then look up events only until HEAD-follow. This can be
+    // used specifically in looping mode to avoid any issues where this client sees incorrect events
+    // near HEAD, but can't re-load them since the Dataworker is running in looping mode. This could ultimately
+    // cause the dataworker to propose an incorrect root bundle. Even worst, the same looping instance will never
+    // consider this root bundle invalid. So, to mitigate this, use a follow distance in spoke clients
+    // specifically in the dataworker when loading spoke pool events.
+    this.latestBlockNumber = (await this.spokePool.provider.getBlockNumber()) - this.followDistance;
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
-      toBlock: this.eventSearchConfig.toBlock || this.latestBlockNumber,
+      toBlock: Math.max(this.eventSearchConfig.toBlock || this.latestBlockNumber, this.firstBlockToSearch),
       maxBlockLookBack: this.eventSearchConfig.maxBlockLookBack,
     };
 

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -201,7 +201,7 @@ export class SpokePoolClient {
     this.latestBlockNumber = (await this.spokePool.provider.getBlockNumber()) - this.followDistance;
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
-      toBlock: Math.max(this.eventSearchConfig.toBlock || this.latestBlockNumber, this.firstBlockToSearch),
+      toBlock: this.eventSearchConfig.toBlock || this.latestBlockNumber,
       maxBlockLookBack: this.eventSearchConfig.maxBlockLookBack,
     };
 

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -35,7 +35,8 @@ export async function constructSpokePoolClientsForBlockAndUpdate(
   clients: DataworkerClients,
   logger: winston.Logger,
   latestMainnetBlock: number,
-  eventsToQuery?: string[]
+  eventsToQuery?: string[],
+  followDistances?: { [chainId: number]: number }
 ): Promise<{ [chainId: number]: SpokePoolClient }> {
   const spokePoolClients = Object.fromEntries(
     chainIdListForBundleEvaluationBlockNumbers.map((chainId) => {
@@ -50,7 +51,8 @@ export async function constructSpokePoolClientsForBlockAndUpdate(
         clients.configStoreClient,
         Number(chainId),
         clients.spokePoolClientSearchSettings[chainId],
-        clients.spokePoolClientSearchSettings[chainId].fromBlock
+        clients.spokePoolClientSearchSettings[chainId].fromBlock,
+        followDistances[chainId]
       );
       return [chainId, client];
     })

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -13,7 +13,7 @@ import {
 import { DataworkerClients, spokePoolClientsToProviders } from "./DataworkerClientHelper";
 import { SpokePoolClient } from "../clients";
 import * as PoolRebalanceUtils from "./PoolRebalanceUtils";
-import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
+import { getBlockRangeForChain, prettyPrintSpokePoolEvents } from "../dataworker/DataworkerUtils";
 import {
   getEndBlockBuffers,
   _buildPoolRebalanceRoot,
@@ -154,6 +154,7 @@ export class Dataworker {
     // list, and the order of chain ID's is hardcoded in the ConfigStore client.
     const blockRangesForProposal = await PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       this.chainIdListForBundleEvaluationBlockNumbers,
+      spokePoolClients,
       getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber
@@ -308,6 +309,7 @@ export class Dataworker {
 
     const widestPossibleExpectedBlockRange = await PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       this.chainIdListForBundleEvaluationBlockNumbers,
+      spokePoolClients,
       getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber
@@ -802,6 +804,7 @@ export class Dataworker {
 
     const widestPossibleExpectedBlockRange = await PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       this.chainIdListForBundleEvaluationBlockNumbers,
+      spokePoolClients,
       getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -13,7 +13,7 @@ import {
 import { DataworkerClients, spokePoolClientsToProviders } from "./DataworkerClientHelper";
 import { SpokePoolClient } from "../clients";
 import * as PoolRebalanceUtils from "./PoolRebalanceUtils";
-import { getBlockRangeForChain, prettyPrintSpokePoolEvents } from "../dataworker/DataworkerUtils";
+import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 import {
   getEndBlockBuffers,
   _buildPoolRebalanceRoot,
@@ -46,21 +46,7 @@ export class Dataworker {
     readonly tokenTransferThreshold: BigNumberForToken = {},
     readonly blockRangeEndBlockBuffer: { [chainId: number]: number } = {},
     readonly spokeRootsLookbackCount = 0
-  ) {
-    if (
-      maxRefundCountOverride !== undefined ||
-      maxL1TokenCountOverride !== undefined ||
-      Object.keys(tokenTransferThreshold).length > 0 ||
-      Object.keys(blockRangeEndBlockBuffer).length > 0
-    )
-      this.logger.debug({
-        at: "Dataworker constructed with overridden config store settings",
-        maxRefundCountOverride: this.maxRefundCountOverride,
-        maxL1TokenCountOverride: this.maxL1TokenCountOverride,
-        tokenTransferThreshold: this.tokenTransferThreshold,
-        blockRangeEndBlockBuffer: this.blockRangeEndBlockBuffer,
-      });
-  }
+  ) {}
 
   // This should be called whenever it's possible that the loadData information for a block range could have changed.
   // For instance, if the spoke or hub clients have been updated, it probably makes sense to clear this to be safe.
@@ -155,7 +141,6 @@ export class Dataworker {
     const blockRangesForProposal = await PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       this.chainIdListForBundleEvaluationBlockNumbers,
       spokePoolClients,
-      getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber
     );
@@ -310,7 +295,6 @@ export class Dataworker {
     const widestPossibleExpectedBlockRange = await PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       this.chainIdListForBundleEvaluationBlockNumbers,
       spokePoolClients,
-      getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber
     );
@@ -397,8 +381,8 @@ export class Dataworker {
       };
     }
 
-    // If the bundle end block is less than HEAD but within the allowable margin of error into future,
-    // then we won't dispute and we'll just exit early from this function.
+    // If the bundle end block is less than latest spoke client block but within the allowable margin of error into
+    // future, then we won't dispute and we'll just exit early from this function.
     if (
       rootBundle.bundleEvaluationBlockNumbers.some((block, index) => block > widestPossibleExpectedBlockRange[index][1])
     ) {
@@ -467,7 +451,16 @@ export class Dataworker {
         this.chainIdListForBundleEvaluationBlockNumbers,
         this.clients,
         this.logger,
-        endBlockForMainnet
+        endBlockForMainnet,
+        [
+          "FundsDeposited",
+          "RequestedSpeedUpDeposit",
+          "FilledRelay",
+          "EnabledDepositRoute",
+          "RelayedRootBundle",
+          "ExecutedRelayerRefundRoot",
+        ],
+        this.blockRangeEndBlockBuffer
       );
 
     // Compare roots with expected. The roots will be different if the block range start blocks were different
@@ -805,7 +798,6 @@ export class Dataworker {
     const widestPossibleExpectedBlockRange = await PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       this.chainIdListForBundleEvaluationBlockNumbers,
       spokePoolClients,
-      getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber
     );

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -6,6 +6,7 @@ export class DataworkerConfig extends CommonConfig {
   readonly maxRelayerRepaymentLeafSizeOverride: number;
   readonly tokenTransferThresholdOverride: { [l1TokenAddress: string]: BigNumber };
   readonly blockRangeEndBlockBuffer: { [chainId: number]: number };
+  readonly spokePoolClientFollowDistance: { [chainId: number]: number };
   readonly rootBundleExecutionThreshold: BigNumber;
   readonly spokeRootsLookbackCount: number; // Consider making this configurable per chain ID.
   readonly finalizerChains: number[];
@@ -31,6 +32,7 @@ export class DataworkerConfig extends CommonConfig {
       MAX_POOL_REBALANCE_LEAF_SIZE_OVERRIDE,
       MAX_RELAYER_REPAYMENT_LEAF_SIZE_OVERRIDE,
       BLOCK_RANGE_END_BLOCK_BUFFER,
+      SPOKE_POOL_CLIENT_FOLLOW_DISTANCE,
       DISPUTER_ENABLED,
       PROPOSER_ENABLED,
       EXECUTOR_ENABLED,
@@ -63,6 +65,9 @@ export class DataworkerConfig extends CommonConfig {
       : toBNWei("500000");
     this.blockRangeEndBlockBuffer = BLOCK_RANGE_END_BLOCK_BUFFER
       ? JSON.parse(BLOCK_RANGE_END_BLOCK_BUFFER)
+      : BUNDLE_END_BLOCK_BUFFERS;
+    this.spokePoolClientFollowDistance = SPOKE_POOL_CLIENT_FOLLOW_DISTANCE
+      ? JSON.parse(SPOKE_POOL_CLIENT_FOLLOW_DISTANCE)
       : BUNDLE_END_BLOCK_BUFFERS;
     this.disputerEnabled = DISPUTER_ENABLED === "true";
     this.proposerEnabled = PROPOSER_ENABLED === "true";

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -73,9 +73,7 @@ export class DataworkerConfig extends CommonConfig {
     // they are more than (follow distance + block range end buffer) older than HEAD, so 20+20=40 mins in this example.
     this.spokePoolClientFollowDistance = SPOKE_POOL_CLIENT_FOLLOW_DISTANCE
       ? JSON.parse(SPOKE_POOL_CLIENT_FOLLOW_DISTANCE)
-      : Object.fromEntries(
-          Object.keys(BUNDLE_END_BLOCK_BUFFERS).map((chain) => [chain, Math.floor(BUNDLE_END_BLOCK_BUFFERS[chain] / 2)])
-        );
+      : BUNDLE_END_BLOCK_BUFFERS;
     this.disputerEnabled = DISPUTER_ENABLED === "true";
     this.proposerEnabled = PROPOSER_ENABLED === "true";
     this.executorEnabled = EXECUTOR_ENABLED === "true";

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -66,9 +66,16 @@ export class DataworkerConfig extends CommonConfig {
     this.blockRangeEndBlockBuffer = BLOCK_RANGE_END_BLOCK_BUFFER
       ? JSON.parse(BLOCK_RANGE_END_BLOCK_BUFFER)
       : BUNDLE_END_BLOCK_BUFFERS;
+
+    // Default follow distance to the block range end buffer. The block range end buffer is already configured
+    // to not count any events that are too close to HEAD (~20 mins within HEAD for example), so we can conservatively
+    // set the follow distance equal to the buffer. This means that events won't be included in root bundles until
+    // they are more than (follow distance + block range end buffer) older than HEAD, so 20+20=40 mins in this example.
     this.spokePoolClientFollowDistance = SPOKE_POOL_CLIENT_FOLLOW_DISTANCE
       ? JSON.parse(SPOKE_POOL_CLIENT_FOLLOW_DISTANCE)
-      : BUNDLE_END_BLOCK_BUFFERS;
+      : Object.fromEntries(
+          Object.keys(BUNDLE_END_BLOCK_BUFFERS).map((chain) => [chain, Math.floor(BUNDLE_END_BLOCK_BUFFERS[chain] / 2)])
+        );
     this.disputerEnabled = DISPUTER_ENABLED === "true";
     this.proposerEnabled = PROPOSER_ENABLED === "true";
     this.executorEnabled = EXECUTOR_ENABLED === "true";

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -6,7 +6,6 @@ export class DataworkerConfig extends CommonConfig {
   readonly maxRelayerRepaymentLeafSizeOverride: number;
   readonly tokenTransferThresholdOverride: { [l1TokenAddress: string]: BigNumber };
   readonly blockRangeEndBlockBuffer: { [chainId: number]: number };
-  readonly spokePoolClientFollowDistance: { [chainId: number]: number };
   readonly rootBundleExecutionThreshold: BigNumber;
   readonly spokeRootsLookbackCount: number; // Consider making this configurable per chain ID.
   readonly finalizerChains: number[];
@@ -32,7 +31,6 @@ export class DataworkerConfig extends CommonConfig {
       MAX_POOL_REBALANCE_LEAF_SIZE_OVERRIDE,
       MAX_RELAYER_REPAYMENT_LEAF_SIZE_OVERRIDE,
       BLOCK_RANGE_END_BLOCK_BUFFER,
-      SPOKE_POOL_CLIENT_FOLLOW_DISTANCE,
       DISPUTER_ENABLED,
       PROPOSER_ENABLED,
       EXECUTOR_ENABLED,
@@ -65,14 +63,6 @@ export class DataworkerConfig extends CommonConfig {
       : toBNWei("500000");
     this.blockRangeEndBlockBuffer = BLOCK_RANGE_END_BLOCK_BUFFER
       ? JSON.parse(BLOCK_RANGE_END_BLOCK_BUFFER)
-      : BUNDLE_END_BLOCK_BUFFERS;
-
-    // Default follow distance to the block range end buffer. The block range end buffer is already configured
-    // to not count any events that are too close to HEAD (~20 mins within HEAD for example), so we can conservatively
-    // set the follow distance equal to the buffer. This means that events won't be included in root bundles until
-    // they are more than (follow distance + block range end buffer) older than HEAD, so 20+20=40 mins in this example.
-    this.spokePoolClientFollowDistance = SPOKE_POOL_CLIENT_FOLLOW_DISTANCE
-      ? JSON.parse(SPOKE_POOL_CLIENT_FOLLOW_DISTANCE)
       : BUNDLE_END_BLOCK_BUFFERS;
     this.disputerEnabled = DISPUTER_ENABLED === "true";
     this.proposerEnabled = PROPOSER_ENABLED === "true";

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -308,20 +308,11 @@ export function getRunningBalanceForL1Token(transferThreshold: BigNumber, runnin
 export async function getWidestPossibleExpectedBlockRange(
   chainIdListForBundleEvaluationBlockNumbers: number[],
   spokePoolClients: { [chainId: number]: SpokePoolClient },
-  endBlockBuffers: number[],
   clients: DataworkerClients,
   latestMainnetBlock: number
 ): Promise<number[][]> {
-  const latestBlockNumbers = await Promise.all(
-    chainIdListForBundleEvaluationBlockNumbers.map(
-      async (chainId: number, index) =>
-        Math.max(0, spokePoolClients[chainId].latestBlockNumber - endBlockBuffers[index])
-      // We subtract a buffer from the end blocks to reduce the chance that network providers
-      // for different bot runs produce different contract state because of variability near the HEAD of the network.
-      // Reducing the latest block that we query also gives partially filled deposits slightly more buffer for relayers
-      // to fully fill the deposit and reduces the chance that the data worker includes a slow fill payment that gets
-      // filled during the challenge period.
-    )
+  const latestBlockNumbers = chainIdListForBundleEvaluationBlockNumbers.map(
+    (chainId: number) => spokePoolClients[chainId].latestBlockNumber
   );
   return chainIdListForBundleEvaluationBlockNumbers.map((chainId: number, index) => [
     clients.hubPoolClient.getNextBundleStartBlockNumber(

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -1,4 +1,4 @@
-import { AcrossConfigStoreClient, HubPoolClient } from "../clients";
+import { AcrossConfigStoreClient, HubPoolClient, SpokePoolClient } from "../clients";
 import * as interfaces from "../interfaces";
 import {
   BigNumberForToken,
@@ -307,6 +307,7 @@ export function getRunningBalanceForL1Token(transferThreshold: BigNumber, runnin
 // greater of 0 and the latest bundle end block for an executed root bundle proposal + 1.
 export async function getWidestPossibleExpectedBlockRange(
   chainIdListForBundleEvaluationBlockNumbers: number[],
+  spokePoolClients: { [chainId: number]: SpokePoolClient },
   endBlockBuffers: number[],
   clients: DataworkerClients,
   latestMainnetBlock: number
@@ -314,7 +315,7 @@ export async function getWidestPossibleExpectedBlockRange(
   const latestBlockNumbers = await Promise.all(
     chainIdListForBundleEvaluationBlockNumbers.map(
       async (chainId: number, index) =>
-        Math.max(0, (await clients.spokePoolSigners[chainId].provider.getBlockNumber()) - endBlockBuffers[index])
+        Math.max(0, spokePoolClients[chainId].latestBlockNumber - endBlockBuffers[index])
       // We subtract a buffer from the end blocks to reduce the chance that network providers
       // for different bot runs produce different contract state because of variability near the HEAD of the network.
       // Reducing the latest block that we query also gives partially filled deposits slightly more buffer for relayers

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -59,7 +59,8 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
             "EnabledDepositRoute",
             "RelayedRootBundle",
             "ExecutedRelayerRefundRoot",
-          ]
+          ],
+          config.spokePoolClientFollowDistance
         );
       else
         await updateSpokePoolClients(spokePoolClients, [

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -60,7 +60,7 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
             "RelayedRootBundle",
             "ExecutedRelayerRefundRoot",
           ],
-          config.spokePoolClientFollowDistance
+          config.blockRangeEndBlockBuffer
         );
       else
         await updateSpokePoolClients(spokePoolClients, [

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -73,13 +73,12 @@ export async function validate(_logger: winston.Logger) {
       "RelayedRootBundle",
       "ExecutedRelayerRefundRoot",
     ],
-    config.spokePoolClientFollowDistance
+    config.blockRangeEndBlockBuffer
   );
 
   const widestPossibleBlockRanges = await getWidestPossibleExpectedBlockRange(
     dataworker.chainIdListForBundleEvaluationBlockNumbers,
     spokePoolClients,
-    getEndBlockBuffers(dataworker.chainIdListForBundleEvaluationBlockNumbers, dataworker.blockRangeEndBlockBuffer),
     clients,
     priceRequestBlock
   );

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -17,6 +17,7 @@ import { PendingRootBundle } from "../interfaces";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
 import { createDataworker } from "../dataworker";
 import { getEndBlockBuffers } from "../dataworker/DataworkerUtils";
+import { constructSpokePoolClientsForBlockAndUpdate } from "../common";
 
 config();
 let logger: winston.Logger;
@@ -59,8 +60,25 @@ export async function validate(_logger: winston.Logger) {
     transactionHash: precedingProposeRootBundleEvent.transactionHash,
   });
 
+  const spokePoolClients = await constructSpokePoolClientsForBlockAndUpdate(
+    dataworker.chainIdListForBundleEvaluationBlockNumbers,
+    clients,
+    logger,
+    clients.hubPoolClient.latestBlockNumber,
+    [
+      "FundsDeposited",
+      "RequestedSpeedUpDeposit",
+      "FilledRelay",
+      "EnabledDepositRoute",
+      "RelayedRootBundle",
+      "ExecutedRelayerRefundRoot",
+    ],
+    config.spokePoolClientFollowDistance
+  );
+
   const widestPossibleBlockRanges = await getWidestPossibleExpectedBlockRange(
     dataworker.chainIdListForBundleEvaluationBlockNumbers,
+    spokePoolClients,
     getEndBlockBuffers(dataworker.chainIdListForBundleEvaluationBlockNumbers, dataworker.blockRangeEndBlockBuffer),
     clients,
     priceRequestBlock

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -36,36 +36,18 @@ describe("Dataworker block range-related utility methods", async function () {
     expect(getEndBlockBuffers([2, 4], defaultBuffer)).to.deep.equal([2, 0]);
   });
   it("PoolRebalanceUtils.getWidestPossibleExpectedBlockRange", async function () {
-    // End blocks equal to HEAD block minus buffer, start block for first bundle equal to 0:
+    // End blocks equal to latest spoke client block, start block for first bundle equal to 0:
     const chainIdListForBundleEvaluationBlockNumbers = CHAIN_ID_TEST_LIST;
-    const defaultEndBlockBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(1);
-    const latestBlocks = await Promise.all(
-      chainIdListForBundleEvaluationBlockNumbers.map(async (chainId: number, index) =>
-        Math.max(
-          0,
-          (await spokePoolClients[chainId].spokePool.provider.getBlockNumber()) - defaultEndBlockBuffers[index]
-        )
-      )
+    const latestBlocks = chainIdListForBundleEvaluationBlockNumbers.map(
+      (chainId: number) => spokePoolClients[chainId].latestBlockNumber
     );
     const latestMainnetBlock = hubPoolClient.latestBlockNumber;
     const startingWidestBlocks = await getWidestPossibleExpectedBlockRange(
       chainIdListForBundleEvaluationBlockNumbers,
       spokePoolClients,
-      defaultEndBlockBuffers,
       dataworkerClients,
       latestMainnetBlock
     );
     expect(startingWidestBlocks).to.deep.equal(latestBlocks.map((endBlock) => [0, endBlock]));
-
-    // End block defaults to 0 if buffer is too large
-    const largeBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(1000);
-    const zeroRange = await getWidestPossibleExpectedBlockRange(
-      chainIdListForBundleEvaluationBlockNumbers,
-      spokePoolClients,
-      largeBuffers,
-      dataworkerClients,
-      latestMainnetBlock
-    );
-    expect(zeroRange).to.deep.equal(latestBlocks.map((endBlock) => [0, 0]));
   });
 });

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -50,6 +50,7 @@ describe("Dataworker block range-related utility methods", async function () {
     const latestMainnetBlock = hubPoolClient.latestBlockNumber;
     const startingWidestBlocks = await getWidestPossibleExpectedBlockRange(
       chainIdListForBundleEvaluationBlockNumbers,
+      spokePoolClients,
       defaultEndBlockBuffers,
       dataworkerClients,
       latestMainnetBlock
@@ -60,6 +61,7 @@ describe("Dataworker block range-related utility methods", async function () {
     const largeBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(1000);
     const zeroRange = await getWidestPossibleExpectedBlockRange(
       chainIdListForBundleEvaluationBlockNumbers,
+      spokePoolClients,
       largeBuffers,
       dataworkerClients,
       latestMainnetBlock

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -121,7 +121,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
 
     // Constructs same roots as proposed root bundle
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(lastSpyLogIncludes(spy, "Pending root bundle matches with expected")).to.be.true;
 
     // Now let's test with some invalid root bundles:
@@ -150,7 +150,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     // Mine blocks so root bundle end blocks are not within HEAD - buffer range
     for (let i = 0; i < BUNDLE_END_BLOCK_BUFFER; i++) await hre.network.provider.send("evm_mine");
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(lastSpyLogIncludes(spy, "Pending root bundle matches with expected")).to.be.true;
 
     // Bundle range end blocks are too low.
@@ -164,7 +164,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal(
       "A bundle end block is < expected start block, submitting dispute"
     );
@@ -182,7 +182,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(lastSpyLogIncludes(spy, "A bundle end block is > latest block but within buffer, skipping")).to.be.true;
     await updateAllClients();
     expect(hubPoolClient.hasPendingProposal()).to.equal(true);
@@ -202,7 +202,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal(
       "A bundle end block is > latest block + buffer for its chain, submitting dispute"
     );
@@ -218,7 +218,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected bundle block range length, disputing");
     await multiCallerClient.executeTransactionQueue();
 
@@ -232,7 +232,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Empty pool rebalance root, submitting dispute");
     await multiCallerClient.executeTransactionQueue();
 
@@ -247,7 +247,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected pool rebalance root, submitting dispute");
     await multiCallerClient.executeTransactionQueue();
 
@@ -261,7 +261,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected pool rebalance root, submitting dispute");
     await multiCallerClient.executeTransactionQueue();
 
@@ -275,7 +275,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected relayer refund root, submitting dispute");
     await multiCallerClient.executeTransactionQueue();
 
@@ -289,7 +289,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       utf8ToHex("BogusRoot")
     );
     await updateAllClients();
-    await dataworkerInstance.validatePendingRootBundle();
+    await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected slow relay root, submitting dispute");
     await multiCallerClient.executeTransactionQueue();
   });

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -61,7 +61,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     );
     await updateAllClients();
     await buildFillForRepaymentChain(spokePool_2, depositor, deposit, 0.5, destinationChainId);
-    // Mine blocks so event blocks are less than HEAD minus buffer.
+    // Mine blocks so event blocks are less than latest minus buffer.
     for (let i = 0; i < BUNDLE_END_BLOCK_BUFFER; i++) await hre.network.provider.send("evm_mine");
     await updateAllClients();
     const latestBlock2 = await hubPool.provider.getBlockNumber();
@@ -147,7 +147,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       expectedRelayerRefundRoot4.tree.getHexRoot(),
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
-    // Mine blocks so root bundle end blocks are not within HEAD - buffer range
+    // Mine blocks so root bundle end blocks are not within latest - buffer range
     for (let i = 0; i < BUNDLE_END_BLOCK_BUFFER; i++) await hre.network.provider.send("evm_mine");
     await updateAllClients();
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
@@ -173,35 +173,34 @@ describe("Dataworker: Validate pending root bundle", async function () {
     // Bundle range end blocks are above latest block but within buffer, should skip.
     await updateAllClients();
     await hubPool.proposeRootBundle(
-      // Since the dataworker sets the end block to HEAD minus buffer, setting the bundle end blocks to HEAD
+      // Since the dataworker sets the end block to latest minus buffer, setting the bundle end blocks to HEAD
       // should fall within buffer.
-      Array(CHAIN_ID_TEST_LIST.length).fill(Number(await hubPool.provider.getBlockNumber())),
+      Object.keys(spokePoolClients).map((chainId) => spokePoolClients[chainId].latestBlockNumber + 1),
       expectedPoolRebalanceRoot4.leaves.length,
       expectedPoolRebalanceRoot4.tree.getHexRoot(),
       expectedRelayerRefundRoot4.tree.getHexRoot(),
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
-    await updateAllClients();
+    await hubPoolClient.update(); // Update only HubPool client, not spoke pool clients so we can simulate them
+    // "lagging" and their latest block is behind the proposed bundle end blocks.
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(lastSpyLogIncludes(spy, "A bundle end block is > latest block but within buffer, skipping")).to.be.true;
     await updateAllClients();
     expect(hubPoolClient.hasPendingProposal()).to.equal(true);
 
-    // Bundle range end blocks are too high.
+    // Bundle range end blocks are too high, more than the buffer past latest.
     await hubPool.emergencyDeleteProposal();
     await updateAllClients();
     await hubPool.proposeRootBundle(
-      Array(CHAIN_ID_TEST_LIST.length).fill(
-        // As shown in previous test, HEAD is the last block after the latest toBlock (set to HEAD - buffer)
-        // to be within the buffer. So, if we blocks to HEAD, we'll be past the buffer window.
-        Number(await hubPool.provider.getBlockNumber()) + 3
+      Object.keys(spokePoolClients).map(
+        (chainId) => spokePoolClients[chainId].latestBlockNumber + BUNDLE_END_BLOCK_BUFFER + 1
       ),
       expectedPoolRebalanceRoot4.leaves.length,
       expectedPoolRebalanceRoot4.tree.getHexRoot(),
       expectedRelayerRefundRoot4.tree.getHexRoot(),
       expectedSlowRelayRefundRoot4.tree.getHexRoot()
     );
-    await updateAllClients();
+    await hubPoolClient.update();
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal(
       "A bundle end block is > latest block + buffer for its chain, submitting dispute"


### PR DESCRIPTION
If follow distance exists, then look up events only until HEAD-follow. This can be used specifically in looping mode to avoid any issues where this client sees incorrect events near HEAD, but can't re-load them since the Dataworker is running in looping mode. This could ultimately cause the dataworker to propose an incorrect root bundle. Even worst, the same looping instance will never consider this root bundle invalid. So, to mitigate this, use a follow distance in spoke clients  specifically in the dataworker when loading spoke pool events.

The follow distance is set to replace the BUNDLE_BLOCK_RANGE_BUFFER. Both block buffers do the same thing, but this PR changes the SpokePoolClient to follow HEAD instead of the Dataworker endblocks to follow the SpokePoolClient.latestBlockNumbers. This is an important distinction especially for running the dataworker in looping mode since it will only ever look up events twice. This is not a concern if running in serverless mode, but running the dataworker currently in serverless mode is very slow and not really usable.