### PR TITLE
fix(logging): Bump financial-templates-lib version to get updates to the logger library

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@maticnetwork/maticjs-ethers": "^1.0.2",
     "@uma/common": "^2.19.0",
     "@uma/contracts-node": "^0.3.1",
-    "@uma/financial-templates-lib": "^2.28.0",
+    "@uma/financial-templates-lib": "^2.29.0",
     "@uma/sdk": "^0.25.0",
     "async": "^3.2.4",
     "bluebird": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,7 +1796,7 @@
   dependencies:
     google-gax "^2.24.1"
 
-"@google-cloud/kms@^3.0.1":
+"@google-cloud/kms@^3.0.0", "@google-cloud/kms@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@google-cloud/kms/-/kms-3.0.1.tgz#2e86889f2c08f13208afc5bd272a7f25326c9f17"
   integrity sha512-xUrhzattC5mkNqbfMcIgBzwAab9eXCYrn1R1KYUNV5E96fK7ciT57bJESaUQvin7XKd18sQcLRD+uOJ6eTfXbg==
@@ -1892,6 +1892,32 @@
     stream-events "^1.0.4"
     teeny-request "^7.1.3"
     xdg-basedir "^4.0.0"
+
+"@google-cloud/storage@^6.1.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@google-cloud/storage/-/storage-6.3.0.tgz#0a9765416b659f54477da6611d9c12b914c04a61"
+  integrity sha512-Ah4wl9cWUEW+2lAqHsKauaLlPmbtdOdQkvJE6BFwmTSZhywYVtVHLcEpf5F+/GmmNTnirFGNdE7UjgbyOxcnRg==
+  dependencies:
+    "@google-cloud/paginator" "^3.0.7"
+    "@google-cloud/projectify" "^3.0.0"
+    "@google-cloud/promisify" "^3.0.0"
+    abort-controller "^3.0.0"
+    arrify "^2.0.0"
+    async-retry "^1.3.3"
+    compressible "^2.0.12"
+    duplexify "^4.0.0"
+    ent "^2.2.0"
+    extend "^3.0.2"
+    gaxios "^5.0.0"
+    google-auth-library "^8.0.1"
+    mime "^3.0.0"
+    mime-types "^2.0.8"
+    p-limit "^3.0.1"
+    pumpify "^2.0.0"
+    retry-request "^5.0.0"
+    stream-events "^1.0.4"
+    teeny-request "^8.0.0"
+    uuid "^8.0.0"
 
 "@google-cloud/storage@^6.2.2":
   version "6.2.2"
@@ -3471,16 +3497,16 @@
     truffle-deploy-registry "^0.5.1"
     web3 "^1.6.0"
 
-"@uma/common@^2.21.0":
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/@uma/common/-/common-2.21.0.tgz#cfdb14dc5ade167c522603591bca2059c8892c6b"
-  integrity sha512-PJSjwVnJWWkcpqsFs6WlG+B1GiCcw6+p1/WLo9jYDuXcYhEwcS9NsOOTcbu4sWqw9cJqI1Mx2r7f/7eOpwSvMQ==
+"@uma/common@^2.24.0":
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/@uma/common/-/common-2.24.0.tgz#089ddcdf39cc44163b1add6bf316db40ae5c7494"
+  integrity sha512-/OnSS6kQVlbbCykohLaLdn1ld7WJEq7wO3rZ0g1WthinlEVhiTfRK72RIyjz7pOb50u2tzY56z3MgpvYZEqu/Q==
   dependencies:
     "@across-protocol/contracts" "^0.1.4"
     "@eth-optimism/hardhat-ovm" "^0.2.2"
     "@ethersproject/bignumber" "^5.0.5"
-    "@google-cloud/kms" "^2.3.1"
-    "@google-cloud/storage" "^5.8.5"
+    "@google-cloud/kms" "^3.0.0"
+    "@google-cloud/storage" "^6.1.0"
     "@nomiclabs/hardhat-ethers" "^2.0.2"
     "@nomiclabs/hardhat-etherscan" "^3.0.0"
     "@nomiclabs/hardhat-web3" "^2.0.0"
@@ -3508,15 +3534,15 @@
     web3 "^1.6.0"
     winston "^3.2.1"
 
+"@uma/contracts-frontend@^0.3.11":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.3.11.tgz#d966be9da9312de2090acdf5860576080b987052"
+  integrity sha512-1ogKI+olhGvcc/MyUtsbMIbwW/2nIqaCbDI/v9zBZrhkTgqp6FKqQeXM+TIx0fbxROAFVZrFd0sJjzyuCmYelg==
+
 "@uma/contracts-frontend@^0.3.7":
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.3.7.tgz#a959490bcf5e6b0cd1d941a60be86f8ff659dd54"
   integrity sha512-we/ZSf91HQPtYSbGyPAnZmHJCU+hREXWJW4Ee2Ics+/dytTx5M4ecqlwgOq9bXJNHpUMMeq4WdwuxLYJjrW19A==
-
-"@uma/contracts-frontend@^0.3.8":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.3.8.tgz#950339e6de03d46edb928da8f11c84356dc9d9be"
-  integrity sha512-3L66+p6HvqpaYuWuguDUk5zxXlvXCOK4iKJ4kj/fJJbynBVSEPG/mp3UgyXKC2h/8pJaAq+zqb2AlbgrTwC8sQ==
 
 "@uma/contracts-frontend@^0.3.9":
   version "0.3.9"
