### PR TITLE
chore: Bump arbitrum-sdk version to 2.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/contracts-v2": "^1.0.2",
     "@across-protocol/sdk-v2": "^0.1.10",
-    "@arbitrum/sdk": "^2.0.4",
+    "@arbitrum/sdk": "^2.0.9",
     "@defi-wonderland/smock": "^2.0.7",
     "@eth-optimism/sdk": "^1.1.5",
     "@ethersproject/abstract-provider": "^5.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,10 +55,10 @@
     lodash.get "^4.4.2"
     superstruct "^0.15.4"
 
-"@arbitrum/sdk-classic@npm:@arbitrum/sdk@1.1.10":
-  version "1.1.10"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-1.1.10.tgz#58d1baf646a37ecf76bab73781e3bc91ac8b803f"
-  integrity sha512-T+pscVnIhxwvtL9s93lb0mwWFi9rUFhMaHj8PwezVJtDZ/u1jCpF37dPLdSUs1LyVApm4gnp+LQvbe5yaUWyRw==
+"@arbitrum/sdk-classic@npm:@arbitrum/sdk@1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-1.1.13.tgz#5221c61e951b53535d5226d67e99adc398b4bf4f"
+  integrity sha512-XnivIDij4ZLx/Yk1KJj77QwzwcbakU3R1pjzWqv548Nzj8Cg8o15nSg4PQGdwEtsv1VWFhabFHSwZMsmIX37GA==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"
@@ -71,10 +71,10 @@
     ts-node "^10.2.1"
     typechain "7.0.0"
 
-"@arbitrum/sdk-nitro@npm:@arbitrum/sdk@3.0.0-beta.3":
-  version "3.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.0.0-beta.3.tgz#98ca31c592bc0f5948c1e11f0b90d0ce59fdaef3"
-  integrity sha512-sKjjy6F8lg4DSVY94f3r2ahbv4c4L/B2lb1TTpFU7sdZKSri2rq4pdQUKpeBs4QnXty6Hmd3VLJGlI6YMUN30w==
+"@arbitrum/sdk-nitro@npm:@arbitrum/sdk@3.0.0-beta.6":
+  version "3.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-3.0.0-beta.6.tgz#a36c3e39a7358396b5533f3288125107da6ae59e"
+  integrity sha512-kPCfgj72MeyVcIXQKoztLO29UTcpSbXFzc/S0oDgVNNcHcXp1hWUJqqkVRg0O43P2yKjZRT/I94K0Nj2nZNiiQ==
   dependencies:
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"
@@ -87,13 +87,13 @@
     ts-node "^10.2.1"
     typechain "7.0.0"
 
-"@arbitrum/sdk@^2.0.4":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-2.0.4.tgz#5d5a336d54f155cb1587f9728b8bd058224e07fa"
-  integrity sha512-0jgZBzU1zMI8zvJFZkkhZ6lFMAJ8+CklWgCdaEQXaVfIcHFtjo8YpEX/Wz45ydRnaYNy5W60g0THliRY0MjH9A==
+"@arbitrum/sdk@^2.0.9":
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/@arbitrum/sdk/-/sdk-2.0.9.tgz#ca76461e660b8b286597c862736d9de94bdda4aa"
+  integrity sha512-HAGuYzD1jtjV1QlpA2moPrvZ+zDk4Kd+PGhfzWOrLBcKFV0LEl0Ny167RGbtOhn2+fYTeXRkkCSnrlmNm0oHYQ==
   dependencies:
-    "@arbitrum/sdk-classic" "npm:@arbitrum/sdk@1.1.10"
-    "@arbitrum/sdk-nitro" "npm:@arbitrum/sdk@3.0.0-beta.3"
+    "@arbitrum/sdk-classic" "npm:@arbitrum/sdk@1.1.13"
+    "@arbitrum/sdk-nitro" "npm:@arbitrum/sdk@3.0.0-beta.6"
     "@ethersproject/address" "^5.0.8"
     "@ethersproject/bignumber" "^5.1.1"
     "@ethersproject/bytes" "^5.0.8"


### PR DESCRIPTION
Keeping arbitrum-sdk version updated in anticipation of nitro upgrade to the AVM﻿
