### PR TITLE
fix: Apply modified relayer fee pct to depositsWithBlocks

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -380,10 +380,15 @@ export class SpokePoolClient {
       // Traverse all deposit events and update them with associated speedups, If they exist.
       for (const destinationChainId of Object.keys(this.depositsWithBlockNumbers))
         for (const [index, deposit] of this.depositsWithBlockNumbers[destinationChainId].entries()) {
-          const speedUpDeposit = this.appendMaxSpeedUpSignatureToDeposit(deposit);
-          if (speedUpDeposit !== deposit) {
+          const { blockNumber, originBlockNumber, ...depositData } = deposit;
+          const speedUpDeposit = this.appendMaxSpeedUpSignatureToDeposit(depositData);
+          if (speedUpDeposit !== depositData) {
             this.deposits[destinationChainId][index] = speedUpDeposit;
-            this.depositsWithBlockNumbers[destinationChainId][index] = speedUpDeposit;
+            this.depositsWithBlockNumbers[destinationChainId][index] = {
+              ...speedUpDeposit,
+              blockNumber,
+              originBlockNumber,
+            };
           }
         }
     }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -378,8 +378,8 @@ export class SpokePoolClient {
       }
 
       // Traverse all deposit events and update them with associated speedups, If they exist.
-      for (const destinationChainId of Object.keys(this.deposits))
-        for (const [index, deposit] of this.deposits[destinationChainId].entries()) {
+      for (const destinationChainId of Object.keys(this.depositsWithBlockNumbers))
+        for (const [index, deposit] of this.depositsWithBlockNumbers[destinationChainId].entries()) {
           const speedUpDeposit = this.appendMaxSpeedUpSignatureToDeposit(deposit);
           if (speedUpDeposit !== deposit) {
             this.deposits[destinationChainId][index] = speedUpDeposit;

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -381,7 +381,10 @@ export class SpokePoolClient {
       for (const destinationChainId of Object.keys(this.deposits))
         for (const [index, deposit] of this.deposits[destinationChainId].entries()) {
           const speedUpDeposit = this.appendMaxSpeedUpSignatureToDeposit(deposit);
-          if (speedUpDeposit !== deposit) this.deposits[destinationChainId][index] = speedUpDeposit;
+          if (speedUpDeposit !== deposit) {
+            this.deposits[destinationChainId][index] = speedUpDeposit;
+            this.depositsWithBlockNumbers[destinationChainId][index] = speedUpDeposit;
+          }
         }
     }
 

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -3,6 +3,7 @@ import { deploySpokePoolWithToken, enableRoutes, simpleDeposit, originChainId, c
 import { depositRelayerFeePct, destinationChainId } from "./constants";
 
 import { SpokePoolClient } from "../src/clients";
+import { getUnfilledDeposits } from "../src/utils";
 
 let spokePool: Contract, erc20: Contract, destErc20: Contract, weth: Contract;
 let owner: SignerWithAddress, depositor: SignerWithAddress;
@@ -71,7 +72,7 @@ describe("SpokePoolClient: SpeedUp", async function () {
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId)).to.deep.equal([expectedDepositData]);
     expect(spokePoolClient.getDepositsFromDepositor(depositor.address)).to.deep.equal([expectedDepositData]);
   });
-  it("Receives a speed up for a correct depositor but invalid deposit Id", async function() {
+  it("Receives a speed up for a correct depositor but invalid deposit Id", async function () {
     const deposit = await simpleDeposit(spokePool, erc20, depositor, depositor, destinationChainId);
 
     await spokePoolClient.update();
@@ -85,9 +86,11 @@ describe("SpokePoolClient: SpeedUp", async function () {
 
     let success = false;
     try {
-        await spokePoolClient.update();
-        success = true;
-    } catch {}
+      await spokePoolClient.update();
+      success = true;
+    } catch {
+      /* no-empty */
+    }
 
     expect(success).to.be.true;
   });


### PR DESCRIPTION
cc to @pleasew8t on this writeup:

## Description

After a user submitted a speed up request via `speedUpDeposit()` ([SpokePool.sol#L315](https://github.com/across-protocol/contracts-v2/blob/b15ae29e6824cd058d6d5bba2ebe2c9a32389262/contracts/SpokePool.sol#L315)) for a deposit, the Spoke Pool client will update the existing deposit with the new relayer fee. This is done by overwriting the updated deposit in the global `deposits` object, as shown below:

```ts
      for (const destinationChainId of Object.keys(this.deposits))
        for (const [index, deposit] of this.deposits[destinationChainId].entries()) {
          const speedUpDeposit = this.appendMaxSpeedUpSignatureToDeposit(deposit);
          // update this.deposits with sped up deposit, overwriting old deposit
          if (speedUpDeposit !== deposit) this.deposits[destinationChainId][index] = speedUpDeposit;
        }
```

However, when the relayer function `checkForUnfilledDepositsAndFill()` ([Relayer.ts#L23](https://github.com/across-protocol/relayer-v2/blob/7290c3ce63e216f22a6b21f9ff2310b72c4dd4ed/src/relayer/Relayer.ts#L23)), the original deposit with the old fee would still be processed instead of the updated deposit.

This is likely due to `checkForUnfilledDepositsAndFill()`'s call to `getUnfilledDeposits()` ([FillUtils.ts#L151](https://github.com/across-protocol/relayer-v2/blob/7290c3ce63e216f22a6b21f9ff2310b72c4dd4ed/src/utils/FillUtils.ts#L151)), which calls `getDepositsForDestinationChain()` ([SpokePoolClient.ts#L62](https://github.com/across-protocol/relayer-v2/blob/7290c3ce63e216f22a6b21f9ff2310b72c4dd4ed/src/clients/SpokePoolClient.ts#L62)) with argument `withBlock` equals to `true` ([FillUtils.ts#L166](https://github.com/across-protocol/relayer-v2/blob/7290c3ce63e216f22a6b21f9ff2310b72c4dd4ed/src/utils/FillUtils.ts#L166)).

When `withBlock` is true, a lookup is performed against the global `depositsWithBlockNumbers` object, as shown below.

```ts
  getDepositsForDestinationChain(destinationChainId: number, withBlock = false): Deposit[] | DepositWithBlock[] {
    return withBlock
      ? this.depositsWithBlockNumbers[destinationChainId] || []
      : this.deposits[destinationChainId] || [];
  }
```

As the speed up functionality only updates the `deposits` object, `checkForUnfilledDepositsAndFill()` would miss the deposit with the updated fee, and any users who's transactions cannot be processed due to low relay fees will not be able to have their updated deposits processed.

## Attack

This issue is not exploitable by a malicious actor against users. However, users who's deposits cannot be filled due to unprofitable relay fees will not be able to update their fees to complete the bridge process.

A test case has been supplied that checks whether the updated deposit is included in the unfilled deposits, rather than the old deposit. To run the test, copy `AuditUnfilledDepositSpeedUp.ts` to the `test` folder in the repository and run `npx hardhat test test/AuditUnfilledDepositSpeedUp.ts`. 

## Suggested Risk Rating

The risk rating for this issue is considered `LOW`. This issue could cause grievences among users, but is not exploitable by third parties.

## Potential Remediation

At the time of investigating other instances of calls to `getDepositsForDestinationChain()` were observed, also setting `withBlock` to `true`, requiring a lookup against `depositsWithBlockNumbers`. For this reason, a recommended solution would be to additionally update `depositsWithBlockNumbers` after updating `deposits` during the processing of speed up events. An example of this is shown below.

```ts
        for (const [index, deposit] of this.depositsWithBlockNumbers[destinationChainId].entries()) {
          const speedUpDeposit = this.appendMaxSpeedUpSignatureToDeposit(deposit);
          if (speedUpDeposit !== deposit) {
            this.deposits[destinationChainId][index] = speedUpDeposit;
            this.depositsWithBlockNumbers[destinationChainId][index] = speedUpDeposit;
          }
        }
```