### PR TITLE
fix: BundleDataClient.loadData should filter allValidFills younger than bundle end block

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -230,8 +230,7 @@ export class BundleDataClient {
             // time. Note that its important we don't skip fills earlier than the block range at this step because
             // we use allValidFills to find the first fill in the entire history associated with a fill in the block
             // range, in order to determine if we already sent a slow fill for it.
-            if (fillWithBlock.blockNumber <= blockRangeForChain[1])
-              allValidFills.push(fillWithBlock);
+            if (fillWithBlock.blockNumber <= blockRangeForChain[1]) allValidFills.push(fillWithBlock);
 
             // If fill is outside block range, we can skip it now since we're not going to add a refund for it.
             if (fillWithBlock.blockNumber > blockRangeForChain[1] || fillWithBlock.blockNumber < blockRangeForChain[0])

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -227,10 +227,11 @@ export class BundleDataClient {
           const matchedDeposit: Deposit = originClient.getDepositForFill(fillWithBlock);
           if (matchedDeposit) {
             // Fill was validated. Save it under all validated fills list with the block number so we can sort it by
-            // time. Note that its important we don't skip fills outside of the block range at this step because
+            // time. Note that its important we don't skip fills earlier than the block range at this step because
             // we use allValidFills to find the first fill in the entire history associated with a fill in the block
             // range, in order to determine if we already sent a slow fill for it.
-            allValidFills.push(fillWithBlock);
+            if (fillWithBlock.blockNumber <= blockRangeForChain[1])
+              allValidFills.push(fillWithBlock);
 
             // If fill is outside block range, we can skip it now since we're not going to add a refund for it.
             if (fillWithBlock.blockNumber > blockRangeForChain[1] || fillWithBlock.blockNumber < blockRangeForChain[0])


### PR DESCRIPTION
Motivation: Proposer is disputing itself when current bundle is not correctly pulling back funds from L2 to account for "excess" tokens left on SpokePool following a slow fill payment sent in previous bundle that was fully filled before the slow fill leaf was executed. In particular, [this function](https://github.com/across-protocol/relayer-v2/blob/master/src/dataworker/PoolRebalanceUtils.ts#L163) contains the bug

Summary:
- `getFillDataForSlowFillFromPreviousRootBundle` is supposed to return the last fill that completed a slow fill, but it searches for that fill within `allValidFills` which contains all blocks up until HEAD.
- This is an issue because the bundle end blocks all lag HEAD by ~20-30 mins, so its possible that the last fill completing a slow fill was sent very recently (close to the proposal block number) is missed by the proposer, but seen by the disputer.
- The fix is to make sure that `allValidFills` cuts off at the bundle end blocks.﻿
