### PR TITLE
fix: Dataworker should filter out all deposits younger than bundle end block

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -222,51 +222,55 @@ export class BundleDataClient {
         );
 
         // Find all valid fills matching a deposit on the origin chain and sent on the destination chain.
-        destinationClient.getFillsWithBlockForOriginChain(Number(originChainId)).forEach((fillWithBlock) => {
-          // If fill matches with a deposit, then its a valid fill.
-          const matchedDeposit: Deposit = originClient.getDepositForFill(fillWithBlock);
-          if (matchedDeposit) {
-            // Fill was validated. Save it under all validated fills list with the block number so we can sort it by
-            // time. Note that its important we don't skip fills earlier than the block range at this step because
-            // we use allValidFills to find the first fill in the entire history associated with a fill in the block
-            // range, in order to determine if we already sent a slow fill for it.
-            if (fillWithBlock.blockNumber <= blockRangeForChain[1]) allValidFills.push(fillWithBlock);
+        // Don't include any fills past the bundle end block for the chain, otherwise the destination client will
+        // return fill events that are younger than the bundle end block.
+        destinationClient
+          .getFillsWithBlockForOriginChain(Number(originChainId))
+          .filter((fillWithBlock) => fillWithBlock.blockNumber <= blockRangeForChain[1])
+          .forEach((fillWithBlock) => {
+            // If fill matches with a deposit, then its a valid fill.
+            const matchedDeposit: Deposit = originClient.getDepositForFill(fillWithBlock);
+            if (matchedDeposit) {
+              // Fill was validated. Save it under all validated fills list with the block number so we can sort it by
+              // time. Note that its important we don't skip fills earlier than the block range at this step because
+              // we use allValidFills to find the first fill in the entire history associated with a fill in the block
+              // range, in order to determine if we already sent a slow fill for it.
+              allValidFills.push(fillWithBlock);
 
-            // If fill is outside block range, we can skip it now since we're not going to add a refund for it.
-            if (fillWithBlock.blockNumber > blockRangeForChain[1] || fillWithBlock.blockNumber < blockRangeForChain[0])
-              return;
+              // If fill is outside block range, we can skip it now since we're not going to add a refund for it.
+              if (fillWithBlock.blockNumber < blockRangeForChain[0]) return;
 
-            // Now create a copy of fill with block data removed, and use its data to update the fills to refund obj.
-            const { blockNumber, transactionIndex, transactionHash, logIndex, ...fill } = fillWithBlock;
-            const { chainToSendRefundTo, repaymentToken } = getRefundInformationFromFill(
-              fill,
-              this.clients.hubPoolClient,
-              blockRangesForChains,
-              this.chainIdListForBundleEvaluationBlockNumbers
-            );
+              // Now create a copy of fill with block data removed, and use its data to update the fills to refund obj.
+              const { blockNumber, transactionIndex, transactionHash, logIndex, ...fill } = fillWithBlock;
+              const { chainToSendRefundTo, repaymentToken } = getRefundInformationFromFill(
+                fill,
+                this.clients.hubPoolClient,
+                blockRangesForChains,
+                this.chainIdListForBundleEvaluationBlockNumbers
+              );
 
-            // Fills to refund includes both slow and non-slow fills and they both should increase the
-            // total realized LP fee %.
-            assignValidFillToFillsToRefund(fillsToRefund, fill, chainToSendRefundTo, repaymentToken);
-            allRelayerRefunds.push({ repaymentToken, repaymentChain: chainToSendRefundTo });
-            updateTotalRealizedLpFeePct(fillsToRefund, fill, chainToSendRefundTo, repaymentToken);
+              // Fills to refund includes both slow and non-slow fills and they both should increase the
+              // total realized LP fee %.
+              assignValidFillToFillsToRefund(fillsToRefund, fill, chainToSendRefundTo, repaymentToken);
+              allRelayerRefunds.push({ repaymentToken, repaymentChain: chainToSendRefundTo });
+              updateTotalRealizedLpFeePct(fillsToRefund, fill, chainToSendRefundTo, repaymentToken);
 
-            // Save deposit as one that is eligible for a slow fill, since there is a fill
-            // for the deposit in this epoch. We save whether this fill is the first fill for the deposit, because
-            // if a deposit has its first fill in this block range, then we can send a slow fill payment to complete
-            // the deposit. If other fills end up completing this deposit, then we'll remove it from the unfilled
-            // deposits later.
-            updateUnfilledDepositsWithMatchedDeposit(fill, matchedDeposit, unfilledDepositsForOriginChain);
+              // Save deposit as one that is eligible for a slow fill, since there is a fill
+              // for the deposit in this epoch. We save whether this fill is the first fill for the deposit, because
+              // if a deposit has its first fill in this block range, then we can send a slow fill payment to complete
+              // the deposit. If other fills end up completing this deposit, then we'll remove it from the unfilled
+              // deposits later.
+              updateUnfilledDepositsWithMatchedDeposit(fill, matchedDeposit, unfilledDepositsForOriginChain);
 
-            // Update total refund counter for convenience when constructing relayer refund leaves
-            updateTotalRefundAmount(fillsToRefund, fill, chainToSendRefundTo, repaymentToken);
-          } else {
-            // Note: If the fill's origin chain is set incorrectly (e.g. equal to the destination chain, or
-            // set to some unexpected chain), then it won't be added to `allInvalidFills` because we wouldn't
-            // have been able to grab it from the destinationClient.getFillsWithBlockForOriginChain call.
-            allInvalidFills.push(fillWithBlock);
-          }
-        });
+              // Update total refund counter for convenience when constructing relayer refund leaves
+              updateTotalRefundAmount(fillsToRefund, fill, chainToSendRefundTo, repaymentToken);
+            } else {
+              // Note: If the fill's origin chain is set incorrectly (e.g. equal to the destination chain, or
+              // set to some unexpected chain), then it won't be added to `allInvalidFills` because we wouldn't
+              // have been able to grab it from the destinationClient.getFillsWithBlockForOriginChain call.
+              allInvalidFills.push(fillWithBlock);
+            }
+          });
       }
     }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1227,7 +1227,8 @@ export class Dataworker {
         this.clients,
         this.chainIdListForBundleEvaluationBlockNumbers,
         this.maxL1TokenCountOverride,
-        this.tokenTransferThreshold
+        this.tokenTransferThreshold,
+        this.logger
       );
     }
 


### PR DESCRIPTION
Same motivation and logic as https://github.com/across-protocol/relayer-v2/pull/221 but this filter on fillWithBlock is set higher in the function.

I don't know if this fixes the underlying bug, but the current situation is that sometimes proposer and disputer see the exact same deposits and fills in the range but construct different `netSendAmounts/runningBalances`, with the disputer consistently seeing lower values.

My guess is that there is some bug in `dataworker/PoolRebanceUtils.ts/subtractExcessFromPreviousSlowFillsFromRunningBalances()` which could only lower the net send amounts.