### PR TITLE
fix(profit client): Allow fetching CG prices when relay gas profitability is disabled

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -210,6 +210,7 @@ export class ProfitClient {
         throw new Error(mrkdwn);
       }
     }
+    this.logger.debug({ at: "ProfitClient", message: "Updated token prices", tokenPrices: this.tokenPrices });
 
     // Short circuit early if profitability is disabled. We still need to fetch CG prices but don't need to fetch gas
     // costs of relays.
@@ -219,18 +220,17 @@ export class ProfitClient {
     const gasCosts = await Promise.all(
       this.enabledChainIds.map((chainId) => this.relayerFeeQueries[chainId].getGasCosts())
     );
-    this.logger.debug({
-      at: "ProfitClient",
-      message: "Fetched gas costs of relays",
-      enabledChainIds: this.enabledChainIds,
-      gasCosts,
-    });
     for (let i = 0; i < this.enabledChainIds.length; i++) {
       // An extra toBN cast is needed as the provider returns a different BigNumber type.
       this.totalGasCosts[this.enabledChainIds[i]] = toBN(gasCosts[i]);
     }
 
-    this.logger.debug({ at: "ProfitClient", message: "Updated Profit client", tokenPrices: this.tokenPrices });
+    this.logger.debug({
+      at: "ProfitClient",
+      message: "Updated gas cost",
+      enabledChainIds: this.enabledChainIds,
+      totalGasCosts: this.totalGasCosts,
+    });
   }
 
   protected async coingeckoPrices(tokens: string[]) {

--- a/test/ProfitClient.PriceRetrieval.ts
+++ b/test/ProfitClient.PriceRetrieval.ts
@@ -2,12 +2,12 @@ import { L1Token } from "../src/interfaces";
 import { expect, createSpyLogger, winston, BigNumber, toBN } from "./utils";
 
 import { MockHubPoolClient } from "./mocks";
-import { ProfitClient, MATIC } from "../src/clients"; // Tested
+import { ProfitClient, MATIC, WETH } from "../src/clients"; // Tested
 
 let hubPoolClient: MockHubPoolClient, spy: sinon.SinonSpy, spyLogger: winston.Logger;
 
 const mainnetTokens: Array<L1Token> = [
-  { symbol: "WETH", address: "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2", decimals: 18 },
+  { symbol: "WETH", address: WETH, decimals: 18 },
   { symbol: "USDC", address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", decimals: 6 },
   { symbol: "WBTC", address: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599", decimals: 8 },
   { symbol: "BOBA", address: "0x42bbfa2e77757c645eeaad1655e0911a7553efbc", decimals: 18 },
@@ -31,20 +31,30 @@ describe("ProfitClient: Price Retrieval", async function () {
     ({ spy, spyLogger } = createSpyLogger());
 
     hubPoolClient = new MockHubPoolClient(null, null);
+    mainnetTokens.forEach((token: L1Token) => hubPoolClient.addL1Token(token));
     profitClient = new ProfitClientWithMockCoingecko(spyLogger, hubPoolClient, {}, true, [], false, toBN(0));
   });
 
   it("Correctly fetches token prices", async function () {
-    mainnetTokens.forEach((token: L1Token) => hubPoolClient.addL1Token(token));
     await profitClient.update();
+    verifyTokenPrices();
+  });
 
-    const tokenPrices: { [k: string]: BigNumber } = profitClient.getAllPrices();
+  it("Still fetches prices when profitability is disabled", async function () {
+    // enableRelayProfitability is set to false.
+    profitClient = new ProfitClientWithMockCoingecko(spyLogger, hubPoolClient, {}, false, []);
 
-    // The client should have fetched prices for all requested tokens.
-    expect(Object.keys(tokenPrices)).to.have.deep.members(mainnetTokens.map((token) => token["address"]));
-    Object.values(tokenPrices).forEach((price: BigNumber) => expect(toBN(price).gt(toBN(0))).to.be.true);
-    Object.keys(tokenPrices).forEach(
-      (token) => expect(toBN(profitClient.getPriceOfToken(token)).gt(toBN(0))).to.be.true
-    );
+    // Verify that update() still fetches prices from Coingecko.
+    await profitClient.update();
+    verifyTokenPrices();
   });
 });
+
+const verifyTokenPrices = () => {
+  const tokenPrices: { [k: string]: BigNumber } = profitClient.getAllPrices();
+
+  // The client should have fetched prices for all requested tokens.
+  expect(Object.keys(tokenPrices)).to.have.deep.members(mainnetTokens.map((token) => token["address"]));
+  Object.values(tokenPrices).forEach((price: BigNumber) => expect(toBN(price).gt(toBN(0))).to.be.true);
+  Object.keys(tokenPrices).forEach((token) => expect(toBN(profitClient.getPriceOfToken(token)).gt(toBN(0))).to.be.true);
+};


### PR DESCRIPTION
**Breaking change:** https://github.com/across-protocol/relayer-v2/pull/261 introduced an enableProfitability flag that, when set to false, skip all prices and gas cost updates in ProfitClient#update(). This can be useful for the relayer when we want to disable profitability check.

**Problem:** However, the dataworker also needs to use the ProfitClient to calculate the current volume of deposits when deciding if the volume is big enough to propose a bundle. Since the dataworker has enableProfitability = false, this stops ProfitClient from fetching prices and thus breaks the dataowker's volume calculation (it's always 0).

**Solution:** Allow ProfitClient to fetch prices in update() regardless of the enableProfitability flag.
**Testing:** An extra unit test is added to ensure prices are still fetched when enableProfitability = false. I also ran the dataworker manually and verified that it gets the prices from Coingecko and still performs volume calc correctly.