### PR TITLE
improve(finalizer): Don't filter out older token bridge events

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -48,8 +48,7 @@ export async function finalize(
     if (chainId === 42161) {
       // Skip events that are likely not past the seven day challenge period.
       const olderTokensBridgedEvents = tokensBridged.filter(
-        (e) =>
-          e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow
+        (e) => e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow
       );
       const finalizableMessages = await getFinalizableMessages(logger, olderTokensBridgedEvents, hubSigner);
       for (const l2Message of finalizableMessages) {
@@ -72,8 +71,7 @@ export async function finalize(
     } else if (chainId === 10) {
       // Skip events that are likely not past the seven day challenge period.
       const olderTokensBridgedEvents = tokensBridged.filter(
-        (e) =>
-          e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow
+        (e) => e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow
       );
       const crossChainMessenger = getOptimismClient(hubSigner);
       const finalizableMessages = await getOptimismFinalizableMessages(

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -46,12 +46,10 @@ export async function finalize(
     const tokensBridged = client.getTokensBridged();
 
     if (chainId === 42161) {
-      // Skip events that are definitely not past the seven day challenge period, and those that are really
-      // old and have already been finalized.
+      // Skip events that are likely not past the seven day challenge period.
       const olderTokensBridgedEvents = tokensBridged.filter(
         (e) =>
-          e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow &&
-          e.blockNumber >= client.latestBlockNumber - 2 * optimisticRollupFinalizationWindow
+          e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow
       );
       const finalizableMessages = await getFinalizableMessages(logger, olderTokensBridgedEvents, hubSigner);
       for (const l2Message of finalizableMessages) {
@@ -72,12 +70,10 @@ export async function finalize(
         await retrieveTokenFromMainnetTokenBridger(logger, l2Token, hubSigner, hubPoolClient);
       }
     } else if (chainId === 10) {
-      // Skip events that are definitely not past the seven day challenge period, and those that are really
-      // old and have already been finalized.
+      // Skip events that are likely not past the seven day challenge period.
       const olderTokensBridgedEvents = tokensBridged.filter(
         (e) =>
-          e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow &&
-          e.blockNumber >= client.latestBlockNumber - 2 * optimisticRollupFinalizationWindow
+          e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow
       );
       const crossChainMessenger = getOptimismClient(hubSigner);
       const finalizableMessages = await getOptimismFinalizableMessages(


### PR DESCRIPTION
L2 block times are hard to predict so we shouldn't filter out events that are "too old", but we can continue to filter out TokensBridged events that are "too young" because eventually they'll be old enough
