### PR TITLE
fix: SpokePoolClient incorrectly overrides deposit.relayerFeePct when a RequestedSpeedUp event is emitted

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -92,7 +92,8 @@ export class ProfitClient {
   }
 
   isFillProfitable(deposit: Deposit, fillAmount: BigNumber) {
-    if (toBN(deposit.relayerFeePct).lt(this.minRelayerFeePct)) {
+    const relayerFeePct = toBN(deposit.newRelayerFeePct ?? deposit.relayerFeePct);
+    if (relayerFeePct.lt(this.minRelayerFeePct)) {
       this.logger.debug({
         at: "ProfitClient",
         message: "Relayer fee % < minimum relayer fee %",
@@ -101,7 +102,7 @@ export class ProfitClient {
       return false;
     }
 
-    if (toBN(deposit.relayerFeePct).eq(toBN(0))) {
+    if (relayerFeePct.eq(toBN(0))) {
       this.logger.debug({ at: "ProfitClient", message: "Deposit set 0 relayerFeePct. Rejecting relay" });
       return false;
     }
@@ -115,7 +116,7 @@ export class ProfitClient {
 
     const { decimals, address: l1Token } = this.hubPoolClient.getTokenInfoForDeposit(deposit);
     const tokenPriceInUsd = this.getPriceOfToken(l1Token);
-    const fillRevenueInRelayedToken = toBN(deposit.relayerFeePct).mul(fillAmount).div(toBN(10).pow(decimals));
+    const fillRevenueInRelayedToken = relayerFeePct.mul(fillAmount).div(toBN(10).pow(decimals));
     const fillRevenueInUsd = fillRevenueInRelayedToken.mul(tokenPriceInUsd).div(toBNWei(1));
 
     // Consider gas cost.

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -92,7 +92,13 @@ export class ProfitClient {
   }
 
   isFillProfitable(deposit: Deposit, fillAmount: BigNumber) {
-    const relayerFeePct = toBN(deposit.newRelayerFeePct ?? deposit.relayerFeePct);
+    const newRelayerFeePct = toBN(deposit.newRelayerFeePct ?? 0);
+    let relayerFeePct = toBN(deposit.relayerFeePct);
+    // Use the maximum between the original newRelayerFeePct and any updated fee from speedups.
+    if (relayerFeePct.lt(newRelayerFeePct)) {
+      relayerFeePct = newRelayerFeePct;
+    }
+
     if (relayerFeePct.lt(this.minRelayerFeePct)) {
       this.logger.debug({
         at: "ProfitClient",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -158,7 +158,7 @@ export class SpokePoolClient {
       prev.newRelayerFeePct.gt(current.newRelayerFeePct) ? prev : current
     );
 
-    // Only if there is a speedup and the new relayer fee is greater than the current relayer fee, save the new the fee.
+    // Only if there is a speedup and the new relayer fee is greater than the current relayer fee, save the new fee.
     if (!maxSpeedUp || maxSpeedUp.newRelayerFeePct.lte(deposit.relayerFeePct)) return deposit;
     return {
       ...deposit,

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -158,9 +158,13 @@ export class SpokePoolClient {
       prev.newRelayerFeePct.gt(current.newRelayerFeePct) ? prev : current
     );
 
-    // Only if there is a speedup and the new relayer fee is greater than the current relayer fee, replace the fee.
+    // Only if there is a speedup and the new relayer fee is greater than the current relayer fee, save the new the fee.
     if (!maxSpeedUp || maxSpeedUp.newRelayerFeePct.lte(deposit.relayerFeePct)) return deposit;
-    return { ...deposit, speedUpSignature: maxSpeedUp.depositorSignature, relayerFeePct: maxSpeedUp.newRelayerFeePct };
+    return {
+      ...deposit,
+      speedUpSignature: maxSpeedUp.depositorSignature,
+      newRelayerFeePct: maxSpeedUp.newRelayerFeePct,
+    };
   }
 
   getDepositForFill(fill: Fill): Deposit | undefined {
@@ -374,7 +378,7 @@ export class SpokePoolClient {
 
     // Disable this loop.
     // eslint-disable-next-line no-constant-condition
-    if (eventsToQuery.includes("RequestedSpeedUpDeposit") && false) {
+    if (eventsToQuery.includes("RequestedSpeedUpDeposit")) {
       const speedUpEvents = queryResults[eventsToQuery.indexOf("RequestedSpeedUpDeposit")];
 
       for (const event of speedUpEvents) {

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -15,6 +15,7 @@ export interface Deposit {
   realizedLpFeePct?: BigNumber; // appended after initialization (not part of Deposit event).
   destinationToken?: string; // appended after initialization (not part of Deposit event).
   speedUpSignature?: string | undefined; // appended after initialization, if deposit was speedup (not part of Deposit event).
+  newRelayerFeePct?: BigNumber; // appended after initialization, if deposit was speedup (not part of Deposit event).
 }
 
 export interface DepositWithBlock extends Deposit, SortableEvent {

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -14,6 +14,7 @@ export class RelayerConfig extends CommonConfig {
   readonly relayerTokens: string[];
   readonly relayerDestinationChains: number[];
   readonly minRelayerFeePct: BigNumber;
+  readonly enableSpeedups: boolean;
 
   constructor(env: ProcessEnv) {
     const {
@@ -25,6 +26,7 @@ export class RelayerConfig extends CommonConfig {
       SEND_RELAYS,
       SEND_SLOW_RELAYS,
       MIN_RELAYER_FEE_PCT,
+      ENABLE_SPEEDUPS,
     } = env;
     super(env);
 
@@ -67,5 +69,6 @@ export class RelayerConfig extends CommonConfig {
     this.ignoreTokenPriceFailures = IGNORE_TOKEN_PRICE_FAILURES === "true";
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
+    this.enableSpeedups = ENABLE_SPEEDUPS === "true";
   }
 }

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -15,13 +15,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Wallet): P
 
     relayerClients = await constructRelayerClients(logger, config, baseSigner);
 
-    const relayer = new Relayer(
-      baseSigner.address,
-      logger,
-      relayerClients,
-      config.maxRelayerUnfilledDepositLookBack,
-      config.relayerTokens
-    );
+    const relayer = new Relayer(baseSigner.address, logger, relayerClients, config);
 
     logger.debug({ at: "Relayer#index", message: "Relayer components initialized. Starting execution loop" });
 

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -86,3 +86,7 @@ export function getUniqueDepositsInRange(
         )
     ) as DepositWithBlock[];
 }
+
+export function isDepositSpedUp(deposit: Deposit): boolean {
+  return deposit.speedUpSignature !== undefined && deposit.newRelayerFeePct !== undefined;
+}

--- a/src/utils/TransactionPropBuilder.ts
+++ b/src/utils/TransactionPropBuilder.ts
@@ -18,3 +18,28 @@ export function buildFillRelayProps(deposit: Deposit, repaymentChainId: number, 
     deposit.depositId,
   ];
 }
+
+export function buildFillRelayWithUpdatedFeeProps(
+  deposit: Deposit,
+  repaymentChainId: number,
+  maxFillAmount: BigNumber
+) {
+  // Validate all keys are present.
+  for (const key in deposit)
+    if (deposit[key] == undefined) throw new Error(`Missing or undefined value in props! ${key}`);
+
+  return [
+    deposit.depositor,
+    deposit.recipient,
+    deposit.destinationToken,
+    deposit.amount,
+    maxFillAmount,
+    repaymentChainId,
+    deposit.originChainId,
+    deposit.realizedLpFeePct,
+    deposit.relayerFeePct,
+    deposit.newRelayerFeePct,
+    deposit.depositId,
+    deposit.speedUpSignature,
+  ];
+}

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -81,9 +81,56 @@ describe("ProfitClient: Consider relay profit", async function () {
 
   it("Considers deposits with relayer fee below min required unprofitable", async function () {
     const profitableWethL1Relay = { relayerFeePct: toBNWei("0.01"), destinationChainId: 1 } as Deposit;
-    // Full profit discount but with a min fee of 0.03%.
-    const profitClientWithMinFee = new MockProfitClient(spyLogger, hubPoolClient, {}, true, [], false, toBNWei("0.03"));
+    // Ignore gas cost but with a min fee of 0.03%.
+    const profitClientWithMinFee = new MockProfitClient(
+      spyLogger,
+      hubPoolClient,
+      {},
+      false,
+      [],
+      false,
+      toBNWei("0.03")
+    );
     expect(profitClientWithMinFee.isFillProfitable(profitableWethL1Relay, toBNWei(1))).to.be.false;
+  });
+
+  it("Considers deposits with newRelayerFeePct", async function () {
+    const profitableWethL1Relay = {
+      relayerFeePct: toBNWei("0.01"),
+      newRelayerFeePct: toBNWei("0.1"),
+      destinationChainId: 1,
+    } as Deposit;
+    // Ignore gas cost but with a min fee of 0.03%.
+    const profitClientWithMinFee = new MockProfitClient(
+      spyLogger,
+      hubPoolClient,
+      {},
+      false,
+      [],
+      false,
+      toBNWei("0.03")
+    );
+    expect(profitClientWithMinFee.isFillProfitable(profitableWethL1Relay, toBNWei(1))).to.be.true;
+  });
+
+  it("Ignores newRelayerFeePct if it's lower than original relayerFeePct", async function () {
+    const profitableWethL1Relay = {
+      relayerFeePct: toBNWei("0.1"),
+      newRelayerFeePct: toBNWei("0.01"),
+      destinationChainId: 1,
+    } as Deposit;
+    profitClient.setGasCosts({ 1: toBNWei("0.01") });
+    // Ignore gas cost but with a min fee of 0.03%.
+    const profitClientWithMinFee = new MockProfitClient(
+      spyLogger,
+      hubPoolClient,
+      {},
+      false,
+      [],
+      false,
+      toBNWei("0.03")
+    );
+    expect(profitClientWithMinFee.isFillProfitable(profitableWethL1Relay, toBNWei(1))).to.be.true;
   });
 
   it("Captures unprofitable fills", async function () {

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -1,4 +1,4 @@
-import { expect, deposit, ethers, Contract, SignerWithAddress, setupTokensForWallet, getLastBlockTime } from "./utils";
+import { expect, deposit, ethers, Contract, SignerWithAddress, setupTokensForWallet, getLastBlockTime, signForSpeedUp } from "./utils";
 import { lastSpyLogIncludes, createSpyLogger, deployConfigStore, deployAndConfigureHubPool, winston } from "./utils";
 import { deploySpokePoolWithToken, enableRoutesOnHubPool, destinationChainId } from "./utils";
 import { originChainId, sinon, toBNWei } from "./utils";
@@ -99,6 +99,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     expect(fillEvents2[0].args.relayerFeePct).to.equal(deposit1.relayerFeePct);
     expect(fillEvents2[0].args.depositor).to.equal(deposit1.depositor);
     expect(fillEvents2[0].args.recipient).to.equal(deposit1.recipient);
+    expect(fillEvents2[0].args.appliedRelayerFeePct).to.equal(deposit1.relayerFeePct);
 
     // There should be no fill events on the origin spoke pool.
     expect((await spokePool_1.queryFilter(spokePool_1.filters.FilledRelay())).length).to.equal(0);
@@ -110,6 +111,46 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     expect(multiCallerClient.transactionCount()).to.equal(0); // no Transactions to send.
     expect(lastSpyLogIncludes(spy, "No unfilled deposits")).to.be.true;
   });
+
+  it("Uses new relayer fee pct if depositor sped it up", async function() {
+    // Set the spokePool's time to the provider time. This is done to enable the block utility time finder identify a
+    // "reasonable" block number based off the block time when looking at quote timestamps.
+    await spokePool_1.setCurrentTime(await getLastBlockTime(spokePool_1.provider));
+    const deposit1 = await deposit(spokePool_1, erc20_1, depositor, depositor, destinationChainId);
+    const newRelayerFeePct = toBNWei(0.1337);
+    const speedUpSignature = await signForSpeedUp(depositor, deposit1, newRelayerFeePct);
+    await spokePool_1.speedUpDeposit(depositor.address, newRelayerFeePct, deposit1.depositId, speedUpSignature);
+    await updateAllClients();
+    await relayerInstance.checkForUnfilledDepositsAndFill();
+    expect(lastSpyLogIncludes(spy, "Filling deposit")).to.be.true;
+    expect(multiCallerClient.transactionCount()).to.equal(1); // One transaction, filling the one deposit.
+
+    const tx = await multiCallerClient.executeTransactionQueue();
+    expect(lastSpyLogIncludes(spy, "Multicall batch sent")).to.be.true;
+    expect(tx.length).to.equal(1); // There should have been exactly one transaction.
+
+    // Check the state change happened correctly on the smart contract. There should be exactly one fill on spokePool_2.
+    const fillEvents2 = await spokePool_2.queryFilter(spokePool_2.filters.FilledRelay());
+    expect(fillEvents2.length).to.equal(1);
+    expect(fillEvents2[0].args.depositId).to.equal(deposit1.depositId);
+    expect(fillEvents2[0].args.amount).to.equal(deposit1.amount);
+    expect(fillEvents2[0].args.destinationChainId).to.equal(Number(deposit1.destinationChainId));
+    expect(fillEvents2[0].args.originChainId).to.equal(Number(deposit1.originChainId));
+    expect(fillEvents2[0].args.relayerFeePct).to.equal(deposit1.relayerFeePct);
+    expect(fillEvents2[0].args.depositor).to.equal(deposit1.depositor);
+    expect(fillEvents2[0].args.recipient).to.equal(deposit1.recipient);
+    expect(fillEvents2[0].args.appliedRelayerFeePct).to.equal(newRelayerFeePct);
+
+    // There should be no fill events on the origin spoke pool.
+    expect((await spokePool_1.queryFilter(spokePool_1.filters.FilledRelay())).length).to.equal(0);
+
+    // Re-run the execution loop and validate that no additional relays are sent.
+    multiCallerClient.clearTransactionQueue();
+    await Promise.all([spokePoolClient_1.update(), spokePoolClient_2.update(), hubPoolClient.update()]);
+    await relayerInstance.checkForUnfilledDepositsAndFill();
+    expect(multiCallerClient.transactionCount()).to.equal(0); // no Transactions to send.
+    expect(lastSpyLogIncludes(spy, "No unfilled deposits")).to.be.true;
+  })
 
   it("Shouldn't double fill a deposit", async function () {
     // Set the spokePool's time to the provider time. This is done to enable the block utility time finder identify a

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -149,7 +149,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     expect(fillEvents2[0].args.depositor).to.equal(deposit1.depositor);
     expect(fillEvents2[0].args.recipient).to.equal(deposit1.recipient);
 
-    // This specific line differs from the above test: the emitted event's appliedRelayerFeePct is 
+    // This specific line differs from the above test: the emitted event's appliedRelayerFeePct is
     // now !== relayerFeePct.
     expect(fillEvents2[0].args.appliedRelayerFeePct).to.equal(newRelayerFeePct);
 

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -148,6 +148,9 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     expect(fillEvents2[0].args.relayerFeePct).to.equal(deposit1.relayerFeePct);
     expect(fillEvents2[0].args.depositor).to.equal(deposit1.depositor);
     expect(fillEvents2[0].args.recipient).to.equal(deposit1.recipient);
+
+    // This specific line differs from the above test: the emitted event's appliedRelayerFeePct is 
+    // now !== relayerFeePct.
     expect(fillEvents2[0].args.appliedRelayerFeePct).to.equal(newRelayerFeePct);
 
     // There should be no fill events on the origin spoke pool.

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -1,4 +1,13 @@
-import { expect, deposit, ethers, Contract, SignerWithAddress, setupTokensForWallet, getLastBlockTime, signForSpeedUp } from "./utils";
+import {
+  expect,
+  deposit,
+  ethers,
+  Contract,
+  SignerWithAddress,
+  setupTokensForWallet,
+  getLastBlockTime,
+  signForSpeedUp,
+} from "./utils";
 import { lastSpyLogIncludes, createSpyLogger, deployConfigStore, deployAndConfigureHubPool, winston } from "./utils";
 import { deploySpokePoolWithToken, enableRoutesOnHubPool, destinationChainId } from "./utils";
 import { originChainId, sinon, toBNWei } from "./utils";
@@ -112,7 +121,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     expect(lastSpyLogIncludes(spy, "No unfilled deposits")).to.be.true;
   });
 
-  it("Uses new relayer fee pct if depositor sped it up", async function() {
+  it("Uses new relayer fee pct if depositor sped it up", async function () {
     // Set the spokePool's time to the provider time. This is done to enable the block utility time finder identify a
     // "reasonable" block number based off the block time when looking at quote timestamps.
     await spokePool_1.setCurrentTime(await getLastBlockTime(spokePool_1.provider));
@@ -150,7 +159,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     await relayerInstance.checkForUnfilledDepositsAndFill();
     expect(multiCallerClient.transactionCount()).to.equal(0); // no Transactions to send.
     expect(lastSpyLogIncludes(spy, "No unfilled deposits")).to.be.true;
-  })
+  });
 
   it("Shouldn't double fill a deposit", async function () {
     // Set the spokePool's time to the provider time. This is done to enable the block utility time finder identify a

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -6,7 +6,8 @@ import { HubPoolClient, AcrossConfigStoreClient, MultiCallerClient } from "../sr
 import { TokenClient, ProfitClient } from "../src/clients";
 import { MockInventoryClient } from "./mocks";
 
-import { Relayer } from "../src/relayer/Relayer"; // Tested
+import { Relayer } from "../src/relayer/Relayer";
+import { RelayerConfig } from "../src/relayer/RelayerConfig"; // Tested
 
 let relayer: SignerWithAddress, hubPool: Contract, mockAdapter: Contract, configStore: Contract;
 let hubPoolClient: HubPoolClient, configStoreClient: AcrossConfigStoreClient, tokenClient: TokenClient;
@@ -56,15 +57,23 @@ describe.skip("Relayer: Iterative fill", async function () {
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new ProfitClient(spyLogger, hubPoolClient, {}, false, [], false, toBNWei(1)); // Set relayer discount to 100%.
     await updateAllClients();
-    relayerInstance = new Relayer(relayer.address, spyLogger, {
-      spokePoolClients,
-      hubPoolClient,
-      configStoreClient,
-      tokenClient,
-      profitClient,
-      multiCallerClient,
-      inventoryClient: new MockInventoryClient(),
-    });
+    relayerInstance = new Relayer(
+      relayer.address,
+      spyLogger,
+      {
+        spokePoolClients,
+        hubPoolClient,
+        configStoreClient,
+        tokenClient,
+        profitClient,
+        multiCallerClient,
+        inventoryClient: new MockInventoryClient(),
+      },
+      {
+        relayerTokens: [],
+        relayerDestinationChains: [],
+      } as RelayerConfig
+    );
 
     let depositCount = 0;
 

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -7,7 +7,8 @@ import { SpokePoolClient, HubPoolClient, AcrossConfigStoreClient, MultiCallerCli
 import { TokenClient, ProfitClient } from "../src/clients";
 import { MockInventoryClient } from "./mocks";
 
-import { Relayer } from "../src/relayer/Relayer"; // Tested
+import { Relayer } from "../src/relayer/Relayer";
+import { RelayerConfig } from "../src/relayer/RelayerConfig"; // Tested
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
 let hubPool: Contract, configStore: Contract, l1Token: Contract;
@@ -50,15 +51,23 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, false, []); // Set relayer discount to 100%.
-    relayerInstance = new Relayer(relayer.address, spyLogger, {
-      spokePoolClients,
-      hubPoolClient,
-      configStoreClient,
-      tokenClient,
-      profitClient,
-      multiCallerClient,
-      inventoryClient: new MockInventoryClient(),
-    });
+    relayerInstance = new Relayer(
+      relayer.address,
+      spyLogger,
+      {
+        spokePoolClients,
+        hubPoolClient,
+        configStoreClient,
+        tokenClient,
+        profitClient,
+        multiCallerClient,
+        inventoryClient: new MockInventoryClient(),
+      },
+      {
+        relayerTokens: [],
+        relayerDestinationChains: [],
+      } as RelayerConfig
+    );
 
     await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // Seed owner to LP.
     await setupTokensForWallet(spokePool_1, depositor, [erc20_1], null, 10);

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -7,7 +7,8 @@ import { SpokePoolClient, HubPoolClient, AcrossConfigStoreClient, MultiCallerCli
 import { TokenClient, ProfitClient } from "../src/clients";
 import { MockInventoryClient } from "./mocks";
 
-import { Relayer } from "../src/relayer/Relayer"; // Tested
+import { Relayer } from "../src/relayer/Relayer";
+import { RelayerConfig } from "../src/relayer/RelayerConfig"; // Tested
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
 let hubPool: Contract, configStore: Contract, l1Token: Contract;
@@ -48,15 +49,23 @@ describe("Relayer: Token balance shortfall", async function () {
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, false, []); // Set the profit discount to 1 (ignore relay cost.)
-    relayerInstance = new Relayer(relayer.address, spyLogger, {
-      spokePoolClients,
-      hubPoolClient,
-      configStoreClient,
-      tokenClient,
-      profitClient,
-      multiCallerClient,
-      inventoryClient: new MockInventoryClient(),
-    });
+    relayerInstance = new Relayer(
+      relayer.address,
+      spyLogger,
+      {
+        spokePoolClients,
+        hubPoolClient,
+        configStoreClient,
+        tokenClient,
+        profitClient,
+        multiCallerClient,
+        inventoryClient: new MockInventoryClient(),
+      },
+      {
+        relayerTokens: [],
+        relayerDestinationChains: [],
+      } as RelayerConfig
+    );
 
     // Seed Owner and depositor wallets but dont seed relayer to test how the relayer handles being out of funds.
     await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // Seed owner to LP.

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -160,7 +160,9 @@ describe("Relayer: Unfilled Deposits", async function () {
     // expect only one unfilled deposit
     expect(unfilledDeposits.length).to.eq(1);
     // expect unfilled deposit to have new relay fee
-    expect(unfilledDeposits[0].deposit.relayerFeePct).to.deep.eq(newRelayFeePct);
+    expect(unfilledDeposits[0].deposit.newRelayerFeePct).to.deep.eq(newRelayFeePct);
+    // Old relayer fee pct is unchanged as this is what's included in relay hash
+    expect(unfilledDeposits[0].deposit.relayerFeePct).to.deep.eq(deposit1.relayerFeePct);
   });
   it("Does not double fill deposit when updating fee after fill", async function () {
     const deposit1 = await simpleDeposit(spokePool_1, erc20_1, depositor, depositor, destinationChainId);

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -145,7 +145,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     ]);
   });
 
-  it.skip("Correctly selects unfilled deposit with updated fee", async function () {
+  it("Correctly selects unfilled deposit with updated fee", async function () {
     // perform simple deposit
     const deposit1 = await simpleDeposit(spokePool_1, erc20_1, depositor, depositor, destinationChainId);
     await updateAllClients();

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -21,6 +21,7 @@ import { MockInventoryClient } from "./mocks";
 // Tested
 import { Relayer } from "../src/relayer/Relayer";
 import { getUnfilledDeposits } from "../src/utils";
+import { RelayerConfig } from "../src/relayer/RelayerConfig";
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
 let hubPool: Contract, l1Token: Contract, configStore: Contract;
@@ -51,15 +52,23 @@ describe("Relayer: Unfilled Deposits", async function () {
     spokePoolClient_1 = new SpokePoolClient(spyLogger, spokePool_1, configStoreClient, originChainId);
     spokePoolClient_2 = new SpokePoolClient(spyLogger, spokePool_2, configStoreClient, destinationChainId);
 
-    relayerInstance = new Relayer(relayer.address, spyLogger, {
-      spokePoolClients: { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 },
-      hubPoolClient,
-      configStoreClient,
-      profitClient: null,
-      tokenClient: null,
-      multiCallerClient: null,
-      inventoryClient: new MockInventoryClient(),
-    });
+    relayerInstance = new Relayer(
+      relayer.address,
+      spyLogger,
+      {
+        spokePoolClients: { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 },
+        hubPoolClient,
+        configStoreClient,
+        profitClient: null,
+        tokenClient: null,
+        multiCallerClient: null,
+        inventoryClient: new MockInventoryClient(),
+      },
+      {
+        relayerTokens: [],
+        relayerDestinationChains: [],
+      } as RelayerConfig
+    );
 
     await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // seed the owner to LP.
     await setupTokensForWallet(spokePool_1, depositor, [erc20_1], null, 100); // seed the depositor to LP.

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -162,24 +162,24 @@ describe("Relayer: Unfilled Deposits", async function () {
     // expect unfilled deposit to have new relay fee
     expect(unfilledDeposits[0].deposit.relayerFeePct).to.deep.eq(newRelayFeePct);
   });
-  it("Does not double fill deposit when updating fee after fill", async function() {
-        const deposit1 = await simpleDeposit(spokePool_1, erc20_1, depositor, depositor, destinationChainId);
-        const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
-        const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
-        await updateAllClients();
-        expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-          { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: deposit1Complete, fillCount: 1 }
-        ]);
+  it("Does not double fill deposit when updating fee after fill", async function () {
+    const deposit1 = await simpleDeposit(spokePool_1, erc20_1, depositor, depositor, destinationChainId);
+    const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
+    const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
+    await updateAllClients();
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
+      { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: deposit1Complete, fillCount: 1 },
+    ]);
 
-        // Speed up deposit, and check that unfilled amount is still the same.
-        const newRelayerFeePct = toBNWei(0.1337);
-        const speedUpSignature = await signForSpeedUp(depositor, deposit1, newRelayerFeePct);
-        await spokePool_1.speedUpDeposit(depositor.address, newRelayerFeePct, deposit1.depositId, speedUpSignature);
-        await updateAllClients(); 
-        const depositWithSpeedUp = { ...deposit1Complete, newRelayerFeePct, speedUpSignature }
-        expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-          { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: depositWithSpeedUp, fillCount: 1 }
-        ]);   
+    // Speed up deposit, and check that unfilled amount is still the same.
+    const newRelayerFeePct = toBNWei(0.1337);
+    const speedUpSignature = await signForSpeedUp(depositor, deposit1, newRelayerFeePct);
+    await spokePool_1.speedUpDeposit(depositor.address, newRelayerFeePct, deposit1.depositId, speedUpSignature);
+    await updateAllClients();
+    const depositWithSpeedUp = { ...deposit1Complete, newRelayerFeePct, speedUpSignature };
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
+      { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: depositWithSpeedUp, fillCount: 1 },
+    ]);
   });
 });
 

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -162,6 +162,25 @@ describe("Relayer: Unfilled Deposits", async function () {
     // expect unfilled deposit to have new relay fee
     expect(unfilledDeposits[0].deposit.relayerFeePct).to.deep.eq(newRelayFeePct);
   });
+  it("Does not double fill deposit when updating fee after fill", async function() {
+        const deposit1 = await simpleDeposit(spokePool_1, erc20_1, depositor, depositor, destinationChainId);
+        const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
+        const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
+        await updateAllClients();
+        expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
+          { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: deposit1Complete, fillCount: 1 }
+        ]);
+
+        // Speed up deposit, and check that unfilled amount is still the same.
+        const newRelayerFeePct = toBNWei(0.1337);
+        const speedUpSignature = await signForSpeedUp(depositor, deposit1, newRelayerFeePct);
+        await spokePool_1.speedUpDeposit(depositor.address, newRelayerFeePct, deposit1.depositId, speedUpSignature);
+        await updateAllClients(); 
+        const depositWithSpeedUp = { ...deposit1Complete, newRelayerFeePct, speedUpSignature }
+        expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
+          { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: depositWithSpeedUp, fillCount: 1 }
+        ]);   
+  });
 });
 
 async function updateAllClients() {

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -35,7 +35,7 @@ describe("SpokePoolClient: SpeedUp", async function () {
     await spokePoolClient.update();
 
     // After speedup should return the appended object with the new fee information and signature.
-    const expectedDepositData = { ...deposit, speedUpSignature, relayerFeePct: newRelayFeePct }; // Old data with new fees.
+    const expectedDepositData = { ...deposit, speedUpSignature, newRelayerFeePct: newRelayFeePct };
     expect(spokePoolClient.appendMaxSpeedUpSignatureToDeposit(deposit)).to.deep.equal(expectedDepositData);
 
     // Fetching deposits for the depositor should contain the correct fees.
@@ -67,7 +67,11 @@ describe("SpokePoolClient: SpeedUp", async function () {
     await spokePoolClient.update();
 
     // Should use the faster data between the two speedups.
-    const expectedDepositData = { ...deposit, speedUpSignature: speedUpFasterSignature, relayerFeePct: speedupFaster };
+    const expectedDepositData = {
+      ...deposit,
+      speedUpSignature: speedUpFasterSignature,
+      newRelayerFeePct: speedupFaster,
+    };
     expect(spokePoolClient.appendMaxSpeedUpSignatureToDeposit(deposit)).to.deep.equal(expectedDepositData);
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId)).to.deep.equal([expectedDepositData]);
     expect(spokePoolClient.getDepositsFromDepositor(depositor.address)).to.deep.equal([expectedDepositData]);

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -21,7 +21,7 @@ describe("SpokePoolClient: SpeedUp", async function () {
     await setupTokensForWallet(spokePool, depositor, [erc20, destErc20], weth, 10);
   });
 
-  it.skip("Fetches speedup data associated with a deposit", async function () {
+  it("Fetches speedup data associated with a deposit", async function () {
     const deposit = await simpleDeposit(spokePool, erc20, depositor, depositor, destinationChainId);
 
     await spokePoolClient.update();
@@ -42,7 +42,7 @@ describe("SpokePoolClient: SpeedUp", async function () {
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId)).to.deep.equal([expectedDepositData]);
     expect(spokePoolClient.getDepositsFromDepositor(depositor.address)).to.deep.equal([expectedDepositData]);
   });
-  it.skip("Selects the highest speedup option when multiple are presented", async function () {
+  it("Selects the highest speedup option when multiple are presented", async function () {
     const deposit = await simpleDeposit(spokePool, erc20, depositor, depositor, destinationChainId);
 
     // Speedup below the original fee should not update to use the new fee.


### PR DESCRIPTION
By overriding `deposit.relayerFeePct`, the `SpokePoolClient` inadvertently leads to the `relayer` sending invalid fills with an incorrect `relayerFeePct`. This could lead to a double spend attack where a depositor receives their full deposit, requests a speedup on their deposit, and then receives another full deposit. In the second case, the fill is invalid, so this is a relayer bug.

The solution is:
- in `SpokePoolClient.appendMaxSpeedUpSignatureToDeposit` add a new field to deposit instead of overriding the `relayerFeePct`, name it `newRelayerFeePct`
- In `Relayer.fillRelay` if `fill.modifiedRelayerFeePct !== undefined` then call `fillRelayWithUpdatedFee()` instead of `fillRelay` on the `SpokePool` contract and pass in the `newRelayerFeePct` and `depositorSignature` params.

In the case of slow fills, sent via `Relayer.zeroFill()`, we can ignore the `newRelayerFeePct` since [any slow leaves that get executed on SpokePools will result in an effective 0% `relayerFeePct`](https://github.com/across-protocol/contracts-v2/blob/master/contracts/SpokePool.sol#L629), so it doesn't do anything to 1-wei fill the deposit with a higher relayer fee pct since the fees on a 1-wei fill will be negligible.