### PR TITLE
feat: Add logic to ignore admin bundles 

### DIFF
--- a/scripts/constructEmergencyRoot.ts
+++ b/scripts/constructEmergencyRoot.ts
@@ -1,0 +1,52 @@
+import { sortRelayerRefundLeaves } from "../src/dataworker/RelayerRefundUtils";
+import {
+  ethers,
+  getSigner,
+  RelayerRefundLeaf,
+  MerkleTree,
+  buildRelayerRefundTree,
+  EMPTY_MERKLE_ROOT,
+  SpokePool
+} from "../src/utils";
+
+// This script can be used to generate a manual merkle root and is filled with example data.
+export async function run(): Promise<void> {
+  const baseSigner = await getSigner();
+
+  // 1. Construct relayer refund leaves
+  const relayerRefundLeaves: any[] = [
+    {
+      amountToReturn: "500000000000000000000",
+      chainId: 10,
+      refundAmounts: [],
+      leafId: 1,
+      l2TokenAddress: "0x4200000000000000000000000000000000000006",
+      refundAddresses: [],
+    },
+  ];
+
+  const relayerRefundRoot: MerkleTree<RelayerRefundLeaf> = buildRelayerRefundTree(
+    sortRelayerRefundLeaves(relayerRefundLeaves)
+  );
+  console.log(relayerRefundLeaves, relayerRefundRoot.getHexRoot());
+
+  // 2. Get ABI encoded function signature to relay roots to spoke pools:
+  // The following address is the Optimism_SpokePool but could be any chain's SpokePool.
+  const spokePool = new ethers.Contract("0xa420b2d1c0841415a695b81e5b867bcd07dff8c9", SpokePool.abi, baseSigner);
+  const abiEncodedFunctionData = spokePool.interface.encodeFunctionData("relayRootBundle", [
+    relayerRefundRoot.getHexRoot(),
+    EMPTY_MERKLE_ROOT,
+  ]);
+  console.log(abiEncodedFunctionData);
+}
+
+if (require.main === module) {
+  run()
+    .then(async () => {
+      process.exit(0);
+    })
+    .catch(async (error) => {
+      console.error("Process exited with", error);
+      process.exit(1);
+    });
+}

--- a/scripts/constructEmergencyRoot.ts
+++ b/scripts/constructEmergencyRoot.ts
@@ -48,7 +48,12 @@ export async function run(): Promise<void> {
   ];
 
   const relayerRefundRoot: MerkleTree<RelayerRefundLeaf> = buildRelayerRefundTree(relayerRefundLeaves);
-  console.log(`relayerRefundRoot:`, prettyRelayerRefundLeaf(relayerRefundLeaves), relayerRefundRoot.getHexRoot());
+  console.log(
+    `relayerRefundRoot:`,
+    prettyRelayerRefundLeaf(relayerRefundLeaves),
+    relayerRefundRoot.getHexRoot(),
+    relayerRefundRoot.getHexProof(relayerRefundLeaves[0])
+  );
 
   // 2. Get ABI encoded function signature to relay roots to spoke pools:
   // The following address is the Optimism_SpokePool but could be any chain's SpokePool.

