### PR TITLE
feat(monitor): Report stuck HubPool -> SpokePool rebalances

### DIFF
--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -13,8 +13,6 @@ const l1Gateways = {
 
 const l1GatewayRouter = "0x72ce9c846789fdb6fc1f34ac4ad25dd9ef7031ef";
 
-const firstL1BlockToSearch = 12640865;
-
 const l2Gateways = {
   "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "0x096760F208390250649E3e8763348E783AEF5562", // USDC
   "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "0x6c411aD3E74De3E7Bd422b94A27770f5B86C623B", // WETH
@@ -38,7 +36,7 @@ export class ArbitrumAdapter extends BaseAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     readonly monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, 42161, firstL1BlockToSearch);
+    super(spokePoolClients, 42161);
   }
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]) {

--- a/src/clients/bridges/OptimismAdapter.ts
+++ b/src/clients/bridges/OptimismAdapter.ts
@@ -10,9 +10,6 @@ const customL1OptimismBridgeAddresses = {
 const l1StandardBridgeAddressOvm = "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1";
 const l1StandardBridgeAddressBoba = "0xdc1664458d2f0B6090bEa60A8793A4E66c2F1c00";
 
-const firstL1BlockOvm = 13352477;
-const firstL1BlockBoba = 13012048;
-
 const ovmL2StandardBridgeAddress = "0x4200000000000000000000000000000000000010";
 const customOvmBridgeAddresses = {
   "0x6B175474E89094C44Da98b954EedeAC495271d0F": "0x467194771dae2967aef3ecbedd3bf9a310c76c65", // DAI
@@ -33,7 +30,7 @@ export class OptimismAdapter extends BaseAdapter {
   ) {
     // Note based on if this isOptimism or not we switch the chainId and starting L1 blocks. This is critical. If done
     // wrong funds WILL be deleted in the canonical bridge (eg sending funds to Optimism with a boba L2 token).
-    super(spokePoolClients, isOptimism ? 10 : 288, isOptimism ? firstL1BlockOvm : firstL1BlockBoba);
+    super(spokePoolClients, isOptimism ? 10 : 288);
     this.l2Gas = isOptimism ? 200000 : 1300000;
   }
 

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -53,8 +53,6 @@ const tokenToBridge = {
   }, // MATIC
 };
 
-const firstL1BlockToSearch = 10167767;
-
 const atomicDepositorAddress = "0x26eaf37ee5daf49174637bdcd2f7759a25206c34";
 
 export class PolygonAdapter extends BaseAdapter {
@@ -63,7 +61,7 @@ export class PolygonAdapter extends BaseAdapter {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     readonly monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, 137, firstL1BlockToSearch);
+    super(spokePoolClients, 137);
   }
 
   // On polygon a bridge transaction looks like a transfer from address(0) to the target.

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -37,8 +37,10 @@ export async function constructMonitorClients(config: MonitorConfig, logger: win
   );
   const tokenTransferClient = new TokenTransferClient(logger, providerPerChain, config.monitoredRelayers);
 
+  const spokePoolAddresses = Object.values(spokePoolClients).map((client) => client.spokePool.address);
   const adapterManager = new AdapterManager(logger, spokePoolClients, commonClients.hubPoolClient, [
     baseSigner.address,
+    ...spokePoolAddresses,
   ]);
   const crossChainTransferClient = new CrossChainTransferClient(logger, config.spokePoolChains, adapterManager);
 

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -3,11 +3,12 @@ import { ethers, BigNumber, ZERO_ADDRESS } from "../utils";
 
 // Set modes to true that you want to enable in the AcrossMonitor bot.
 export interface BotModes {
+  balancesEnabled: boolean;
+  reportEnabled: boolean;
+  stuckRebalancesEnabled: boolean;
   utilizationEnabled: boolean; // Monitors pool utilization ratio
   unknownRootBundleCallersEnabled: boolean; // Monitors relay related events triggered by non-whitelisted addresses
   unknownRelayerCallersEnabled: boolean;
-  reportEnabled: boolean;
-  balancesEnabled: boolean;
 }
 
 export class MonitorConfig extends CommonConfig {
@@ -17,7 +18,7 @@ export class MonitorConfig extends CommonConfig {
   readonly utilizationThreshold: number;
   readonly hubPoolStartingBlock: number | undefined;
   readonly hubPoolEndingBlock: number | undefined;
-  readonly monitorReportInterval: number;
+  readonly stuckRebalancesEnabled: boolean;
   readonly monitoredRelayers: string[];
   readonly whitelistedDataworkers: string[];
   readonly whitelistedRelayers: string[];
@@ -48,14 +49,16 @@ export class MonitorConfig extends CommonConfig {
       KNOWN_V1_ADDRESSES,
       BALANCES_ENABLED,
       MONITORED_BALANCES,
+      STUCK_REBALANCES_ENABLED,
     } = env;
 
     this.botModes = {
+      balancesEnabled: BALANCES_ENABLED === "true",
+      reportEnabled: MONITOR_REPORT_ENABLED === "true",
       utilizationEnabled: UTILIZATION_ENABLED === "true",
       unknownRootBundleCallersEnabled: UNKNOWN_ROOT_BUNDLE_CALLERS_ENABLED === "true",
       unknownRelayerCallersEnabled: UNKNOWN_RELAYER_CALLERS_ENABLED === "true",
-      reportEnabled: MONITOR_REPORT_ENABLED === "true",
-      balancesEnabled: BALANCES_ENABLED === "true",
+      stuckRebalancesEnabled: STUCK_REBALANCES_ENABLED === "true",
     };
 
     // Used to monitor activities not from whitelisted data workers or relayers.

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -26,6 +26,9 @@ export async function runMonitor(_logger: winston.Logger) {
       if (config.botModes.unknownRelayerCallersEnabled) await acrossMonitor.checkUnknownRelayers();
       else logger.debug({ at: "AcrossMonitor", message: "UnknownRelayerCallers monitor disabled" });
 
+      if (config.botModes.stuckRebalancesEnabled) await acrossMonitor.checkStuckRebalances();
+      else logger.debug({ at: "AcrossMonitor", message: "StuckRebalances monitor disabled" });
+
       if (config.botModes.reportEnabled) {
         await acrossMonitor.reportRelayerBalances();
         await acrossMonitor.reportUnfilledDeposits();

--- a/src/utils/ExecutionUtils.ts
+++ b/src/utils/ExecutionUtils.ts
@@ -16,7 +16,7 @@ export async function processCrash(logger: winston.Logger, fileName: String, pol
   logger.error({
     at: `${fileName}#index`,
     message: `There was an execution error! ${pollingDelay != 0 ? "Re-running loop" : ""}`,
-    error,
+    error: JSON.stringify(error),
     notificationPath: "across-error",
   });
   await delay(5);

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -10,8 +10,13 @@ import {
   TokenTransferClient,
   BalanceAllocator,
 } from "../src/clients";
-import { CrossChainTransferClient, AdapterManager } from "../src/clients/bridges";
-import { Monitor, ALL_CHAINS_NAME, UNKNOWN_TRANSFERS_NAME } from "../src/monitor/Monitor";
+import { CrossChainTransferClient } from "../src/clients/bridges";
+import {
+  Monitor,
+  ALL_CHAINS_NAME,
+  REBALANCE_FINALIZE_GRACE_PERIOD,
+  UNKNOWN_TRANSFERS_NAME,
+} from "../src/monitor/Monitor";
 import { MonitorConfig } from "../src/monitor/MonitorConfig";
 import { amountToDeposit, destinationChainId, mockTreeRoot, originChainId, repaymentChainId } from "./constants";
 import * as constants from "./constants";
@@ -210,22 +215,7 @@ describe("Monitor", async function () {
     expect(reports[depositor.address]["L1"][ALL_CHAINS_NAME][BalanceType.NEXT]).to.be.equal(getRefundForFills([fill1]));
 
     // Execute pool rebalance leaves.
-    const latestBlock = await hubPool.provider.getBlockNumber();
-    const blockRange = constants.CHAIN_ID_TEST_LIST.map((_) => [0, latestBlock]);
-    const expectedPoolRebalanceRoot = dataworkerInstance.buildPoolRebalanceRoot(blockRange, spokePoolClients);
-    await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
-    for (const leaf of expectedPoolRebalanceRoot.leaves) {
-      await hubPool.executeRootBundle(
-        leaf.chainId,
-        leaf.groupIndex,
-        leaf.bundleLpFees,
-        leaf.netSendAmounts,
-        leaf.runningBalances,
-        leaf.leafId,
-        leaf.l1Tokens,
-        expectedPoolRebalanceRoot.tree.getHexProof(leaf)
-      );
-    }
+    await executeBundle(hubPool);
 
     // Before relayer refund leaves are executed, the refund is now in the pending column
     await monitorInstance.update();
@@ -274,6 +264,51 @@ describe("Monitor", async function () {
     ).to.be.equal(toBN(5));
   });
 
+  it("Monitor should report stuck rebalances", async function () {
+    await updateAllClients();
+    await monitorInstance.update();
+    // Send a deposit and a fill so that dataworker builds simple roots.
+    const deposit = await buildDeposit(
+      configStoreClient,
+      hubPoolClient,
+      spokePool_1,
+      l2Token,
+      l1Token,
+      depositor,
+      destinationChainId,
+      amountToDeposit
+    );
+    await buildFillForRepaymentChain(spokePool_2, depositor, deposit, 0.5, destinationChainId);
+    await monitorInstance.update();
+
+    // Have the data worker propose a new bundle.
+    await dataworkerInstance.proposeRootBundle(spokePoolClients);
+    await l1Token.approve(hubPool.address, MAX_UINT_VAL);
+    await multiCallerClient.executeTransactionQueue();
+
+    // Execute pool rebalance leaves.
+    await executeBundle(hubPool);
+
+    // Fast-forward by 2 hours to pass the grace period.
+    await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + REBALANCE_FINALIZE_GRACE_PERIOD + 1);
+
+    // Simulate some pending cross chain transfers to SpokePools.
+    adapterManager.setMockedOutstandingCrossChainTransfers(
+      originChainId,
+      spokePool_1.address,
+      l1Token.address,
+      toBN(5)
+    );
+    await monitorInstance.update();
+    await monitorInstance.checkStuckRebalances();
+
+    expect(lastSpyLogIncludes(spy, "HubPool -> SpokePool rebalances stuck 🦴")).to.be.true;
+    const log = spy.lastCall;
+    expect(log.lastArg.mrkdwn).to.contains(
+      `Rebalances of ${await l1Token.symbol()} to ${getNetworkName(originChainId)} is stuck`
+    );
+  });
+
   it("Monitor should report unfilled deposits", async function () {
     await updateAllClients();
     await monitorInstance.update();
@@ -309,3 +344,22 @@ describe("Monitor", async function () {
     expect(lastSpyLogIncludes(spy, `Transfers that are not fills for relayer ${depositor.address} 🦨`)).to.be.true;
   });
 });
+
+const executeBundle = async (hubPool: Contract) => {
+  const latestBlock = await hubPool.provider.getBlockNumber();
+  const blockRange = constants.CHAIN_ID_TEST_LIST.map((_) => [0, latestBlock]);
+  const expectedPoolRebalanceRoot = dataworkerInstance.buildPoolRebalanceRoot(blockRange, spokePoolClients);
+  await hubPool.setCurrentTime(Number(await hubPool.getCurrentTime()) + Number(await hubPool.liveness()) + 1);
+  for (const leaf of expectedPoolRebalanceRoot.leaves) {
+    await hubPool.executeRootBundle(
+      leaf.chainId,
+      leaf.groupIndex,
+      leaf.bundleLpFees,
+      leaf.netSendAmounts,
+      leaf.runningBalances,
+      leaf.leafId,
+      leaf.l1Tokens,
+      expectedPoolRebalanceRoot.tree.getHexProof(leaf)
+    );
+  }
+};


### PR DESCRIPTION
This PR does 2 things:
1. Reduce adapters' event query by reusing max relayer lookback. Before they were always fetching from hardcoded block numbers which were weeks ago from the time of this PR.
2. Add support to the reporter to report stuck rebalances (HubPool -> SpokePool cross chain transfers). This uses a very simple approximation - if there are any pending cross chain transfers from HubPool -> SpokePool more than a certain amount of time (Grace period) from the last bundle execution, those funds must be stuck on the native bridge.