### PR TITLE
improve(relayer): Add a per-network following distance to spoke pool's event search config

### DIFF
--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -41,12 +41,7 @@ export class AcrossConfigStoreClient {
     readonly logger: winston.Logger,
     readonly configStore: Contract, // TODO: Rename to ConfigStore
     readonly hubPoolClient: HubPoolClient,
-    readonly eventSearchConfig: EventSearchConfig = {
-      fromBlock: 0,
-      toBlock: null,
-      maxBlockLookBack: 0,
-      followingDistance: 0,
-    },
+    readonly eventSearchConfig: EventSearchConfig = { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 },
     readonly redisClient?: ReturnType<typeof createClient>
   ) {
     this.firstBlockToSearch = eventSearchConfig.fromBlock;

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -41,7 +41,12 @@ export class AcrossConfigStoreClient {
     readonly logger: winston.Logger,
     readonly configStore: Contract, // TODO: Rename to ConfigStore
     readonly hubPoolClient: HubPoolClient,
-    readonly eventSearchConfig: EventSearchConfig = { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 },
+    readonly eventSearchConfig: EventSearchConfig = {
+      fromBlock: 0,
+      toBlock: null,
+      maxBlockLookBack: 0,
+      followingDistance: 0,
+    },
     readonly redisClient?: ReturnType<typeof createClient>
   ) {
     this.firstBlockToSearch = eventSearchConfig.fromBlock;

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -43,10 +43,7 @@ export class SpokePoolClient {
     readonly configStoreClient: AcrossConfigStoreClient | null,
     readonly chainId: number,
     readonly eventSearchConfig: EventSearchConfig = { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 },
-    readonly spokePoolDeploymentBlock: number = 0,
-    // Number of blocks to subtract from latest block the provider returns. This helps avoid fork reorgs that can lead
-    // to double filling of the same deposit.
-    readonly blockFollowingDistance: number = 0
+    readonly spokePoolDeploymentBlock: number = 0
   ) {
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
   }
@@ -226,7 +223,8 @@ export class SpokePoolClient {
     );
 
     // Use a following distance to ensure the data we see are final.
-    this.latestBlockNumber = (await this.spokePool.provider.getBlockNumber()) - this.blockFollowingDistance;
+    const followingDistance = this.eventSearchConfig.followingDistance ?? 0;
+    this.latestBlockNumber = (await this.spokePool.provider.getBlockNumber()) - followingDistance;
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
       toBlock: this.eventSearchConfig.toBlock || this.latestBlockNumber,

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -39,10 +39,14 @@ export class SpokePoolClient {
   constructor(
     readonly logger: winston.Logger,
     readonly spokePool: Contract,
-    readonly configStoreClient: AcrossConfigStoreClient | null, // Can be excluded. This disables some deposit validation.
+    // Can be excluded. This disables some deposit validation.
+    readonly configStoreClient: AcrossConfigStoreClient | null,
     readonly chainId: number,
     readonly eventSearchConfig: EventSearchConfig = { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 },
-    readonly spokePoolDeploymentBlock: number = 0
+    readonly spokePoolDeploymentBlock: number = 0,
+    // Number of blocks to subtract from latest block the provider returns. This helps avoid fork reorgs that can lead
+    // to double filling of the same deposit.
+    readonly blockFollowingDistance: number = 0
   ) {
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
   }
@@ -221,7 +225,8 @@ export class SpokePoolClient {
       process.env[`NODE_MAX_CONCURRENCY_${this.chainId}`] || NODE_MAX_CONCURRENCY || "1000"
     );
 
-    this.latestBlockNumber = await this.spokePool.provider.getBlockNumber();
+    // Use a following distance to ensure the data we see are final.
+    this.latestBlockNumber = (await this.spokePool.provider.getBlockNumber()) - this.blockFollowingDistance;
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
       toBlock: this.eventSearchConfig.toBlock || this.latestBlockNumber,

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -80,22 +80,23 @@ export async function constructSpokePoolClientsWithLookback(
   });
 
   // Create client for each spoke pool.
-  spokePools.forEach((obj: { networkId: number; contract: Contract }) => {
+  spokePools.forEach(({ networkId, contract }) => {
     const spokePoolDeploymentBlock = getDeploymentBlockNumber("SpokePool", obj.networkId);
     const spokePoolClientSearchSettings = {
-      fromBlock: fromBlocks[obj.networkId]
-        ? Math.max(fromBlocks[obj.networkId], spokePoolDeploymentBlock)
+      fromBlock: fromBlocks[networkId]
+        ? Math.max(fromBlocks[networkId], spokePoolDeploymentBlock)
         : spokePoolDeploymentBlock,
       toBlock: null,
-      maxBlockLookBack: config.maxBlockLookBack[obj.networkId],
+      maxBlockLookBack: config.maxBlockLookBack[networkId],
     };
-    spokePoolClients[obj.networkId] = new SpokePoolClient(
+    spokePoolClients[networkId] = new SpokePoolClient(
       logger,
-      obj.contract,
+      contract,
       configStoreClient,
-      obj.networkId,
+      networkId,
       spokePoolClientSearchSettings,
-      spokePoolDeploymentBlock
+      spokePoolDeploymentBlock,
+      config.followingDistances[networkId] ?? 0
     );
   });
 

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -81,7 +81,7 @@ export async function constructSpokePoolClientsWithLookback(
 
   // Create client for each spoke pool.
   spokePools.forEach(({ networkId, contract }) => {
-    const spokePoolDeploymentBlock = getDeploymentBlockNumber("SpokePool", obj.networkId);
+    const spokePoolDeploymentBlock = getDeploymentBlockNumber("SpokePool", networkId);
     const spokePoolClientSearchSettings = {
       fromBlock: fromBlocks[networkId]
         ? Math.max(fromBlocks[networkId], spokePoolDeploymentBlock)

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -88,6 +88,7 @@ export async function constructSpokePoolClientsWithLookback(
         : spokePoolDeploymentBlock,
       toBlock: null,
       maxBlockLookBack: config.maxBlockLookBack[networkId],
+      followingDistance: config.followingDistances[networkId],
     };
     spokePoolClients[networkId] = new SpokePoolClient(
       logger,
@@ -95,8 +96,7 @@ export async function constructSpokePoolClientsWithLookback(
       configStoreClient,
       networkId,
       spokePoolClientSearchSettings,
-      spokePoolDeploymentBlock,
-      config.followingDistances[networkId] ?? 0
+      spokePoolDeploymentBlock
     );
   });
 

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -17,6 +17,8 @@ export class CommonConfig {
   readonly bundleRefundLookback: number;
   readonly maxRelayerLookBack: { [chainId: number]: number };
   readonly maxRelayerUnfilledDepositLookBack: { [chainId: number]: number };
+  // Following distances in blocks to guarantee finality on each chain.
+  readonly followingDistances: { [chainId: number]: number };
 
   constructor(env: ProcessEnv) {
     const {
@@ -30,6 +32,7 @@ export class CommonConfig {
       SEND_TRANSACTIONS,
       REDIS_URL,
       BUNDLE_REFUND_LOOKBACK,
+      FOLLOWING_DISTANCES,
     } = env;
 
     // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
@@ -59,5 +62,6 @@ export class CommonConfig {
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
     this.redisUrl = REDIS_URL;
     this.bundleRefundLookback = BUNDLE_REFUND_LOOKBACK ? Number(BUNDLE_REFUND_LOOKBACK) : 2;
+    this.followingDistances = FOLLOWING_DISTANCES ? JSON.parse(FOLLOWING_DISTANCES) : {};
   }
 }

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -28,6 +28,9 @@ export function spreadEvent(event: Event) {
 export interface EventSearchConfig {
   fromBlock: number;
   toBlock: number | null;
+  // Number of blocks to subtract from latest block the provider returns. This helps avoid fork reorgs that can lead
+  // to double filling of the same deposit.
+  followingDistance?: number;
   maxBlockLookBack?: number;
   concurrency?: number | null;
 }


### PR DESCRIPTION
Forks can happen on chains such as Polygon. We need to add support for following distances to make sure we only fill deposits that have been finalized (and not subject to forks being undone).