--- a/scripts/constructEmergencyRoot.ts
+++ b/scripts/constructEmergencyRoot.ts
@@ -1,4 +1,4 @@
-import { sortRelayerRefundLeaves } from "../src/dataworker/RelayerRefundUtils";
+import { PoolRebalanceLeaf } from "../src/interfaces";
 import {
   ethers,
   getSigner,
@@ -6,29 +6,49 @@ import {
   MerkleTree,
   buildRelayerRefundTree,
   EMPTY_MERKLE_ROOT,
-  SpokePool
+  SpokePool,
+  toBNWei,
+  toBN,
+  buildPoolRebalanceLeafTree,
 } from "../src/utils";
 
+function prettyRelayerRefundLeaf(leaves: RelayerRefundLeaf[]) {
+  return leaves.map((leaf) => {
+    return {
+      ...leaf,
+      amountToReturn: leaf.amountToReturn.toString(),
+      refundAmounts: leaf.refundAmounts.map((x) => x.toString()),
+    };
+  });
+}
+function prettyPoolRebalanceLeaf(leaves: PoolRebalanceLeaf[]) {
+  return leaves.map((leaf) => {
+    return {
+      ...leaf,
+      netSendAmounts: leaf.netSendAmounts.map((x) => x.toString()),
+      runningBalances: leaf.runningBalances.map((x) => x.toString()),
+      bundleLpFees: leaf.bundleLpFees.map((x) => x.toString()),
+    };
+  });
+}
 // This script can be used to generate a manual merkle root and is filled with example data.
 export async function run(): Promise<void> {
   const baseSigner = await getSigner();
 
   // 1. Construct relayer refund leaves
-  const relayerRefundLeaves: any[] = [
+  const relayerRefundLeaves: RelayerRefundLeaf[] = [
     {
-      amountToReturn: "500000000000000000000",
+      amountToReturn: toBNWei("500"),
       chainId: 10,
       refundAmounts: [],
-      leafId: 1,
+      leafId: 0,
       l2TokenAddress: "0x4200000000000000000000000000000000000006",
       refundAddresses: [],
     },
   ];
 
-  const relayerRefundRoot: MerkleTree<RelayerRefundLeaf> = buildRelayerRefundTree(
-    sortRelayerRefundLeaves(relayerRefundLeaves)
-  );
-  console.log(relayerRefundLeaves, relayerRefundRoot.getHexRoot());
+  const relayerRefundRoot: MerkleTree<RelayerRefundLeaf> = buildRelayerRefundTree(relayerRefundLeaves);
+  console.log(`relayerRefundRoot:`, prettyRelayerRefundLeaf(relayerRefundLeaves), relayerRefundRoot.getHexRoot());
 
   // 2. Get ABI encoded function signature to relay roots to spoke pools:
   // The following address is the Optimism_SpokePool but could be any chain's SpokePool.
@@ -37,7 +57,35 @@ export async function run(): Promise<void> {
     relayerRefundRoot.getHexRoot(),
     EMPTY_MERKLE_ROOT,
   ]);
-  console.log(abiEncodedFunctionData);
+  console.log(`abiEncodedFunctionData`, abiEncodedFunctionData);
+
+  // 3. Construct pool rebalance leaves
+  const poolRebalanceLeaves: PoolRebalanceLeaf[] = [
+    {
+      chainId: 1,
+      bundleLpFees: [toBN("124122273836729709").sub(toBN("123603942018663986"))],
+      netSendAmounts: [toBN("120200463420953608591").sub(toBN("119648808743556644079"))],
+      runningBalances: [toBN(0)],
+      groupIndex: 0,
+      leafId: 0,
+      l1Tokens: ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"],
+    },
+  ];
+  const relayerRefundLeaves2: RelayerRefundLeaf[] = [
+    {
+      amountToReturn: toBN(0),
+      chainId: 1,
+      refundAmounts: [toBN("132101928812168900443").sub(toBN("131550274134771935931"))],
+      leafId: 0,
+      l2TokenAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      refundAddresses: ["0x428AB2BA90Eba0a4Be7aF34C9Ac451ab061AC010"],
+    },
+  ];
+  const poolRebalanceRoot: MerkleTree<PoolRebalanceLeaf> = buildPoolRebalanceLeafTree(poolRebalanceLeaves);
+
+  const relayerRefundRoot2: MerkleTree<RelayerRefundLeaf> = buildRelayerRefundTree(relayerRefundLeaves2);
+  console.log(`relayerRefundRoot2:`, prettyRelayerRefundLeaf(relayerRefundLeaves2), relayerRefundRoot2.getHexRoot());
+  console.log(`poolRebalanceRoot:`, prettyPoolRebalanceLeaf(poolRebalanceLeaves), poolRebalanceRoot.getHexRoot());
 }
 
 if (require.main === module) {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1,6 +1,6 @@
 import { assign, Contract, winston, BigNumber, ERC20, sortEventsAscending, EventSearchConfig } from "../utils";
 import { sortEventsDescending, spreadEvent, spreadEventWithBlockNumber, paginatedEventQuery, toBN } from "../utils";
-import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES } from "../common"
+import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES } from "../common";
 import { Deposit, L1Token, CancelledRootBundle, DisputedRootBundle, LpToken } from "../interfaces";
 import { ExecutedRootBundle, PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { CrossChainContractsSet, DestinationTokenWithBlock, SetPoolRebalanceRoot } from "../interfaces";

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -55,7 +55,7 @@ export const l2TokensToL1TokenValidation = {
 // latest dataworker code, or there is no matching L1 root bundle, because the root bundle was relayed by an admin.
 export const IGNORED_SPOKE_BUNDLES = {
   1: [74, 101],
-  10: [74, 101],
+  10: [74, 101, 105],
   137: [74, 101],
   288: [90],
   42161: [74, 101],

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -54,7 +54,7 @@ export const l2TokensToL1TokenValidation = {
 // Maps chain ID to root bundle ID to ignore because the roots are known to be invalid from the perspective of the
 // latest dataworker code, or there is no matching L1 root bundle, because the root bundle was relayed by an admin.
 export const IGNORED_SPOKE_BUNDLES = {
-  1: [],
+  1: [74, 101],
   10: [74, 101],
   137: [74, 101],
   288: [90],

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -50,3 +50,21 @@ export const l2TokensToL1TokenValidation = {
     42161: "0x2f2a2543B76A4166549F7aaB2e75Bef0aefC5B0f",
   }, // WBTC
 };
+
+// Maps chain ID to root bundle ID to ignore because the roots are known to be invalid from the perspective of the 
+// latest dataworker code, or there is no matching L1 root bundle, because the root bundle was relayed by an admin.
+export const IGNORED_SPOKE_BUNDLES = {
+  1: [],
+  10: [74, 101],
+  137: [74, 101],
+  288: [90],
+  42161: [74, 101],
+};
+
+// List of proposal block numbers to ignore. This should be ignored because they are administrative bundle proposals
+// with useless bundle block eval numbers and other data that isn't helpful for the dataworker to know. This does not
+// include any invalid bundles that got through, such as at blocks 15001113 or 15049343 which are missing
+// some events but have correct bundle eval blocks. This list specifically contains admin proposals that are sent
+// to correct the bundles such as 15049343 that missed some events.
+export const IGNORED_HUB_PROPOSED_BUNDLES = [];
+export const IGNORED_HUB_EXECUTED_BUNDLES = [];

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -51,7 +51,7 @@ export const l2TokensToL1TokenValidation = {
   }, // WBTC
 };
 
-// Maps chain ID to root bundle ID to ignore because the roots are known to be invalid from the perspective of the 
+// Maps chain ID to root bundle ID to ignore because the roots are known to be invalid from the perspective of the
 // latest dataworker code, or there is no matching L1 root bundle, because the root bundle was relayed by an admin.
 export const IGNORED_SPOKE_BUNDLES = {
   1: [],

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -592,9 +592,9 @@ export class Dataworker {
     await Promise.all(
       Object.entries(spokePoolClients).map(async ([chainId, client]) => {
         let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter(
-          (rootBundle) => 
-          rootBundle.slowRelayRoot !== EMPTY_MERKLE_ROOT &&
-          !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
+          (rootBundle) =>
+            rootBundle.slowRelayRoot !== EMPTY_MERKLE_ROOT &&
+            !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
         );
 
         // Only grab the most recent n roots that have been sent if configured to do so.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -23,6 +23,7 @@ import {
 import { constructSpokePoolClientsForBlockAndUpdate } from "../common/ClientHelper";
 import { BalanceAllocator } from "../clients";
 import _ from "lodash";
+import { IGNORED_SPOKE_BUNDLES } from "../common";
 
 // @notice Constructs roots to submit to HubPool on L1. Fetches all data synchronously from SpokePool/HubPool clients
 // so this class assumes that those upstream clients are already updated and have fetched on-chain data from RPC's.
@@ -591,7 +592,9 @@ export class Dataworker {
     await Promise.all(
       Object.entries(spokePoolClients).map(async ([chainId, client]) => {
         let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter(
-          (rootBundle) => rootBundle.slowRelayRoot !== EMPTY_MERKLE_ROOT
+          (rootBundle) => 
+          rootBundle.slowRelayRoot !== EMPTY_MERKLE_ROOT &&
+          !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
         );
 
         // Only grab the most recent n roots that have been sent if configured to do so.
@@ -979,7 +982,9 @@ export class Dataworker {
     await Promise.all(
       Object.entries(spokePoolClients).map(async ([chainId, client]) => {
         let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter(
-          (rootBundle) => rootBundle.relayerRefundRoot !== EMPTY_MERKLE_ROOT
+          (rootBundle) =>
+            rootBundle.relayerRefundRoot !== EMPTY_MERKLE_ROOT &&
+            !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
         );
 
         // Only grab the most recent n roots that have been sent if configured to do so.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -594,7 +594,7 @@ export class Dataworker {
         let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter(
           (rootBundle) =>
             rootBundle.slowRelayRoot !== EMPTY_MERKLE_ROOT &&
-            !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
+            (IGNORED_SPOKE_BUNDLES[chainId] ? !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId) : true)
         );
 
         // Only grab the most recent n roots that have been sent if configured to do so.
@@ -984,7 +984,7 @@ export class Dataworker {
         let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter(
           (rootBundle) =>
             rootBundle.relayerRefundRoot !== EMPTY_MERKLE_ROOT &&
-            !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
+            (IGNORED_SPOKE_BUNDLES[chainId] ? !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId) : true)
         );
 
         // Only grab the most recent n roots that have been sent if configured to do so.


### PR DESCRIPTION
- Should be able to skip over spoke bundles in Dataworker.execute logic. This is pretty simple, as the Dataworker can just ignore these bundles when executing leaves. Additionally, when proposing new bundles, the Dataworker never considers RootBundles relayed to the spoke pools, so there isn't any other logic to change besides adding a filter to the execute methods.
- HubPoolClient should be able to ignore admin root bundles. Imagine the case where a PoolRebalanceLeaf is manually constructed and proposed, and not disputed on purpose, even though its conventionally "invalid". How should the Dataworker deal with it? For now, I've filtered out Propose and Executed events but curious if this is sufficient or too much?