### PR TITLE
improve(dataworker): Buffer between proposals should start at block of oldest executed relayer refund leaf, not newest

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -252,15 +252,15 @@ export class Dataworker {
             value: true,
             mostRecentValidatedBundle: mostRecentValidatedBundle.blockNumber,
             mostRecentEthereumRootBundle: mostRecentEthereumRootBundle.rootBundleId,
-            latestExecutedLeaf: undefined,
+            earliestExecutedLeaf: undefined,
             bufferInEthBlocks: this.bufferToPropose,
           };
-        const latestExecutedLeaf = sortEventsDescending([...executedLeavesInEthereumBundle])[0];
+        const earliestExecutedLeaf = sortEventsAscending([...executedLeavesInEthereumBundle])[0];
         return {
-          value: mainnetBundleEndBlock - this.bufferToPropose < latestExecutedLeaf.blockNumber,
+          value: mainnetBundleEndBlock - this.bufferToPropose < earliestExecutedLeaf.blockNumber,
           mostRecentValidatedBundle: mostRecentValidatedBundle.blockNumber,
           mostRecentEthereumRootBundle: mostRecentEthereumRootBundle.rootBundleId,
-          latestExecutedLeaf: latestExecutedLeaf.blockNumber,
+          earliestExecutedLeaf: earliestExecutedLeaf.blockNumber,
           bufferInEthBlocks: this.bufferToPropose,
         };
       } else


### PR DESCRIPTION
The dataworker currently waits until after the most recently proposed bundle has been executed, and that means it not only waits for the PoolRebalanceLeaves to be executed but also for the subsequent
RelayerRefundLeaf to be executed on Mainnet. In serverless mode, this  means the dataworker will wait at least 2 iterations between proposing new bundles. In practice, the buffer is ~2 hours after
the newest RelayerRefundLeaf on Mainnet is executed, however this buffer can be a lot longer than expected if the leaf executions are delayed for some reason. It's reasonable to start this buffer
after the oldest RelayerRefundLeaf assuming the buffer is set to something reasonable like >30 mins.

﻿Signed-off-by: nicholaspai <npai.nyc@gmail.com>
