### PR TITLE
fix(dataworker): Check for executed pool rebalance leaves until proposal block, not bundle end block

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -131,6 +131,7 @@ export class Dataworker {
 
     return this._getPoolRebalanceRoot(
       blockRangesForChains,
+      spokePoolClients[1].latestBlockNumber,
       endBlockForMainnet,
       fillsToRefund,
       deposits,
@@ -195,6 +196,7 @@ export class Dataworker {
     this.logger.debug({ at: "Dataworker", message: "Building pool rebalance root", blockRangesForProposal });
     const poolRebalanceRoot = this._getPoolRebalanceRoot(
       blockRangesForProposal,
+      spokePoolClients[1].latestBlockNumber,
       endBlockForMainnet,
       fillsToRefund,
       deposits,
@@ -548,6 +550,7 @@ export class Dataworker {
     );
     const expectedPoolRebalanceRoot = this._getPoolRebalanceRoot(
       blockRangesImpliedByBundleEndBlocks,
+      spokePoolClients[1].latestBlockNumber,
       endBlockForMainnet,
       fillsToRefund,
       deposits,
@@ -1115,6 +1118,7 @@ export class Dataworker {
           );
           const expectedPoolRebalanceRoot = this._getPoolRebalanceRoot(
             blockNumberRanges,
+            spokePoolClients[1].latestBlockNumber,
             endBlockForMainnet,
             fillsToRefund,
             deposits,
@@ -1277,7 +1281,8 @@ export class Dataworker {
 
   _getPoolRebalanceRoot(
     blockRangesForChains: number[][],
-    endBlockForMainnet: number,
+    latestMainnetBlock: number,
+    mainnetBundleEndBlock: number,
     fillsToRefund: FillsToRefund,
     deposits: DepositWithBlock[],
     allValidFills: FillWithBlock[],
@@ -1288,7 +1293,8 @@ export class Dataworker {
     const key = JSON.stringify(blockRangesForChains);
     if (!this.rootCache[key]) {
       this.rootCache[key] = _buildPoolRebalanceRoot(
-        endBlockForMainnet,
+        latestMainnetBlock,
+        mainnetBundleEndBlock,
         fillsToRefund,
         deposits,
         allValidFills,

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -216,7 +216,6 @@ export function _buildRelayerRefundRoot(
 }
 
 export function _buildPoolRebalanceRoot(
-  latestMainnetBlock: number,
   mainnetBundleEndBlock: number,
   fillsToRefund: FillsToRefund,
   deposits: DepositWithBlock[],
@@ -254,7 +253,7 @@ export function _buildPoolRebalanceRoot(
   // balances because the prior partial fill would have triggered a refund to be sent to the spoke pool to refund
   // a slow fill.
   const fillsTriggeringExcesses = subtractExcessFromPreviousSlowFillsFromRunningBalances(
-    latestMainnetBlock,
+    clients.hubPoolClient.latestBlockNumber,
     runningBalances,
     clients.hubPoolClient,
     allValidFills,

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -216,7 +216,8 @@ export function _buildRelayerRefundRoot(
 }
 
 export function _buildPoolRebalanceRoot(
-  endBlockForMainnet: number,
+  latestMainnetBlock: number,
+  mainnetBundleEndBlock: number,
   fillsToRefund: FillsToRefund,
   deposits: DepositWithBlock[],
   allValidFills: FillWithBlock[],
@@ -241,19 +242,19 @@ export function _buildPoolRebalanceRoot(
   initializeRunningBalancesFromRelayerRepayments(
     runningBalances,
     realizedLpFees,
-    endBlockForMainnet,
+    mainnetBundleEndBlock,
     clients.hubPoolClient,
     fillsToRefund
   );
 
   // Add payments to execute slow fills.
-  addSlowFillsToRunningBalances(endBlockForMainnet, runningBalances, clients.hubPoolClient, unfilledDeposits);
+  addSlowFillsToRunningBalances(mainnetBundleEndBlock, runningBalances, clients.hubPoolClient, unfilledDeposits);
 
   // For certain fills associated with another partial fill from a previous root bundle, we need to adjust running
   // balances because the prior partial fill would have triggered a refund to be sent to the spoke pool to refund
   // a slow fill.
   const fillsTriggeringExcesses = subtractExcessFromPreviousSlowFillsFromRunningBalances(
-    endBlockForMainnet,
+    latestMainnetBlock,
     runningBalances,
     clients.hubPoolClient,
     allValidFills,
@@ -277,10 +278,10 @@ export function _buildPoolRebalanceRoot(
 
   // Add to the running balance value from the last valid root bundle proposal for {chainId, l1Token}
   // combination if found.
-  addLastRunningBalance(endBlockForMainnet, runningBalances, clients.hubPoolClient);
+  addLastRunningBalance(mainnetBundleEndBlock, runningBalances, clients.hubPoolClient);
 
   const leaves: PoolRebalanceLeaf[] = constructPoolRebalanceLeaves(
-    endBlockForMainnet,
+    mainnetBundleEndBlock,
     runningBalances,
     realizedLpFees,
     clients.configStoreClient,

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -253,7 +253,7 @@ export function _buildPoolRebalanceRoot(
   // balances because the prior partial fill would have triggered a refund to be sent to the spoke pool to refund
   // a slow fill.
   const fillsTriggeringExcesses = subtractExcessFromPreviousSlowFillsFromRunningBalances(
-    clients.hubPoolClient.latestBlockNumber,
+    mainnetBundleEndBlock,
     runningBalances,
     clients.hubPoolClient,
     allValidFills,

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -182,7 +182,7 @@ export function subtractExcessFromPreviousSlowFillsFromRunningBalances(
     .forEach((fill: interfaces.FillWithBlock) => {
       const { lastFillBeforeSlowFillIncludedInRoot, rootBundleEndBlockContainingFirstFill } =
         getFillDataForSlowFillFromPreviousRootBundle(
-          endBlockForMainnet,
+          hubPoolClient.latestBlockNumber,
           fill,
           allValidFills,
           hubPoolClient,
@@ -203,7 +203,7 @@ export function subtractExcessFromPreviousSlowFillsFromRunningBalances(
       // first fill for this deposit. If it is the same as the ProposeRootBundle event containing the
       // current fill, then the first fill is in the current bundle and we can exit early.
       const rootBundleEndBlockContainingFullFill = hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(
-        endBlockForMainnet,
+        hubPoolClient.latestBlockNumber,
         fill.blockNumber,
         fill.destinationChainId,
         chainIdListForBundleEvaluationBlockNumbers

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -161,7 +161,7 @@ export function computePoolRebalanceUsdVolume(leaves: PoolRebalanceLeaf[], clien
 }
 
 export function subtractExcessFromPreviousSlowFillsFromRunningBalances(
-  endBlockForMainnet: number,
+  mainnetBundleEndBlock: number,
   runningBalances: interfaces.RunningBalances,
   hubPoolClient: HubPoolClient,
   allValidFills: interfaces.FillWithBlock[],
@@ -235,7 +235,7 @@ export function subtractExcessFromPreviousSlowFillsFromRunningBalances(
         finalFill: fill,
       });
 
-      updateRunningBalanceForFill(endBlockForMainnet, runningBalances, hubPoolClient, fill, excess.mul(toBN(-1)));
+      updateRunningBalanceForFill(mainnetBundleEndBlock, runningBalances, hubPoolClient, fill, excess.mul(toBN(-1)));
     });
 
   // Sort excess entries by block number, most recent first.


### PR DESCRIPTION
This is a bug but AFAICT did not lead to any issues in production. The following situation highlights the bug:

- There was some partial fill in bundle 1.
- Bundle 1 sends slow relay funds.
- Bundle 1 is executed.
- We’re now trying to build bundle 2.
- Our mainnet end block for bundle 2 is before the execution block for bundle 1 because of our buffer.

I think in this case, we consider bundle 1 as not valid yet (reasonable, since this bundle hasn’t really “seen” those blocks yet). This means [this check](https://github.com/across-protocol/relayer-v2/blob/587b9039d27cab2fd0775e08934dd78c8628413f/src/clients/HubPoolClient.ts#L189) returns false for the bundle that would have contained the first fill. This means [this call](https://github.com/across-protocol/relayer-v2/blob/587b9039d27cab2fd0775e08934dd78c8628413f/src/utils/FillUtils.ts#L114) returns undefined, causing both values returned [here](https://github.com/across-protocol/relayer-v2/blob/587b9039d27cab2fd0775e08934dd78c8628413f/src/utils/FillUtils.ts#L129-L132) to be undefined. This means we hit [this return](https://github.com/across-protocol/relayer-v2/blob/587b9039d27cab2fd0775e08934dd78c8628413f/src/dataworker/PoolRebalanceUtils.ts#L199), meaning we ignore this excess. The end result is that a bundle constructed by current code might not return enough excess to mainnet.

The reason why I think this hasn't been an issue in prod yet is TODO.

Signed-off-by: nicholaspai <npai.nyc@gmail.com>
