### PR TITLE
improve: Reduce overheads in CoinGecko price retrieval

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -136,8 +136,9 @@ export class ProfitClient {
 
     if (errors.length > 0) {
       let mrkdwn = "The following L1 token prices could not be fetched:\n";
-      errors.forEach((token) => {
-        mrkdwn += `- ${token.symbol} Not found. Using last known price of ${this.getPriceOfToken(token.address)}.\n`;
+      errors.forEach((token: { [k: string]: string }) => {
+        mrkdwn += `- ${token["symbol"]} not found.`;
+        mrkdwn += ` Using last known price of ${this.getPriceOfToken(token["address"])}.\n`;
       });
       this.logger.warn({ at: "ProfitClient", message: "Could not fetch all token prices 💳", mrkdwn });
     }

--- a/test/ProfitClient.PriceRetrieval.ts
+++ b/test/ProfitClient.PriceRetrieval.ts
@@ -1,3 +1,4 @@
+import { L1Token } from "../src/interfaces/HubPool";
 import { expect, ethers, SignerWithAddress, createSpyLogger, winston, BigNumber, toBN } from "./utils";
 
 import { MockHubPoolClient } from "./mocks/MockHubPoolClient";
@@ -6,8 +7,15 @@ import { ProfitClient } from "../src/clients"; // Tested
 let hubPoolClient: MockHubPoolClient, owner: SignerWithAddress, spy: sinon.SinonSpy, spyLogger: winston.Logger;
 let profitClient: ProfitClient; // tested
 
-const mainnetWeth = "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2";
-const mainnetUsdc = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+const mainnetTokens: Array<L1Token> = [
+  { symbol: "WETH", address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", decimals: 18 },
+  { symbol: "USDC", address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", decimals: 6 },
+  { symbol: "WBTC", address: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599", decimals: 8 },
+  { symbol: "BOBA", address: "0x42bbfa2e77757c645eeaad1655e0911a7553efbc", decimals: 18 },
+  { symbol: "DAI", address: "0x6b175474e89094c44da98b954eedeac495271d0f", decimals: 18 },
+  { symbol: "UMA", address: "0x04fa0d235c4abf4bcf4787af4cf447de572ef828", decimals: 18 },
+  { symbol: "BADGER", address: "0x3472a5a71965499acd81997a54bba8d852c6e53d", decimals: 18 },
+];
 
 describe("ProfitClient: Price Retrieval", async function () {
   beforeEach(async function () {
@@ -19,17 +27,15 @@ describe("ProfitClient: Price Retrieval", async function () {
   });
 
   it("Correctly fetches token prices", async function () {
-    // Set the MockHubPool to have WETH and USDC in it.
-    hubPoolClient.addL1Token({ address: mainnetWeth, symbol: "WETH", decimals: 18 });
-    hubPoolClient.addL1Token({ address: mainnetUsdc, symbol: "USDC", decimals: 6 });
+    mainnetTokens.forEach((token: L1Token) => hubPoolClient.addL1Token(token));
     await profitClient.update();
 
-    // The client should have fetched the prices for both tokens.
-    expect(Object.keys(profitClient.getAllPrices())).to.deep.equal([mainnetWeth, mainnetUsdc]);
-    Object.values(profitClient.getAllPrices()).forEach(
-      (price: BigNumber) => expect(toBN(price).gt(toBN(0))).to.be.true
-    );
-    Object.keys(profitClient.getAllPrices()).forEach(
+    const tokenPrices: { [k: string]: BigNumber } = profitClient.getAllPrices();
+
+    // The client should have fetched prices for all requested tokens.
+    expect(Object.keys(tokenPrices)).to.have.deep.members(mainnetTokens.map((token) => token["address"]));
+    Object.values(tokenPrices).forEach((price: BigNumber) => expect(toBN(price).gt(toBN(0))).to.be.true);
+    Object.keys(tokenPrices).forEach(
       (token) => expect(toBN(profitClient.getPriceOfToken(token)).gt(toBN(0))).to.be.true
     );
   });


### PR DESCRIPTION
Today we had many incidents where various bots were unable to retrieve
prices from CoinGecko. In each incident, *all* requested token prices
were unavailable. This indicates either a network/transport issue, or
some error over at CoinGecko. Unfortunately I wasn't able to see any
logging of the underlying cause (maybe I wasn't looking in the right
place).

In any case, this change introduces the following modifications:

 - Bundle token price requests, such that we perform one HTTP request
   in total, instead of 1 per token (currently 7).

 - When exceptions occur during retrieval and parsing, ensure that the
   underlying cause is logged.
   
An additional part of this PR was to support retries on the CoinGecko HTTP
request (nominally 2), but that was stripped out after feedback from
David.

Ref: ACX-125