### PR TITLE
fix(spokepoolclient): invalid deposit IDs during speed up could cause denial of service

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -153,7 +153,7 @@ export class SpokePoolClient {
   }
 
   appendMaxSpeedUpSignatureToDeposit(deposit: Deposit) {
-    const maxSpeedUp = this.speedUps[deposit.depositor]?.[deposit.depositId].reduce((prev, current) =>
+    const maxSpeedUp = this.speedUps[deposit.depositor]?.[deposit.depositId]?.reduce((prev, current) =>
       prev.newRelayerFeePct.gt(current.newRelayerFeePct) ? prev : current
     );
 

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -71,4 +71,24 @@ describe("SpokePoolClient: SpeedUp", async function () {
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId)).to.deep.equal([expectedDepositData]);
     expect(spokePoolClient.getDepositsFromDepositor(depositor.address)).to.deep.equal([expectedDepositData]);
   });
+  it("Receives a speed up for a correct depositor but invalid deposit Id", async function() {
+    const deposit = await simpleDeposit(spokePool, erc20, depositor, depositor, destinationChainId);
+
+    await spokePoolClient.update();
+
+    // change deposit ID to some invalid value
+    deposit.depositId = 1337;
+
+    const newRelayFeePct = toBNWei(0.1337);
+    const speedUpSignature = await signForSpeedUp(depositor, deposit, newRelayFeePct);
+    await spokePool.speedUpDeposit(depositor.address, newRelayFeePct, deposit.depositId, speedUpSignature);
+
+    let success = false;
+    try {
+        await spokePoolClient.update();
+        success = true;
+    } catch {}
+
+    expect(success).to.be.true;
+  });
 });


### PR DESCRIPTION
After a user performed a deposit ([SpokePool.sol#L246](https://github.com/across-protocol/contracts-v2/blob/b15ae29e6824cd058d6d5bba2ebe2c9a32389262/contracts/SpokePool.sol#L246)) via the `SpokePool` contract, they can additionally call `speedUpDeposit()` ([SpokePool.sol#L315](https://github.com/across-protocol/contracts-v2/blob/b15ae29e6824cd058d6d5bba2ebe2c9a32389262/contracts/SpokePool.sol#L315)) in order to increase the relayer fee they are willing to pay. `speedUpDeposit()` will then emit the `RequestedSpeedUpDeposit` event, notifying Spoke Pool clients that a deposit's relayer fee has changed ([SpokePoolClient.ts#L372](https://github.com/across-protocol/relayer-v2/blob/7290c3ce63e216f22a6b21f9ff2310b72c4dd4ed/src/clients/SpokePoolClient.ts#L372)).

The event is handled by adding the speed up event to a global object called `speedUps` ([SpokePoolClient.ts#L377](https://github.com/across-protocol/relayer-v2/blob/7290c3ce63e216f22a6b21f9ff2310b72c4dd4ed/src/clients/SpokePoolClient.ts#L377)), and then iterating over all deposits and calling `appendMaxSpeedUpSignatureToDeposit()` for each deposit ([SpokePoolClient.ts#L383](https://github.com/across-protocol/relayer-v2/blob/7290c3ce63e216f22a6b21f9ff2310b72c4dd4ed/src/clients/SpokePoolClient.ts#L383)).

`appendMaxSpeedUpSignatureToDeposit()` will use the provided deposit and attempt to identify if a matching speed up exists in the global `speedUps` object. An excerpt of this code is shown below.

```ts
appendMaxSpeedUpSignatureToDeposit(deposit: Deposit) {
    const maxSpeedUp = this.speedUps[deposit.depositor]?.[deposit.depositId].reduce((prev, current) =>
      prev.newRelayerFeePct.gt(current.newRelayerFeePct) ? prev : current
    );
    ...
}
```

In the above code, if the key `deposit.depositor` does not exist in `this.speedUps`, the optional chaining operator will ensure that `maxSpeedUp` is undefined, which will later cause the function to correctly return. 

However, no optional chaining operator is used when accessing the `deposit.depositId` index. Therefore, if a speed up exists for a given deposit, but an incorrect deposit Id is received, `reduce()` will be called on an undefined object, leading to an exception being thrown, and crashing the process.

## Solution

Add an optional chaining operator after accessing index `deposit.depositId` in `appendMaxSpeedUpSignatureToDeposit()` to ensure `reduce()` is not called on an undefined object.