### PR TITLE
improve(bundle logging): Fix fee formatting and explicitly say when there are no slow relay leaves

### DIFF
--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -20,6 +20,7 @@ import {
   MerkleTree,
   winston,
   toBNWei,
+  formatFeePct,
 } from "../utils";
 import { DataworkerClients } from "./DataworkerClientHelper";
 import { getFillDataForSlowFillFromPreviousRootBundle } from "../utils";
@@ -463,9 +464,9 @@ export function generateMarkdownForRootBundle(
     leaf.recipient = shortenHexString(leaf.recipient);
     leaf.destToken = convertTokenAddressToSymbol(leaf.destinationChainId, leaf.destinationToken);
     leaf.amount = convertFromWei(leaf.amount, decimalsForDestToken);
-    // Fee decimals is always 18. 1e18 = 100%.
-    leaf.realizedLpFee = `${convertFromWei(leaf.realizedLpFeePct, 16)}%`;
-    leaf.relayerFee = `${convertFromWei(leaf.relayerFeePct, 16)}%`;
+    // Fee decimals is always 18. 1e18 = 100% so 1e16 = 1%.
+    leaf.realizedLpFee = `${formatFeePct(leaf.realizedLpFeePct)}%`;
+    leaf.relayerFee = `${formatFeePct(leaf.relayerFeePct)}%`;
     delete leaf.destinationToken;
     delete leaf.realizedLpFeePct;
     delete leaf.relayerFeePct;

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -464,8 +464,8 @@ export function generateMarkdownForRootBundle(
     leaf.destToken = convertTokenAddressToSymbol(leaf.destinationChainId, leaf.destinationToken);
     leaf.amount = convertFromWei(leaf.amount, decimalsForDestToken);
     // Fee decimals is always 18. 1e18 = 100%.
-    leaf.realizedLpFee = `${convertFromWei(leaf.realizedLpFeePct, 18)}%`;
-    leaf.relayerFee = `${convertFromWei(leaf.relayerFeePct, 18)}%`;
+    leaf.realizedLpFee = `${convertFromWei(leaf.realizedLpFeePct, 16)}%`;
+    leaf.relayerFee = `${convertFromWei(leaf.relayerFeePct, 16)}%`;
     delete leaf.destinationToken;
     delete leaf.realizedLpFeePct;
     delete leaf.relayerFeePct;

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -472,13 +472,17 @@ export function generateMarkdownForRootBundle(
     delete leaf.destinationChainId;
     slowRelayLeavesPretty += `\n\t\t\t${index}: ${JSON.stringify(leaf)}`;
   });
+
+  const slowRelayMsg = slowRelayLeavesPretty
+    ? `root:${shortenHexString(slowRelayRoot)}...\n\t\tleaves:${slowRelayLeavesPretty}`
+    : "No slow relay leaves";
   return (
     `\n\t*Bundle blocks*:${bundleBlockRangePretty}` +
     `\n\t*PoolRebalance*:\n\t\troot:${shortenHexString(
       poolRebalanceRoot
     )}...\n\t\tleaves:${poolRebalanceLeavesPretty}` +
     `\n\t*RelayerRefund*\n\t\troot:${shortenHexString(relayerRefundRoot)}...\n\t\tleaves:${relayerRefundLeavesPretty}` +
-    `\n\t*SlowRelay*\n\troot:${shortenHexString(slowRelayRoot)}...\n\t\tleaves:${slowRelayLeavesPretty}`
+    `\n\t*SlowRelay*\n\t${slowRelayMsg}`
   );
 }
 

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -463,8 +463,9 @@ export function generateMarkdownForRootBundle(
     leaf.recipient = shortenHexString(leaf.recipient);
     leaf.destToken = convertTokenAddressToSymbol(leaf.destinationChainId, leaf.destinationToken);
     leaf.amount = convertFromWei(leaf.amount, decimalsForDestToken);
-    leaf.realizedLpFee = `${convertFromWei(leaf.realizedLpFeePct, decimalsForDestToken)}%`;
-    leaf.relayerFee = `${convertFromWei(leaf.relayerFeePct, decimalsForDestToken)}%`;
+    // Fee decimals is always 18. 1e18 = 100%.
+    leaf.realizedLpFee = `${convertFromWei(leaf.realizedLpFeePct, 18)}%`;
+    leaf.relayerFee = `${convertFromWei(leaf.relayerFeePct, 18)}%`;
     delete leaf.destinationToken;
     delete leaf.realizedLpFeePct;
     delete leaf.relayerFeePct;

--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -16,7 +16,8 @@ export const toBN = (num: string | number | BigNumber) => {
 };
 
 export const formatFeePct = (relayerFeePct: BigNumber): string => {
-  return createFormatFunction(2, 4, false, 18)(toBN(relayerFeePct).mul(100).toString());
+  // 1e18 = 100% so 1e16 = 1%.
+  return createFormatFunction(2, 4, false, 16)(toBN(relayerFeePct).toString());
 };
 
 export { createFormatFunction } from "@uma/common";


### PR DESCRIPTION
1. Fee formatting is incorrect:
SlowRelay
    root:0xc8a05438...
        leaves:
            0: {"depositor":"0xD275E5cb","recipient":"0xD275E5cb","amount":"15,000,000.00","depositId":50372,"originChain":10,"destinationChain":1,"destToken":"USDC","realizedLpFee":"754,528,997.61%","relayerFee":"727,688,639.33%"}

2. Slack message for new bundle currently prints out when there are no slow fills

SlowRelay
    root:0x00000000...
        leaves:

when there are no slow relay leaves which is confusing as it looks like an error. We should explicitly say "No slow relay leaves" 