### PR TITLE
improve: bot exception handling

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,9 +21,8 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
     relayer: runRelayer,
   };
 
-  /* todo Make the mode of operation an operand, rather than an option.
-   * i.e. ts-node ./index.ts [options] <relayer|...>
-   */
+  // todo Make the mode of operation an operand, rather than an option.
+  // i.e. ts-node ./index.ts [options] <relayer|...>
   const cmd = Object.keys(cmds).find((_cmd) => !!args[_cmd]);
 
   if (cmd === "help") cmds[cmd](); // no return

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -134,6 +134,6 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
     logger.debug("Disconnecting from redis server.");
     clients.configStoreClient.redisClient.disconnect();
 
-    throw error
+    throw error;
   }
 }

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -127,9 +127,6 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
       if (await processEndPollingLoop(logger, "Dataworker", config.pollingDelay)) break;
     }
   } catch (error) {
-    // eslint-disable-next-line no-process-exit
-    if (await processCrash(logger, "Dataworker", config.pollingDelay, error)) process.exit(1);
-
     if (clients.configStoreClient.redisClient !== undefined) {
       // todo understand why redisClient isn't GCed automagically.
       logger.debug("Disconnecting from redis server.");

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -130,9 +130,11 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
     // eslint-disable-next-line no-process-exit
     if (await processCrash(logger, "Dataworker", config.pollingDelay, error)) process.exit(1);
 
-    // todo understand why redisClient isn't GCed automagically.
-    logger.debug("Disconnecting from redis server.");
-    clients.configStoreClient.redisClient.disconnect();
+    if (clients.configStoreClient.redisClient !== undefined) {
+      // todo understand why redisClient isn't GCed automagically.
+      logger.debug("Disconnecting from redis server.");
+      clients.configStoreClient.redisClient.disconnect();
+    }
 
     throw error;
   }

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -134,6 +134,6 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
     logger.debug("Disconnecting from redis server.");
     clients.configStoreClient.redisClient.disconnect();
 
-    await runDataworker(logger);
+    throw error
   }
 }

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -129,6 +129,11 @@ export async function runDataworker(_logger: winston.Logger): Promise<void> {
   } catch (error) {
     // eslint-disable-next-line no-process-exit
     if (await processCrash(logger, "Dataworker", config.pollingDelay, error)) process.exit(1);
+
+    // todo understand why redisClient isn't GCed automagically.
+    logger.debug("Disconnecting from redis server.");
+    clients.configStoreClient.redisClient.disconnect();
+
     await runDataworker(logger);
   }
 }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -157,9 +157,6 @@ export async function runFinalizer(_logger: winston.Logger): Promise<void> {
       if (await processEndPollingLoop(logger, "Dataworker", config.pollingDelay)) break;
     }
   } catch (error) {
-    // eslint-disable-next-line no-process-exit
-    if (await processCrash(logger, "Dataworker", config.pollingDelay, error)) process.exit(1);
-
     if (commonClients.configStoreClient.redisClient !== undefined) {
       // If this throws an exception, it will mask the underlying error.
       logger.debug("Disconnecting from redis server.");

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -159,6 +159,10 @@ export async function runFinalizer(_logger: winston.Logger): Promise<void> {
   } catch (error) {
     // eslint-disable-next-line no-process-exit
     if (await processCrash(logger, "Dataworker", config.pollingDelay, error)) process.exit(1);
+
+    // If this throws an exception, it will mask the underlying error.
+    commonClients.configStoreClient.redisClient.disconnect();
+
     await runFinalizer(logger);
   }
 }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -162,7 +162,6 @@ export async function runFinalizer(_logger: winston.Logger): Promise<void> {
 
     // If this throws an exception, it will mask the underlying error.
     commonClients.configStoreClient.redisClient.disconnect();
-
-    await runFinalizer(logger);
+    throw error
   }
 }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -160,8 +160,11 @@ export async function runFinalizer(_logger: winston.Logger): Promise<void> {
     // eslint-disable-next-line no-process-exit
     if (await processCrash(logger, "Dataworker", config.pollingDelay, error)) process.exit(1);
 
-    // If this throws an exception, it will mask the underlying error.
-    commonClients.configStoreClient.redisClient.disconnect();
+    if (commonClients.configStoreClient.redisClient !== undefined) {
+      // If this throws an exception, it will mask the underlying error.
+      logger.debug("Disconnecting from redis server.");
+      commonClients.configStoreClient.redisClient.disconnect();
+    }
     throw error;
   }
 }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -162,6 +162,6 @@ export async function runFinalizer(_logger: winston.Logger): Promise<void> {
 
     // If this throws an exception, it will mask the underlying error.
     commonClients.configStoreClient.redisClient.disconnect();
-    throw error
+    throw error;
   }
 }

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -49,7 +49,6 @@ export async function runMonitor(_logger: winston.Logger) {
       logger.debug("Disconnecting from redis server.");
       clients.configStoreClient.redisClient.disconnect();
     }
