### PR TITLE
improve: Explicitly indicate gzip support in provider config

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -238,7 +238,9 @@ export function getProvider(chainId: number) {
   const timeout = Number(process.env[`NODE_TIMEOUT_${chainId}`] || NODE_TIMEOUT || defaultTimeout);
 
   const constructorArgumentLists = getNodeUrlList(chainId).map(
-    (nodeUrl): [{ url: string; timeout: number }, number] => [{ url: nodeUrl, timeout }, chainId]
+    (nodeUrl): [{
+      url: string; timeout: number; allowGzip: boolean
+    }, number] => [ { url: nodeUrl, timeout, allowGzip: true }, chainId ]
   );
 
   // Default to 2 retries.


### PR DESCRIPTION
This seems to be a client-side flag to the RPC that it will accept
gzip-compressed responses. Per the ethers documentation, this
flag actually defaults to false. The decision as to whether to
compress (or not) should be up to the server. Infura don't appear
to support it yet, but Alchemy are pretty positive about it:

> To provide users with better product experiences, we updated our
> internal infrastructure to offer Alchemy developers support for
> gzip compression on all responses larger than 1kb in size.

> Gzip compression offers up to a 95% decrease in the size of files
> sent over a streaming connection. However, the actual latency and
> bandwidth savings is dependent on the structure of data being
> broadcast, the connection speeds of the client and server, and the
> size of the response.

> In practice, we’ve seen roughly a 75% improvement in the total
> latency of typical JSON-RPC replayTransaction calls.

Note: I've tested that it works with a peasant-tier Alchemy plan, but
haven't actually checked to see whether it performs better yet. I'm
just placing this here in case anyone else wants to give it a try with
heavier loads.

Ref: ACX-67