### PR TITLE
improve: Set defaults for relayer deposit lookback

### DIFF
--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -33,7 +33,10 @@ export class CommonConfig {
     } = env;
 
     // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
-    this.maxRelayerLookBack = MAX_RELAYER_DEPOSIT_LOOK_BACK ? JSON.parse(MAX_RELAYER_DEPOSIT_LOOK_BACK) : {};
+    this.maxRelayerLookBack = MAX_RELAYER_DEPOSIT_LOOK_BACK
+      ? JSON.parse(MAX_RELAYER_DEPOSIT_LOOK_BACK)
+      : Constants.MAX_RELAYER_DEPOSIT_LOOK_BACK;
+
     // `maxRelayerUnfilledDepositLookBack` informs relayer to ignore any unfilled deposits older than this amount of
     // of blocks from latest. This allows us to ignore any false positive unfilled deposits that occur because of how
     // `maxRelayerLookBack` is set. This can happen because block lookback per chain is not exactly equal to the same

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -3,12 +3,12 @@
 export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];
 
 export const MAX_RELAYER_DEPOSIT_LOOK_BACK: { [chainId: number]: number } = {
-    1: 11500,
-    10: 350000,
-    137: 70000,
-    288: 6000,
-    42161: 35000,
-}
+  1: 11500,
+  10: 350000,
+  137: 70000,
+  288: 6000,
+  42161: 35000,
+};
 
 // Optimism, ethereum can do infinity lookbacks. boba and Arbitrum limited to 100000 on infura.
 export const CHAIN_MAX_BLOCK_LOOKBACK = {

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -2,6 +2,14 @@
 // in the HubPool's proposeRootBundle method should be: Mainnet, Optimism, Polygon, Boba, Arbitrum
 export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];
 
+export const MAX_RELAYER_DEPOSIT_LOOK_BACK: { [chainId: number]: number } = {
+    1: 11500,
+    10: 350000,
+    137: 70000,
+    288: 6000,
+    42161: 35000,
+}
+
 // Optimism, ethereum can do infinity lookbacks. boba and Arbitrum limited to 100000 on infura.
 export const CHAIN_MAX_BLOCK_LOOKBACK = {
   1: 0, // Note: 0 gets defaulted to infinity lookback

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -2,12 +2,13 @@
 // in the HubPool's proposeRootBundle method should be: Mainnet, Optimism, Polygon, Boba, Arbitrum
 export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];
 
+// Target ~2 days per chain. Avg. block times: { 1: 15s, 10/42161: 0.5s, 137: 2.5s, 288: 30s }
 export const MAX_RELAYER_DEPOSIT_LOOK_BACK: { [chainId: number]: number } = {
   1: 11500,
   10: 350000,
   137: 70000,
   288: 6000,
-  42161: 35000,
+  42161: 350000,
 };
 
 // Optimism, ethereum can do infinity lookbacks. boba and Arbitrum limited to 100000 on infura.


### PR DESCRIPTION
Enables the user to avoid manually setting MAX_RELAYER_DEPOSIT_LOOK_BACK
in their environment, thereby making the overall configuration simpler. The default
values match the configuration recommended in the Across GitBook.

Ref: ACX-73