@@ -3533,15 +3559,15 @@
   resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.2.tgz#884b00b2c6bf983c9f136d5f8a0749c5ff4e08cd"
   integrity sha512-Ncl7Kv2nxuY/wV5oczH2Nf6XCS7dJLad9DlzMI3jwPMPU98YT8ChHydcDe6ZiL0SAVTg7FgpIyh7lX0B7nV9Aw==
 
+"@uma/contracts-node@^0.3.11":
+  version "0.3.11"
+  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.11.tgz#ecbb7e4eb5f389a5ceef0c646653a0ae54041116"
+  integrity sha512-meRHB9YRz6DCF/0i3+IwVUwfi7gMyvJazvcWPbavFKRZzgYHSloWCOz5CL7ckYaz2OwfVupgYeCFmBltLM0B3A==
+
 "@uma/contracts-node@^0.3.7":
   version "0.3.7"
   resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.7.tgz#d2a1afefc021c70b6565558b24cf5fd082b493fd"
   integrity sha512-mzI7sv+W91Cm7TBjkMioKg0pvHEOgT8QMlCNPmuQtkxUNqMnNJCj6MLzzotF4c6i3YzHsmA+PbiSsh2jVbhftw==
-
-"@uma/contracts-node@^0.3.8":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.3.8.tgz#93159afd70fd67291c8cd8b6749c7e7d866ea572"
-  integrity sha512-/kiOV1cAALEAtJ/ojxPFlTOreLk9iE3jUerigOGS5tJ99S7P+isM5UpEH0q7A2xjH21MtJTf+Bca8LNMZ20ZTA==
 
 "@uma/contracts-node@^0.3.9":
   version "0.3.9"
@@ -3562,17 +3588,17 @@
     "@uniswap/v3-core" "^1.0.0-rc.2"
     "@uniswap/v3-periphery" "^1.0.0-beta.23"
 
-"@uma/financial-templates-lib@^2.28.0":
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/@uma/financial-templates-lib/-/financial-templates-lib-2.28.0.tgz#a1f7ab58ecbe30852f64b486cbdf4737f0049e5a"
-  integrity sha512-o7l7b4k7bMYFNPdBySgZiKq++Zm3RXndzNLB1BKozgLO/EjDZKbzgxDnvb6hlLZBOKMWfIBTDGdqt/44gXZd0g==
+"@uma/financial-templates-lib@^2.29.0":
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/@uma/financial-templates-lib/-/financial-templates-lib-2.30.1.tgz#d2115d2ad7557647baec04d320263efbe5ac6f90"
+  integrity sha512-rvncBGyfySaWVDp7hNawdVQd+J3LCcsb617I1k6A/MdEJFo3WAS/0NJPHum8XVGR/T0Bc6ILWf1R9AANR1M/PA==
   dependencies:
     "@ethersproject/bignumber" "^5.4.2"
     "@google-cloud/logging-winston" "^4.1.1"
     "@google-cloud/trace-agent" "^5.1.6"
-    "@uma/common" "^2.21.0"
-    "@uma/contracts-node" "^0.3.8"
-    "@uma/sdk" "^0.24.0"
+    "@uma/common" "^2.24.0"
+    "@uma/contracts-node" "^0.3.11"
+    "@uma/sdk" "^0.27.0"
     "@uniswap/sdk" "^2.0.5"
     bluebird "^3.7.2"
     bn.js "^4.11.9"
@@ -3604,22 +3630,6 @@
     immer "^9.0.7"
     lodash-es "^4.17.21"
 
-"@uma/sdk@^0.24.0":
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.24.0.tgz#d037996d6ea1f34e421b534400828dcbc2a1539f"
-  integrity sha512-IfSi7tCBPtaBkSUvC7d6h02W3WTHL5oVzHAQnl5Ne5CCA8HZPRH5tH9IJEgMHeaoD5Wsdi7aeM862/sbjHoHww==
-  dependencies:
-    "@google-cloud/datastore" "^6.6.0"
-    "@types/lodash-es" "^4.17.5"
-    "@uma/contracts-frontend" "^0.3.8"
-    "@uma/contracts-node" "^0.3.8"
-    axios "^0.24.0"
-    bn.js "^4.11.9"
-    decimal.js "^10.3.1"
-    highland "^2.13.5"
-    immer "^9.0.7"
-    lodash-es "^4.17.21"
-
 "@uma/sdk@^0.25.0":
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.25.0.tgz#20b472fac51894fe4998c14e645044c98632eea1"
@@ -3629,6 +3639,22 @@
     "@types/lodash-es" "^4.17.5"
     "@uma/contracts-frontend" "^0.3.9"
     "@uma/contracts-node" "^0.3.9"
+    axios "^0.24.0"
+    bn.js "^4.11.9"
+    decimal.js "^10.3.1"
+    highland "^2.13.5"
+    immer "^9.0.7"
+    lodash-es "^4.17.21"
+
+"@uma/sdk@^0.27.0":
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.27.0.tgz#c4f25bb3d1094ac3ed35e456135d2476ef81cea9"
+  integrity sha512-vy4LHxSW+O3lYmXoFj1hk/tIlUQMY4EOxSMgPY7skk20fWPHEkzUlA/TMrDJYT5piEhfLoAA7p7SBUxV/Rzo6w==
+  dependencies:
+    "@google-cloud/datastore" "^6.6.0"
+    "@types/lodash-es" "^4.17.5"
+    "@uma/contracts-frontend" "^0.3.11"
+    "@uma/contracts-node" "^0.3.11"
     axios "^0.24.0"
     bn.js "^4.11.9"
     decimal.js "^10.3.1"


### PR DESCRIPTION
Context: https://linear.app/uma/issue/ACX-129/lost-lines-in-slack-logs-from-across-bots
TLDR; the financial-templates-lib wasn't not updated in relayer-v2