### PR TITLE
fix(relayer): Remember to update the profit client

### DIFF
--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -68,6 +68,7 @@ export async function constructRelayerClients(
 
 export async function updateRelayerClients(clients: RelayerClients) {
   await updateClients(clients);
+  await clients.profitClient.update();
   // SpokePoolClient client requires up to date HubPoolClient and ConfigStore client.
 
   // TODO: the code below can be refined by grouping with promise.all. however you need to consider the inter


### PR DESCRIPTION
Wasn't working after the recent profitClient dedup. Only detectable when
running with ENABLE_PROFITABILITY=true.