### PR TITLE
fix(dataworker, monitor): Don't throw errors on CG prfice fetch errors

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -165,7 +165,7 @@ export async function constructClients(
   const multiCallerClient = new MultiCallerClient(logger);
 
   // Disable profitability by default as only the relayer needs it. Relayer has its own client initializations.
-  const profitClient = new ProfitClient(logger, hubPoolClient, {}, false, []);
+  const profitClient = new ProfitClient(logger, hubPoolClient, {}, false, [], true);
 
   return { hubPoolClient, configStoreClient, multiCallerClient, profitClient, hubSigner };
 }


### PR DESCRIPTION
After a recent change in ProfitClient, we became a bit too strict with CG price failures. We can tolerate these failures in monitor and dataworker bots. Dataworker would not try to propose any bundles if price fetches fail as the volume would be 0).