### PR TITLE
improve(relayer): Track which deposits the relayer has tried to fill so it doesn't double fill (waste of gas)

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -96,12 +96,6 @@ export class Relayer {
       return;
     }
 
-    // Only track complete fills by the relayer.
-    // TODO: Revisit in the future when we implement partial fills.
-    if (toBN(deposit.amount).eq(fillAmount)) {
-      this.fullyFilledDeposits[fillKey] = true;
-    }
-
     try {
       // Fetch the repayment chain from the inventory client. Sanity check that it is one of the known chainIds.
       const repaymentChain = this.clients.inventoryClient.determineRefundChainId(deposit);
@@ -118,6 +112,9 @@ export class Relayer {
         message: "Relay instantly sent 🚀", // message sent to logger.
         mrkdwn: this.constructRelayFilledMrkdwn(deposit, repaymentChain, fillAmount), // message details mrkdwn
       });
+
+      // TODO: Revisit in the future when we implement partial fills.
+      this.fullyFilledDeposits[fillKey] = true;
 
       // Decrement tokens in token client used in the fill. This ensures that we dont try and fill more than we have.
       this.clients.tokenClient.decrementLocalBalance(deposit.destinationChainId, deposit.destinationToken, fillAmount);

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -98,7 +98,7 @@ export class Relayer {
 
     // Only track complete fills by the relayer.
     // TODO: Revisit in the future when we implement partial fills.
-    if (deposit.amount.eq(fillAmount)) {
+    if (toBN(deposit.amount).eq(fillAmount)) {
       this.fullyFilledDeposits[fillKey] = true;
     }
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -3,10 +3,13 @@ import { createFormatFunction, etherscanLink, toBN } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
 
 import { Deposit } from "../interfaces";
+import { destinationChainId } from "@across-protocol/contracts-v2/dist/test/constants";
 
 const UNPROFITABLE_DEPOSIT_NOTICE_PERIOD = 60 * 60; // 1 hour
 
 export class Relayer {
+  private filledDepositsByChain: { [destinationChain: number]: { [depositId: number]: boolean } } = {};
+
   constructor(
     readonly relayerAddress: string,
     readonly logger: winston.Logger,
@@ -35,6 +38,17 @@ export class Relayer {
     // is has no other fills then send a 0 sized fill to initiate a slow relay. If unprofitable then add the
     // unprofitable tx to the unprofitable tx tracker to produce an appropriate log.
     for (const { deposit, unfilledAmount, fillCount } of unfilledDeposits) {
+      if (this.filledDepositsByChain[deposit.destinationChainId] === undefined) {
+        this.filledDepositsByChain[deposit.destinationChainId] = {};
+      }
+      // Skip deposits that this relayer has already filled to prevent double filling (which is a waste of gas as the
+      // second fill would fail).
+      // TODO: Handle the edge case scenario where the first fill failed due to transient errors and needs to be retried
+      if (this.filledDepositsByChain[deposit.destinationChainId][deposit.depositId]) {
+        continue;
+      }
+      this.filledDepositsByChain[deposit.destinationChainId][deposit.depositId] = true;
+
       // Skip any L1 tokens that are not specified in the config.
       // If relayerTokens is an empty list, we'll assume that all tokens are supported.
       const l1Token = this.clients.hubPoolClient.getL1TokenInfoForL2Token(deposit.originToken, deposit.originChainId);


### PR DESCRIPTION
Currently when run in looping mode with POLLING_DELAY of 30s, the relayer bot sometimes double fill (second fill for the same deposit fails, which is a waste of gas). This happens very frequently for even smaller POLLING_DELAY such as 10s.

This solution keeps track of filled deposits in memory so that when run in looping mode, the relayer wouldn't try to do double fill when the first fill is still pending.