### PR TITLE
improve: Drop excess per-chain multicall chunks

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -183,7 +183,7 @@ export class MultiCallerClient {
       this.logger.debug({
         at: "MultiCallerClient",
         message: "Executing transactions grouped by target chain",
-        txs: Object.keys(groupedTransactions).map((chainId) => ({ chainId, num: groupedTransactions[chainId].length })),
+        txs: Object.entries(chunkedTransactions).map(([chainId, txns]) => ({ chainId, num: txns.length })),
       });
 
       // Construct multiCall transaction for each target chain.

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -1,4 +1,4 @@
-import { CHAIN_MULTICALL_MAX_CHUNK_SIZE } from "../common";
+import { DEFAULT_MULTICALL_CHUNK_SIZE, CHAIN_MULTICALL_CHUNK_SIZE } from "../common";
 import {
   winston,
   getNetworkName,
@@ -113,7 +113,7 @@ export class MultiCallerClient {
 
       const chunkedTransactions: { [networkId: number]: AugmentedTransaction[][] } = Object.fromEntries(
         Object.entries(groupedTransactions).map(([chainId, transactions]) => {
-          const chunkSize: number = CHAIN_MULTICALL_MAX_CHUNK_SIZE[chainId];
+          const chunkSize: number = CHAIN_MULTICALL_CHUNK_SIZE[chainId] || DEFAULT_MULTICALL_CHUNK_SIZE;
           if (transactions.length > chunkSize) {
             const dropped: Array<{ [k: string]: string }> = transactions.slice(chunkSize).map((txn) => {
               return { address: txn.contract.address, method: txn.method, args: txn.args };

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -136,7 +136,7 @@ export class MultiCallerClient {
         let mrkdwn = "";
         valueTransactions.forEach((transaction, i) => {
           mrkdwn += "*Transaction excluded from batches because it contained value:*\n";
-          mrkdwn += `  ${i + 1}. ${transaction.message || "0 message"}: ` + `${transaction.mrkdwn || "0 mrkdwn"}\n`;
+          mrkdwn += `  ${i + 1}. ${transaction.message || "0 message"}: ${transaction.mrkdwn || "0 mrkdwn"}\n`;
         });
         Object.keys(chunkedTransactions).forEach((chainId) => {
           mrkdwn += `*Transactions sent in batch on ${getNetworkName(chainId)}:*\n`;

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -1,3 +1,4 @@
+import { CHAIN_MULTICALL_MAX_CHUNK_SIZE } from "../common";
 import {
   winston,
   getNetworkName,
@@ -110,9 +111,9 @@ export class MultiCallerClient {
         assign(groupedTransactions, [transaction.chainId], [transaction]);
       }
 
-      const chunkSize = 100;
       const chunkedTransactions: { [networkId: number]: AugmentedTransaction[][] } = Object.fromEntries(
         Object.entries(groupedTransactions).map(([chainId, transactions]) => {
+          const chunkSize: number = CHAIN_MULTICALL_MAX_CHUNK_SIZE[chainId];
           if (transactions.length > chunkSize) {
             const dropped: Array<{ [k: string]: string }> = transactions.slice(chunkSize).map((txn) => {
               return { address: txn.contract.address, method: txn.method, args: txn.args };

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -28,6 +28,14 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
   42161: 3000, // At a conservative 10 TPS, 300 seconds = 3000 transactions. And 1 block per txn.
 };
 
+export const CHAIN_MULTICALL_MAX_CHUNK_SIZE: { [chainId: number]: number } = {
+  1: 100,
+  10: 100,
+  137: 100,
+  288: 100,
+  42161: 100,
+};
+
 // The most critical failure mode that can happen in the inventory management module is a miss-mapping between L1 token
 //  and the associated L2 token. If this is wrong the bot WILL delete money. The mapping below is used to enforce that
 // what the hubpool thinks is the correct L2 token for a given L1 token is actually the correct L2 token. It is simply a

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -28,12 +28,13 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
   42161: 3000, // At a conservative 10 TPS, 300 seconds = 3000 transactions. And 1 block per txn.
 };
 
-export const CHAIN_MULTICALL_MAX_CHUNK_SIZE: { [chainId: number]: number } = {
-  1: 100,
-  10: 100,
-  137: 100,
-  288: 100,
-  42161: 100,
+export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
+export const CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
+  1: DEFAULT_MULTICALL_CHUNK_SIZE,
+  10: DEFAULT_MULTICALL_CHUNK_SIZE,
+  137: DEFAULT_MULTICALL_CHUNK_SIZE,
+  288: DEFAULT_MULTICALL_CHUNK_SIZE,
+  42161: DEFAULT_MULTICALL_CHUNK_SIZE,
 };
 
 // The most critical failure mode that can happen in the inventory management module is a miss-mapping between L1 token


### PR DESCRIPTION
This change modifies the bot's transaction handling when a chain has > x
relay fills to be submitted in a multicall transaction. The approach is to
basically give it a lobotomy, so it just truncates the list of transactions to
ensure that we will always fit within the configured chunk size limit.

The current implementation doesn't work as intended due to the fact that
successive chunks are submitted in parallel, so they all tend to get the
same nonce. This means that a maximum of one multicall txn can succeed
per chain. On top of this, the successful multicall seems to often be
the smallest, which means that a large number of fills are "blocked"
until demand slows down and the bot has a chance at submitting the same
multicall txn without any new Deposit candidates arriving.

The change itself is pretty lightweight, and deliberately retains compatibility
with the surrounding code - i.e. by pretending that we might actually still
see multiple multicall chunks per chain. This makes it easier to re-add that
capability once we have a test environment that will enable proper
verification of that behaviour.
 
As part of this change, also add support for per-chain multicall chunk size
configuration. It seems likely that this flexibility might be needed at some
point in the future, so that we don't have to spend time finding the
goldilocks chunk size. Finally, while here, it addressed a small nit in some
markdown formatting in the same area.

Ref: ACX-98