### PR TITLE
improve(ProfitClient): Safe default for minRelayerFeePct

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -2,6 +2,8 @@
 // in the HubPool's proposeRootBundle method should be: Mainnet, Optimism, Polygon, Boba, Arbitrum
 export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];
 
+export const RELAYER_MIN_FEE_PCT = 0.0003;
+
 // Target ~2 days per chain. Avg. block times: { 1: 15s, 10/42161: 0.5s, 137: 2.5s, 288: 30s }
 export const MAX_RELAYER_DEPOSIT_LOOK_BACK: { [chainId: number]: number } = {
   1: 11500,

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -1,5 +1,6 @@
 import { BigNumber, toBNWei, assert, toBN, replaceAddressCase } from "../utils";
 import { CommonConfig, ProcessEnv } from "../common";
+import * as Constants from "../common/Constants";
 import { InventoryConfig } from "../interfaces";
 
 export class RelayerConfig extends CommonConfig {
@@ -33,7 +34,7 @@ export class RelayerConfig extends CommonConfig {
     // Empty means all tokens.
     this.relayerTokens = RELAYER_TOKENS ? JSON.parse(RELAYER_TOKENS) : [];
     this.inventoryConfig = RELAYER_INVENTORY_CONFIG ? JSON.parse(RELAYER_INVENTORY_CONFIG) : {};
-    this.minRelayerFeePct = MIN_RELAYER_FEE_PCT ? toBNWei(MIN_RELAYER_FEE_PCT) : toBN(0);
+    this.minRelayerFeePct = toBNWei(MIN_RELAYER_FEE_PCT || Constants.RELAYER_MIN_FEE_PCT);
 
     if (Object.keys(this.inventoryConfig).length > 0) {
       this.inventoryConfig = replaceAddressCase(this.inventoryConfig); // Cast any non-address case addresses.


### PR DESCRIPTION
Third-party relayers should not need to configure this to avoid filling
unprofitable relays.