### PR TITLE
feat: add incremental event caching class and update spokepookclient …

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "main": "dist/index.js",
   "scripts": {
     "lint": "yarn prettier --list-different",
+    "watch": "tsc --watch",
     "lint-fix": "yarn eslint --fix && yarn prettier --write",
     "prettier": "prettier .",
     "eslint": "eslint .",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -244,6 +244,7 @@ export class SpokePoolClient {
   validateFillForDeposit(fill: Fill, deposit: Deposit) {
     let isValid = true;
     Object.keys(deposit).forEach((key) => {
+      if (["transactionHash", "transactionIndex", "logIndex", "blockNumber"].includes(key)) return;
       if (fill[key] !== undefined && deposit[key].toString() !== fill[key].toString()) isValid = false;
     });
     return isValid;
@@ -342,6 +343,7 @@ export class SpokePoolClient {
           const deposit: DepositWithBlock = {
             ...event,
             realizedLpFeePct: dataForQuoteTime[index].realizedLpFeePct,
+            originBlockNumber: event.blockNumber,
           };
           deposit.destinationToken = this.getDestinationTokenForDeposit(deposit);
           assign(this.depositHashes, [this.getDepositHash(deposit)], deposit);
@@ -349,7 +351,7 @@ export class SpokePoolClient {
           assign(
             this.depositsWithBlockNumbers,
             [deposit.destinationChainId],
-            [{ ...deposit, blockNumber: dataForQuoteTime[index].quoteBlock, originBlockNumber: deposit.blockNumber }]
+            [{ ...deposit, blockNumber: dataForQuoteTime[index].quoteBlock }]
           );
         });
       }

--- a/src/utils/EventCache.ts
+++ b/src/utils/EventCache.ts
@@ -1,0 +1,142 @@
+import { createClient } from "redis4";
+import lodash from "lodash";
+import {
+  EventSearchConfig,
+  EventFilter,
+  Contract,
+  eventKey,
+  deepSerialize,
+  deepDeserialize,
+  spreadEventWithBlockNumber,
+} from ".";
+import { SortableEvent } from "../interfaces";
+export type RedisClient = ReturnType<typeof createClient>;
+export type Segments = [number, number][];
+export type Config = {
+  // key is a unique string provided by user, if you want to have different event filters for the same
+  // name, you can keep those caches separate using a different key.
+  key: string;
+  // this is constructed with an event name to differentiate across event types in redis
+  eventName: string;
+  // chain id is required to separate chains
+  chainId: number;
+  redisClient: RedisClient;
+  // you must construct this with a filter and contract, as this cannot change during the life of this cache.
+  eventFilter: EventFilter;
+  contract: Contract;
+};
+// This class acts a low level event cacher, and should work together with block paginator. It will
+// cache blocks of event requests as they are found. It uses 2 data structures, one is the known segements
+// the other is a serializable event. These get stored in redis at unique keys which are a combination of
+// a user defined key, event name, chain id, and the data type (segment or event). This class only works for
+// a single event type, single query parameters,  on a single chain, so multiple instantiations would typically be required.
+export class EventCache {
+  private segmentKey: string;
+  private eventKey: string;
+  // need to store local source of truth of known block ranges, to prevent concurrency issues when updating an array in redis.
+  private segments: Segments | undefined;
+  constructor(private readonly config: Config) {
+    // Construct unique redis keys.
+    this.segmentKey = ["segment", config.key, config.chainId, config.eventName].join("!");
+    this.eventKey = ["event", config.key, config.chainId, config.eventName].join("!");
+  }
+  // merge overlapping segments. taken from https://stackoverflow.com/questions/32585990/algorithm-merge-overlapping-segments
+  static mergeSegments(segments: Segments): Segments {
+    if (segments.length === 0) return segments;
+    const sorted = segments.sort((a, b) => {
+      return a[0] - b[0];
+    });
+
+    const merged: [number, number][] = [sorted.shift()];
+
+    sorted.forEach(([start, end]) => {
+      const last = merged[merged.length - 1];
+      // if the end of the last segment is more than 1 away than start of next segment, its not connected
+      if (start - last[1] > 1) {
+        merged.push([start, end]);
+      } else {
+        // because we have overlap set the last known segements end to the current segements end
+        merged[merged.length - 1][1] = end;
+      }
+    });
+    return merged;
+  }
+  // This takes an event, uses a special serializer to turn it into json safe for storign in redis
+  static serializeEvent = (event: SortableEvent): string => {
+    return [eventKey(event), deepSerialize(event)].join("!");
+  };
+  // take a string of of redis, rehydrate it to be a js object, basically just uses JSON.parse.
+  static deserializeEvent = (event: string): SortableEvent => {
+    const [, eventString] = event.split("!");
+    return deepDeserialize<SortableEvent>(eventString);
+  };
+  // merges and stores known segments
+  private async updateCachedSegments(fromBlock: number, toBlock: number): Promise<void> {
+    const cachedSegments = await this.getLocalOrCachedSegments();
+    await this.setCachedSegments(EventCache.mergeSegments([...cachedSegments, [fromBlock, toBlock]]));
+  }
+  // writes to redis and our local in memory representation of the segments array
+  private async setCachedSegments(segments: Segments): Promise<void> {
+    this.segments = segments;
+    await this.config.redisClient.set(this.segmentKey, JSON.stringify(segments));
+  }
+  // gets known segments from redis.
+  private async getCachedSegments(): Promise<Segments> {
+    const data = (await this.config.redisClient.get(this.segmentKey)) || "[]";
+    return JSON.parse(data) as Segments;
+  }
+  // use local memory or fallback to redis cache and store it locally
+  async getLocalOrCachedSegments(): Promise<Segments> {
+    if (this.segments) return this.segments;
+    this.segments = await this.getCachedSegments();
+    return this.segments;
+  }
+  // stores events in a sorted set in redis, this allows us to retrieve ranges in sorted order
+  private async setCachedEvents(events: SortableEvent[]): Promise<void> {
+    if (events.length === 0) return;
+    await this.config.redisClient.zAdd(
+      this.eventKey,
+      events.map((event) => {
+        return {
+          // this score is 0 to allow for lexical sorting and querying on the value
+          score: 0,
+          value: EventCache.serializeEvent(event),
+        };
+      })
+    );
+  }
+  // checks if the block range is within our known segments
+  private async hasCachedEvents(fromBlock: number, toBlock: number): Promise<boolean> {
+    const cachedSegments = await this.getLocalOrCachedSegments();
+    const found = cachedSegments.find(([segmentStart, segmentEnd]) => {
+      return fromBlock >= segmentStart && toBlock <= segmentEnd;
+    });
+    return found !== undefined;
+  }
+  // retrieves a range of events based on block numbers from redis. using a sorted set in redis so things should be returned in ascending order.
+  // includeLastBlock is a toggle to allow you to be inclusive or exclusive to the last block, by default its inclusive.
+  private async getCachedEvents(fromBlock: number, toBlock: number, includeLastBlock = true): Promise<SortableEvent[]> {
+    const prefix = includeLastBlock ? "[" : "(";
+    const search: [string, string] = [
+      "[" + eventKey({ blockNumber: fromBlock, transactionIndex: 0, logIndex: 0 }),
+      prefix + eventKey({ blockNumber: toBlock, transactionIndex: 0, logIndex: 0 }),
+    ];
+    // use scored entries and lexigraphic sort for event keys
+    const data = (await this.config.redisClient.zRangeByLex(this.eventKey, ...search)) || [];
+    return data.map(EventCache.deserializeEvent);
+  }
+  // This is the main entry point to start queries. It will either return cached events or query the blockchain
+  // cache and return the events. Latestblocktocache can be used to prevent caching of blocks after that number.
+  async queryFilter(fromBlock: number, toBlock: number, latestBlockToCache = 0): Promise<SortableEvent[]> {
+    if (await this.hasCachedEvents(fromBlock, toBlock)) {
+      return this.getCachedEvents(fromBlock, toBlock);
+    }
+    const events = await this.config.contract.queryFilter(this.config.eventFilter, fromBlock, toBlock);
+    const sortableEvents = events.map(spreadEventWithBlockNumber);
+
+    if (toBlock <= latestBlockToCache) {
+      await Promise.all([this.setCachedEvents(sortableEvents), this.updateCachedSegments(fromBlock, toBlock)]);
+    }
+    return sortableEvents;
+  }
+}

--- a/src/utils/FillMathUtils.ts
+++ b/src/utils/FillMathUtils.ts
@@ -2,11 +2,11 @@ import { Fill } from "../interfaces";
 import { toBNWei, BigNumber, toBN } from ".";
 
 export function _getRefundForFill(fill: Fill): BigNumber {
-  return fill.fillAmount.mul(toBNWei(1).sub(fill.realizedLpFeePct)).div(toBNWei(1));
+  return BigNumber.from(fill.fillAmount).mul(toBNWei(1).sub(fill.realizedLpFeePct)).div(toBNWei(1));
 }
 
 export function _getRealizedLpFeeForFill(fill: Fill): BigNumber {
-  return fill.fillAmount.mul(fill.realizedLpFeePct).div(toBNWei(1));
+  return BigNumber.from(fill.fillAmount).mul(fill.realizedLpFeePct).div(toBNWei(1));
 }
 
 export function getRefund(fillAmount: BigNumber, realizedLpFeePct: BigNumber): BigNumber {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,7 @@ import fetch from "node-fetch";
 export { winston, assert, fetch };
 export { delay, Logger } from "@uma/financial-templates-lib";
 
-export { BigNumber, Signer, Contract, ContractFactory, Transaction } from "ethers";
+export { BigNumber, Signer, Contract, ContractFactory, Transaction, BigNumberish } from "ethers";
 export { utils, EventFilter, BaseContract, Event, Wallet } from "ethers";
 export { ethers, providers } from "ethers";
 export type { Block, TransactionResponse, TransactionReceipt } from "@ethersproject/abstract-provider";
@@ -33,6 +33,7 @@ export * from "./TimeUtils";
 export * from "./RedisUtils";
 export * from "./TypeGuards";
 export * from "./Help";
+export * from "./EventCache";
 
 export { ZERO_ADDRESS, MAX_SAFE_ALLOWANCE, MAX_UINT_VAL, replaceAddressCase } from "@uma/common";
 


### PR DESCRIPTION
…to use

Signed-off-by: david <david@umaproject.org>

## Motivation
We are currently only caching event data if we have a successful run in the dataworker. This is problematic because the lack of events in cache can typically cause timeout/request errors that prevent a successful run in the first place. We want to incrementally save events as we get them, so that in the event of a failure we can resume with less probability of erroring out.

## Summary
This change adds a new paginated query function that uses a new `EventCache` class which can incrementally store events for each successfully paged event query. This requires a redis connection.  The main structural changes are to the spoke pool class, which now has its caching mechanism completely removed in favor of this new implementation, and the event data structures are slightly changed. Now the spoke pool must be able to use a deserialzied event object from redis, rather than previously using the raw event data from the blockchain.  Most changes to the spoke pool are to handle these cases.

## Testing
This is a very high risk change, but I tried to be thorough testing this by running the dataworker as if it was in production and validating the redis caching and retrieval. Still theres a possibility of issues if other parts of the system were relying on the spoke pools cache being filled, as this has been disabled.  Also if there are still parts of the spoke pool that require raw event data, those places will have to be changed to use the deserialzied event data instead. 