-
-    await runMonitor(logger);
+    throw error
   }
 }

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -41,9 +41,6 @@ export async function runMonitor(_logger: winston.Logger) {
       if (await processEndPollingLoop(logger, "Monitor", config.pollingDelay)) break;
     }
   } catch (error) {
-    // eslint-disable-next-line no-process-exit
-    if (await processCrash(logger, "Monitor", config.pollingDelay, error)) process.exit(1);
-
     if (clients !== undefined && clients.configStoreClient.redisClient !== undefined) {
       // todo understand why redisClient isn't GCed automagically.
       logger.debug("Disconnecting from redis server.");

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -49,6 +49,6 @@ export async function runMonitor(_logger: winston.Logger) {
       logger.debug("Disconnecting from redis server.");
       clients.configStoreClient.redisClient.disconnect();
     }
-    throw error
+    throw error;
   }
 }

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -8,10 +8,12 @@ let logger: winston.Logger;
 export async function runMonitor(_logger: winston.Logger) {
   logger = _logger;
   const config = new MonitorConfig(process.env);
+  let clients;
+
   try {
     logger[startupLogLevel(config)]({ at: "AcrossMonitor#index", message: "Monitor started 🔭", config });
 
-    const clients = await constructMonitorClients(config, logger);
+    clients = await constructMonitorClients(config, logger);
     const acrossMonitor = new Monitor(logger, config, clients);
 
     for (;;) {
@@ -41,6 +43,13 @@ export async function runMonitor(_logger: winston.Logger) {
   } catch (error) {
     // eslint-disable-next-line no-process-exit
     if (await processCrash(logger, "Monitor", config.pollingDelay, error)) process.exit(1);
+
+    if (clients !== undefined) {
+      // todo understand why redisClient isn't GCed automagically.
+      logger.debug("Disconnecting from redis server.");
+      clients.configStoreClient.redisClient.disconnect();
+    }
+
     await runMonitor(logger);
   }
 }

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -44,7 +44,7 @@ export async function runMonitor(_logger: winston.Logger) {
     // eslint-disable-next-line no-process-exit
     if (await processCrash(logger, "Monitor", config.pollingDelay, error)) process.exit(1);
 
-    if (clients !== undefined) {
+    if (clients !== undefined && clients.configStoreClient.redisClient !== undefined) {
       // todo understand why redisClient isn't GCed automagically.
       logger.debug("Disconnecting from redis server.");
       clients.configStoreClient.redisClient.disconnect();

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -49,7 +49,7 @@ export async function runRelayer(_logger: winston.Logger): Promise<void> {
     // eslint-disable-next-line no-process-exit
     if (await processCrash(logger, "Relayer", config.pollingDelay, error)) process.exit(1);
 
-    if (relayerClients !== undefined) {
+    if (relayerClients !== undefined && relayerClients.configStoreClient.redisClient !== undefined) {
       // todo understand why redisClient isn't GCed automagically.
       logger.debug("Disconnecting from redis server.");
       relayerClients.configStoreClient.redisClient.disconnect();

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -54,7 +54,6 @@ export async function runRelayer(_logger: winston.Logger): Promise<void> {
       logger.debug("Disconnecting from redis server.");
       relayerClients.configStoreClient.redisClient.disconnect();
     }
-
-    await runRelayer(logger);
+    throw error
   }
 }

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -46,9 +46,6 @@ export async function runRelayer(_logger: winston.Logger): Promise<void> {
       if (await processEndPollingLoop(logger, "Relayer", config.pollingDelay)) break;
     }
   } catch (error) {
-    // eslint-disable-next-line no-process-exit
-    if (await processCrash(logger, "Relayer", config.pollingDelay, error)) process.exit(1);
-
     if (relayerClients !== undefined && relayerClients.configStoreClient.redisClient !== undefined) {
       // todo understand why redisClient isn't GCed automagically.
       logger.debug("Disconnecting from redis server.");

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -54,6 +54,6 @@ export async function runRelayer(_logger: winston.Logger): Promise<void> {
       logger.debug("Disconnecting from redis server.");
       relayerClients.configStoreClient.redisClient.disconnect();
     }
-    throw error
+    throw error;
   }
 }


### PR DESCRIPTION
This PR addresses two main observations:

1. The existing exception handling recursively calls into the same function that experienced the exception. With a non-zero POLLING_DELAY, this increase stack usage and will leak memory.

2. For some unknown reason, Redis client instances don't appear to be GC'ed after they have gone out of scope. This means that Redis connections are maintained indefinitely - even though they are not used. When an exception is caught by the top-level handler, this results in a new connection being established. At some point, the server will stop accepting new connections. I have seen the bot hang in this scenario.

The fix for (1) is easy enough - exceptions that are otherwise unhandled will now ripple all the way back to the top-level index.ts, which avoids recursive re-entry.

A workaround/bodge is proposed to address (2). There's some underlying issue here that needs deeper investigation; the proposed workaround simply manually shuts down the Redis connection before re-throwing whatever underlying exception occurred.

As an observation from this work, there is some "common" functionality that is repeated across each supported sub-function (dataworker, finalizer, monitor, relayer). This can be seen in that the redis teardown had to be inserted in 4 separate places, all of which were very similar (but not identical). A future task could be to factor some of this common functionality out into the top-level index.ts.