### PR TITLE
WIP: Dataworker should cache older Deposit/Fill events

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -442,7 +442,7 @@ export class SpokePoolClient {
   private async setDepositDataInCache(newData: CachedDepositData) {
     if (!this.configStoreClient.redisClient) return;
     const key = `deposit_data_${this.chainId}`;
-    // await this.configStoreClient.redisClient.set(key, JSON.stringify(newData));
+    await this.configStoreClient.redisClient.set(key, JSON.stringify(newData));
   }
 
   // Neccessary to use this function because RedisDB can only store strings so we need to stringify the BN objects

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -13,6 +13,7 @@ import { CommonConfig } from "./Config";
 import { DataworkerClients } from "../dataworker/DataworkerClientHelper";
 import { createClient } from "redis4";
 import { SpokePoolClientsByChain } from "../interfaces";
+import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 
 export interface Clients {
   hubPoolClient: HubPoolClient;
@@ -35,7 +36,8 @@ export async function constructSpokePoolClientsForBlockAndUpdate(
   clients: DataworkerClients,
   logger: winston.Logger,
   latestMainnetBlock: number,
-  eventsToQuery?: string[]
+  eventsToQuery?: string[],
+  latestFullyExecutedBundleEndBlocks: { [chainId: number]: number } = {}
 ): Promise<{ [chainId: number]: SpokePoolClient }> {
   const spokePoolClients = Object.fromEntries(
     chainIdListForBundleEvaluationBlockNumbers.map((chainId) => {
@@ -55,7 +57,7 @@ export async function constructSpokePoolClientsForBlockAndUpdate(
       return [chainId, client];
     })
   );
-  await updateSpokePoolClients(spokePoolClients, eventsToQuery);
+  await updateSpokePoolClients(spokePoolClients, eventsToQuery, latestFullyExecutedBundleEndBlocks);
   return spokePoolClients;
 }
 
@@ -111,9 +113,14 @@ export async function constructSpokePoolClientsWithLookback(
 
 export async function updateSpokePoolClients(
   spokePoolClients: { [chainId: number]: SpokePoolClient },
-  eventsToQuery?: string[]
+  eventsToQuery?: string[],
+  latestFullyExecutedBundleEndBlocks: { [chainId: number]: number } = {}
 ) {
-  await Promise.all(Object.values(spokePoolClients).map((client: SpokePoolClient) => client.update(eventsToQuery)));
+  await Promise.all(
+    Object.values(spokePoolClients).map((client: SpokePoolClient) =>
+      client.update(eventsToQuery, latestFullyExecutedBundleEndBlocks[client.chainId])
+    )
+  );
 }
 
 export async function constructClients(logger: winston.Logger, config: CommonConfig): Promise<Clients> {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1072,7 +1072,6 @@ export class Dataworker {
           );
 
           if (tree.getHexRoot() !== rootBundleRelay.relayerRefundRoot) {
-            console.log(leaves, rootBundleRelay.rootBundleId)
             this.logger.warn({
               at: "Dataworke#executeRelayerRefundLeaves",
               message: "Constructed a different root for the block range!",

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1072,6 +1072,7 @@ export class Dataworker {
           );
 
           if (tree.getHexRoot() !== rootBundleRelay.relayerRefundRoot) {
+            console.log(leaves, rootBundleRelay.rootBundleId)
             this.logger.warn({
               at: "Dataworke#executeRelayerRefundLeaves",
               message: "Constructed a different root for the block range!",

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -46,6 +46,18 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
       // Clear cache so results can be updated with new data.
       dataworker.clearCache();
       await updateDataworkerClients(clients);
+
+      // Grab end blocks for latest fully executed bundle. We can use this block to optimize the dataworker event
+      // search by loading partially from the cache.
+      const latestFullyExecutedBundleEndBlocks = clients.hubPoolClient.getLatestFullyExecutedRootBundle(
+        clients.hubPoolClient.latestBlockNumber
+      ).bundleEvaluationBlockNumbers;
+      const bundleEndBlockMapping = Object.fromEntries(
+        dataworker.chainIdListForBundleEvaluationBlockNumbers.map((chainId, index) => {
+          return [chainId, latestFullyExecutedBundleEndBlocks[index].toNumber()];
+        })
+      )
+    
       if (spokePoolClients === undefined)
         spokePoolClients = await constructSpokePoolClientsForBlockAndUpdate(
           dataworker.chainIdListForBundleEvaluationBlockNumbers,
@@ -59,17 +71,22 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
             "EnabledDepositRoute",
             "RelayedRootBundle",
             "ExecutedRelayerRefundRoot",
-          ]
+          ],
+          bundleEndBlockMapping
         );
       else
-        await updateSpokePoolClients(spokePoolClients, [
-          "FundsDeposited",
-          "RequestedSpeedUpDeposit",
-          "FilledRelay",
-          "EnabledDepositRoute",
-          "RelayedRootBundle",
-          "ExecutedRelayerRefundRoot",
-        ]);
+        await updateSpokePoolClients(
+          spokePoolClients,
+          [
+            "FundsDeposited",
+            "RequestedSpeedUpDeposit",
+            "FilledRelay",
+            "EnabledDepositRoute",
+            "RelayedRootBundle",
+            "ExecutedRelayerRefundRoot",
+          ],
+          bundleEndBlockMapping
+        );
 
       // Validate and dispute pending proposal before proposing a new one
       if (config.disputerEnabled)

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -20,6 +20,22 @@ export interface Deposit {
 export interface DepositWithBlock extends Deposit, SortableEvent {
   originBlockNumber: number;
 }
+
+export interface DepositWithBlockInCache extends SortableEvent {
+  depositId: number;
+  depositor: string;
+  recipient: string;
+  originToken: string;
+  amount: string;
+  originChainId: number;
+  destinationChainId: number;
+  relayerFeePct: string;
+  quoteTimestamp: number;
+  realizedLpFeePct: string;
+  destinationToken: string;
+  originBlockNumber: number;
+  speedUpSignature?: string | undefined;
+}
 export interface Fill {
   amount: BigNumber;
   totalFilledAmount: BigNumber;


### PR DESCRIPTION
The idea behind this PR is that the Dataworker should be able to cache events older than the latest validated root bundle's evaluation end blocks