### PR TITLE
improve: Consolidate use of getSigner() during startup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import minimist from "minimist";
 import { CommonConfig } from "./src/common";
-import { config, delay, help, Logger, processCrash, usage, winston } from "./src/utils";
+import { config, delay, getSigner, help, Logger, processCrash, usage, winston } from "./src/utils";
 import { runRelayer } from "./src/relayer";
 import { runDataworker } from "./src/dataworker";
 import { runMonitor } from "./src/monitor";
@@ -33,7 +33,9 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
   } else {
     do {
       try {
-        await cmds[cmd](logger);
+        // One global signer for use with a specific per-chain provider.
+        // todo: Support a void signer for monitor mode (only) if no wallet was supplied.
+        await cmds[cmd](logger, await getSigner());
       } catch (error) {
         // eslint-disable-next-line no-process-exit
         if (await processCrash(logger, cmd, config.pollingDelay, error)) process.exit(1);

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -1,13 +1,5 @@
 import winston from "winston";
-import {
-  getProvider,
-  getSigner,
-  getDeployedContract,
-  getDeploymentBlockNumber,
-  Wallet,
-  SpokePool,
-  Contract,
-} from "../utils";
+import { getProvider, getDeployedContract, getDeploymentBlockNumber, Wallet, SpokePool, Contract } from "../utils";
 import { HubPoolClient, MultiCallerClient, AcrossConfigStoreClient, SpokePoolClient, ProfitClient } from "../clients";
 import { CommonConfig } from "./Config";
 import { DataworkerClients } from "../dataworker/DataworkerClientHelper";
@@ -122,10 +114,11 @@ export async function updateSpokePoolClients(
   );
 }
 
-export async function constructClients(logger: winston.Logger, config: CommonConfig): Promise<Clients> {
-  // Create signers for each chain. Each is connected to an associated provider for that chain.
-  const baseSigner = await getSigner();
-
+export async function constructClients(
+  logger: winston.Logger,
+  config: CommonConfig,
+  baseSigner: Wallet
+): Promise<Clients> {
   const hubSigner = baseSigner.connect(getProvider(config.hubPoolChainId));
 
   // Create contract instances for each chain for each required contract.

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -1,7 +1,7 @@
 import winston from "winston";
 import { DataworkerConfig } from "./DataworkerConfig";
 import { CHAIN_ID_LIST_INDICES, Clients, constructClients, getSpokePoolSigners, updateClients } from "../common";
-import { EventSearchConfig, getDeploymentBlockNumber, getSigner, Wallet, ethers } from "../utils";
+import { EventSearchConfig, getDeploymentBlockNumber, Wallet, ethers } from "../utils";
 import { BundleDataClient, SpokePoolClient, TokenClient } from "../clients";
 
 export interface DataworkerClients extends Clients {
@@ -13,10 +13,10 @@ export interface DataworkerClients extends Clients {
 
 export async function constructDataworkerClients(
   logger: winston.Logger,
-  config: DataworkerConfig
+  config: DataworkerConfig,
+  baseSigner: Wallet
 ): Promise<DataworkerClients> {
-  const commonClients = await constructClients(logger, config);
-  const baseSigner = await getSigner();
+  const commonClients = await constructClients(logger, config, baseSigner);
 
   // We don't pass any spoke pool clients to token client since data worker doesn't need to set approvals for L2 tokens.
   const tokenClient = new TokenClient(logger, baseSigner.address, {}, commonClients.hubPoolClient);

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -1,4 +1,4 @@
-import { processEndPollingLoop, winston, config, startupLogLevel, processCrash } from "../utils";
+import { processEndPollingLoop, winston, config, startupLogLevel, processCrash, Wallet } from "../utils";
 import * as Constants from "../common";
 import { Dataworker } from "./Dataworker";
 import { DataworkerConfig } from "./DataworkerConfig";
@@ -13,9 +13,9 @@ import { SpokePoolClientsByChain } from "../interfaces";
 config();
 let logger: winston.Logger;
 
-export async function createDataworker(_logger: winston.Logger) {
+export async function createDataworker(_logger: winston.Logger, baseSigner: Wallet) {
   const config = new DataworkerConfig(process.env);
-  const clients = await constructDataworkerClients(_logger, config);
+  const clients = await constructDataworkerClients(_logger, config, baseSigner);
 
   const dataworker = new Dataworker(
     _logger,
@@ -35,9 +35,9 @@ export async function createDataworker(_logger: winston.Logger) {
     dataworker,
   };
 }
-export async function runDataworker(_logger: winston.Logger): Promise<void> {
+export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
   logger = _logger;
-  const { clients, config, dataworker } = await createDataworker(logger);
+  const { clients, config, dataworker } = await createDataworker(logger, baseSigner);
   let spokePoolClients: SpokePoolClientsByChain;
   try {
     logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -1,4 +1,4 @@
-import { Wallet, config, startupLogLevel, processEndPollingLoop, processCrash, getSigner } from "../utils";
+import { Wallet, config, startupLogLevel, processEndPollingLoop, processCrash } from "../utils";
 import { winston } from "../utils";
 import {
   finalizeArbitrum,
@@ -86,10 +86,8 @@ export async function finalize(
   }
 }
 
-export async function constructFinalizerClients(_logger: winston.Logger, config) {
-  const baseSigner = await getSigner();
-
-  const commonClients = await constructClients(_logger, config);
+export async function constructFinalizerClients(_logger: winston.Logger, config, baseSigner: Wallet) {
+  const commonClients = await constructClients(_logger, config, baseSigner);
 
   const spokePoolClients = await constructSpokePoolClientsWithLookback(
     logger,
@@ -128,12 +126,12 @@ export class FinalizerConfig extends DataworkerConfig {
   }
 }
 
-export async function runFinalizer(_logger: winston.Logger): Promise<void> {
+export async function runFinalizer(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
   logger = _logger;
   // Same config as Dataworker for now.
   const config = new FinalizerConfig(process.env);
 
-  const { commonClients, spokePoolClients } = await constructFinalizerClients(logger, config);
+  const { commonClients, spokePoolClients } = await constructFinalizerClients(logger, config, baseSigner);
 
   try {
     logger[startupLogLevel(config)]({ at: "Finalizer#index", message: "Finalizer started 🏋🏿‍♀️", config });

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -1,5 +1,5 @@
 import { MonitorConfig } from "./MonitorConfig";
-import { getSigner, winston } from "../utils";
+import { Wallet, winston } from "../utils";
 import { BundleDataClient, HubPoolClient, TokenTransferClient } from "../clients";
 import { AdapterManager, CrossChainTransferClient } from "../clients/bridges";
 import {
@@ -19,9 +19,12 @@ export interface MonitorClients extends Clients {
   tokenTransferClient: TokenTransferClient;
 }
 
-export async function constructMonitorClients(config: MonitorConfig, logger: winston.Logger): Promise<MonitorClients> {
-  const baseSigner = await getSigner(); // todo: add getVoidSigner
-  const commonClients = await constructClients(logger, config);
+export async function constructMonitorClients(
+  config: MonitorConfig,
+  logger: winston.Logger,
+  baseSigner: Wallet
+): Promise<MonitorClients> {
+  const commonClients = await constructClients(logger, config, baseSigner);
   const spokePoolClients = await constructSpokePoolClientsWithLookback(
     logger,
     commonClients.configStoreClient,

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -1,11 +1,11 @@
-import { winston, processEndPollingLoop, processCrash, config, startupLogLevel } from "../utils";
+import { winston, processEndPollingLoop, processCrash, config, startupLogLevel, Wallet } from "../utils";
 import { Monitor } from "./Monitor";
 import { MonitorConfig } from "./MonitorConfig";
 import { constructMonitorClients } from "./MonitorClientHelper";
 config();
 let logger: winston.Logger;
 
-export async function runMonitor(_logger: winston.Logger) {
+export async function runMonitor(_logger: winston.Logger, baseSigner: Wallet) {
   logger = _logger;
   const config = new MonitorConfig(process.env);
   let clients;

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -13,7 +13,7 @@ export async function runMonitor(_logger: winston.Logger, baseSigner: Wallet) {
   try {
     logger[startupLogLevel(config)]({ at: "AcrossMonitor#index", message: "Monitor started 🔭", config });
 
-    clients = await constructMonitorClients(config, logger);
+    clients = await constructMonitorClients(config, logger, baseSigner);
     const acrossMonitor = new Monitor(logger, config, clients);
 
     for (;;) {

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -1,5 +1,5 @@
 import winston from "winston";
-import { getSigner } from "../utils";
+import { Wallet } from "../utils";
 import { TokenClient, ProfitClient, BundleDataClient, InventoryClient } from "../clients";
 import { AdapterManager, CrossChainTransferClient } from "../clients/bridges";
 import { RelayerConfig } from "./RelayerConfig";
@@ -14,10 +14,12 @@ export interface RelayerClients extends Clients {
   inventoryClient: InventoryClient;
 }
 
-export async function constructRelayerClients(logger: winston.Logger, config: RelayerConfig): Promise<RelayerClients> {
-  const baseSigner = await getSigner();
-
-  const commonClients = await constructClients(logger, config);
+export async function constructRelayerClients(
+  logger: winston.Logger,
+  config: RelayerConfig,
+  baseSigner: Wallet
+): Promise<RelayerClients> {
+  const commonClients = await constructClients(logger, config, baseSigner);
 
   const spokePoolClients = await constructSpokePoolClientsWithLookback(
     logger,

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -1,11 +1,11 @@
-import { processEndPollingLoop, winston, processCrash, config, startupLogLevel, getSigner } from "../utils";
+import { processEndPollingLoop, winston, processCrash, config, startupLogLevel, Wallet } from "../utils";
 import { Relayer } from "./Relayer";
 import { RelayerConfig } from "./RelayerConfig";
 import { constructRelayerClients, updateRelayerClients } from "./RelayerClientHelper";
 config();
 let logger: winston.Logger;
 
-export async function runRelayer(_logger: winston.Logger): Promise<void> {
+export async function runRelayer(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
   logger = _logger;
   const config = new RelayerConfig(process.env);
   let relayerClients;
@@ -13,9 +13,8 @@ export async function runRelayer(_logger: winston.Logger): Promise<void> {
   try {
     logger[startupLogLevel(config)]({ at: "Relayer#index", message: "Relayer started 🏃‍♂️", config });
 
-    relayerClients = await constructRelayerClients(logger, config);
+    relayerClients = await constructRelayerClients(logger, config, baseSigner);
 
-    const baseSigner = await getSigner();
     const relayer = new Relayer(
       baseSigner.address,
       logger,


### PR DESCRIPTION
At very least this will leave fewer copies of the private key in memory.
For gckms configurations it should also save a few redundant connections
to Google on each run of the bot.

Ref: ACX-40
Ref: ACX-122
