### PR TITLE
fix(profit client): Only instantiate/update profit client for dataworker + relayer

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -1,6 +1,6 @@
 import winston from "winston";
 import { getProvider, getDeployedContract, getDeploymentBlockNumber, Wallet, SpokePool, Contract } from "../utils";
-import { HubPoolClient, MultiCallerClient, AcrossConfigStoreClient, SpokePoolClient, ProfitClient } from "../clients";
+import { HubPoolClient, MultiCallerClient, AcrossConfigStoreClient, SpokePoolClient } from "../clients";
 import { CommonConfig } from "./Config";
 import { DataworkerClients } from "../dataworker/DataworkerClientHelper";
 import { createClient } from "redis4";
@@ -10,7 +10,6 @@ export interface Clients {
   hubPoolClient: HubPoolClient;
   configStoreClient: AcrossConfigStoreClient;
   multiCallerClient: MultiCallerClient;
-  profitClient: ProfitClient;
   hubSigner?: Wallet;
 }
 
@@ -164,15 +163,9 @@ export async function constructClients(
 
   const multiCallerClient = new MultiCallerClient(logger);
 
-  // Disable profitability by default as only the relayer needs it. Relayer has its own client initializations.
-  const profitClient = new ProfitClient(logger, hubPoolClient, {}, false, [], true);
-
-  return { hubPoolClient, configStoreClient, multiCallerClient, profitClient, hubSigner };
+  return { hubPoolClient, configStoreClient, multiCallerClient, hubSigner };
 }
 
 export async function updateClients(clients: Clients) {
   await Promise.all([clients.hubPoolClient.update(), clients.configStoreClient.update()]);
-  // Must come after hubPoolClient. // TODO: this should be refactored to check if the hubpool client has had one
-  // previous update run such that it has l1 tokens within it.If it has we dont need to make it sequential like this.
-  await clients.profitClient.update();
 }

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -2,9 +2,10 @@ import winston from "winston";
 import { DataworkerConfig } from "./DataworkerConfig";
 import { CHAIN_ID_LIST_INDICES, Clients, constructClients, getSpokePoolSigners, updateClients } from "../common";
 import { EventSearchConfig, getDeploymentBlockNumber, Wallet, ethers } from "../utils";
-import { BundleDataClient, SpokePoolClient, TokenClient } from "../clients";
+import { BundleDataClient, ProfitClient, SpokePoolClient, TokenClient } from "../clients";
 
 export interface DataworkerClients extends Clients {
+  profitClient: ProfitClient;
   tokenClient: TokenClient;
   spokePoolSigners: { [chainId: number]: Wallet };
   spokePoolClientSearchSettings: { [chainId: number]: EventSearchConfig };
@@ -37,7 +38,19 @@ export async function constructDataworkerClients(
   // Dataworker does not yet have to depend on SpokePoolClients so we don't need to construct them for now.
   const spokePoolClients = {};
   const bundleDataClient = new BundleDataClient(logger, commonClients, spokePoolClients, CHAIN_ID_LIST_INDICES);
-  return { ...commonClients, bundleDataClient, tokenClient, spokePoolSigners, spokePoolClientSearchSettings };
+
+  // Disable profitability by default as only the relayer needs it.
+  // The dataworker only needs price updates from ProfitClient to calculate bundle volume.
+  const profitClient = new ProfitClient(logger, commonClients.hubPoolClient, {}, false, [], true);
+
+  return {
+    ...commonClients,
+    bundleDataClient,
+    profitClient,
+    tokenClient,
+    spokePoolSigners,
+    spokePoolClientSearchSettings,
+  };
 }
 
 export async function updateDataworkerClients(clients: DataworkerClients) {
@@ -48,6 +61,11 @@ export async function updateDataworkerClients(clients: DataworkerClients) {
 
   // Run approval on hub pool.
   await clients.tokenClient.setBondTokenAllowance();
+
+  // Must come after hubPoolClient.
+  // TODO: This should be refactored to check if the hubpool client has had one previous update run such that it has
+  // L1 tokens within it.If it has we dont need to make it sequential like this.
+  await clients.profitClient.update();
 }
 
 export function spokePoolClientsToProviders(spokePoolClients: { [chainId: number]: SpokePoolClient }): {

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -6,11 +6,8 @@ import {
   HubPoolClient,
   SpokePoolClient,
   MultiCallerClient,
-  ProfitClient,
   TokenTransferClient,
   BalanceAllocator,
-  WETH,
-  MATIC,
 } from "../src/clients";
 import { CrossChainTransferClient } from "../src/clients/bridges";
 import {
@@ -26,7 +23,7 @@ import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 import { Dataworker } from "../src/dataworker/Dataworker";
 import { getNetworkName, getRefundForFills, MAX_UINT_VAL, toBN } from "../src/utils";
 import { spokePoolClientsToProviders } from "../src/dataworker/DataworkerClientHelper";
-import { MockAdapterManager, MockProfitClient } from "./mocks";
+import { MockAdapterManager } from "./mocks";
 import { BalanceType } from "../src/interfaces";
 
 let l1Token: Contract, l2Token: Contract, erc20_2: Contract;
@@ -35,7 +32,7 @@ let dataworker: SignerWithAddress, depositor: SignerWithAddress;
 let dataworkerInstance: Dataworker;
 let bundleDataClient: BundleDataClient;
 let configStoreClient: AcrossConfigStoreClient;
-let hubPoolClient: HubPoolClient, multiCallerClient: MultiCallerClient, profitClient: MockProfitClient;
+let hubPoolClient: HubPoolClient, multiCallerClient: MultiCallerClient;
 let tokenTransferClient: TokenTransferClient;
 let monitorInstance: Monitor;
 let spokePoolClients: { [chainId: number]: SpokePoolClient };
@@ -72,11 +69,6 @@ describe("Monitor", async function () {
       0
     ));
 
-    profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, false, []);
-    profitClient.setTokenPrices({
-      [l1Token.address]: toBNWei(1),
-    });
-
     const monitorConfig = new MonitorConfig({
       STARTING_BLOCK_NUMBER: "0",
       ENDING_BLOCK_NUMBER: "100",
@@ -98,7 +90,6 @@ describe("Monitor", async function () {
       {
         configStoreClient,
         multiCallerClient,
-        profitClient,
         hubPoolClient,
       },
       spokePoolClients,
@@ -116,7 +107,6 @@ describe("Monitor", async function () {
       bundleDataClient,
       configStoreClient,
       multiCallerClient,
-      profitClient,
       hubPoolClient,
       spokePoolClients,
       tokenTransferClient,

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -181,7 +181,6 @@ export async function setupDataworker(
     {
       configStoreClient,
       multiCallerClient,
-      profitClient,
       hubPoolClient,
     },
     spokePoolClients,


### PR DESCRIPTION
I reexamined current uses of ProfitClient as it's automatically instantiated and updated as part of the common clients. This means all bots use it although only 2 really need it:
1. Dataworker needs ProfitClient to decide whether there's enough volume to propose a bundle
2. Relayer uses ProfitClient to decide whether a fill is profitable. But profitability is currently disabled so it doesn't need those prices really.

Since the other bots don't need ProfitClient, we can separate it from CommonClients and only specifically instantiate/call update() for the dataworker + relayer. This will significantly reduce the price fetch volume and subsequently alert noise.