### PR TITLE
improve: Change gas requirement for Arbitrum l1 --> l2 messages

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1241,11 +1241,11 @@ export class Dataworker {
     //    signified by groupIndex === 0.
     // 2. Any netSendAmount > 0 triggers an L1 -> L2 token send, which costs 0.02 ETH.
     let requiredAmount = leaf.netSendAmounts.reduce(
-      (acc, curr) => (curr.gt(0) ? acc.add(toBNWei("0.034")) : acc),
+      (acc, curr) => (curr.gt(0) ? acc.add(toBNWei("0.02")) : acc),
       BigNumber.from(0)
     );
 
-    if (leaf.groupIndex === 0) requiredAmount = requiredAmount.add(toBNWei("0.034"));
+    if (leaf.groupIndex === 0) requiredAmount = requiredAmount.add(toBNWei("0.02"));
     return requiredAmount;
   }
 }


### PR DESCRIPTION
Dataworker needs to be aware of required L1 call value for executing pool rebalance leaves, not sure why 0.034 was set before that was a mistake it should have been 0.13 but setting this value too high doesn't cause errors its just capital inefficient