### PR TITLE
temp(profit client): Temporarily downgrade logs for CG failures to debug

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -208,7 +208,7 @@ export class ProfitClient {
       if (!this.ignoreTokenPriceFailures) {
         throw new Error(errMsg);
       }
-      this.logger.debug({ at: "ProfitClient", message: errMsg, tokens: tokens });
+      this.logger.info({ at: "ProfitClient", message: errMsg, tokens: tokens });
       return;
     }
 
@@ -237,7 +237,7 @@ export class ProfitClient {
         mrkdwn += `- ${token["symbol"]} not found (${token["cause"]}).`;
         mrkdwn += ` Using last known price of ${this.getPriceOfToken(token["address"])}.\n`;
       });
-      this.logger.debug({ at: "ProfitClient", message: "Could not fetch all token prices 💳", mrkdwn });
+      this.logger.warn({ at: "ProfitClient", message: "Could not fetch all token prices 💳", mrkdwn });
       if (!this.ignoreTokenPriceFailures) {
         throw new Error(mrkdwn);
       }

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -208,7 +208,7 @@ export class ProfitClient {
       if (!this.ignoreTokenPriceFailures) {
         throw new Error(errMsg);
       }
-      this.logger.warn({ at: "ProfitClient", message: errMsg, tokens: tokens });
+      this.logger.debug({ at: "ProfitClient", message: errMsg, tokens: tokens });
       return;
     }
 
@@ -237,7 +237,7 @@ export class ProfitClient {
         mrkdwn += `- ${token["symbol"]} not found (${token["cause"]}).`;
         mrkdwn += ` Using last known price of ${this.getPriceOfToken(token["address"])}.\n`;
       });
-      this.logger.warn({ at: "ProfitClient", message: "Could not fetch all token prices 💳", mrkdwn });
+      this.logger.debug({ at: "ProfitClient", message: "Could not fetch all token prices 💳", mrkdwn });
       if (!this.ignoreTokenPriceFailures) {
         throw new Error(mrkdwn);
       }


### PR DESCRIPTION
CG fetches currently fail a lot due to rate limit. Thus, issuing warning logs on these failures currently makes oncall very noisy as it generates a lot of low-urgency alerts.

This PR temporarily lowers the logs to debug. We can change them back to warn after we address underlying CG failure issues.