### PR TITLE
fix(relayer): Convert gas cost to BigNumber explicitly

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -79,8 +79,9 @@ export class ProfitClient {
     return this.tokenPrices[token];
   }
 
-  getTotalGasCost(chainId: number) {
-    return this.totalGasCosts[chainId] ?? toBN(0);
+  getTotalGasCost(chainId: number): BigNumber {
+    // TODO: Figure out where the mysterious BigNumber -> string conversion happens.
+    return toBN(this.totalGasCosts[chainId]) ?? toBN(0);
   }
 
   getUnprofitableFills() {
@@ -127,7 +128,7 @@ export class ProfitClient {
 
     // Consider gas cost.
     const totalGasCostWei = this.getTotalGasCost(deposit.destinationChainId);
-    if (totalGasCostWei === undefined || totalGasCostWei.eq(toBN(0))) {
+    if (totalGasCostWei.eq(toBN(0))) {
       const chainId = deposit.destinationChainId;
       const errorMsg = `Missing total gas cost for ${chainId}. This likely indicates some gas cost request failed`;
       this.logger.warn({


### PR DESCRIPTION
For some reason, the numbers in totalGasCosts are written to as BigNumber, but when they're read, they somehow become strings. No other code writes to it, so not sure where this weird BigNumber -> string conversion happens. I suspect this happens somehow at when TS is compiled into JS as TS would not allow such a type mismatch.

I discovered this when running the relayer and adding some logs:
2022-08-31 16:35:22 [debug]: {
  "at": "ProfitClient",
  "message": "totalGasCostWei",
  "totalGasCostWei": "55022680789668",
  "type": "string",
  "correct_type": "object",
  "totalGasCostWeiString": "55022680789668",
  "bot-identifier": "kev-local"
}

The logging code I added:
this.logger.debug({
      at: "ProfitClient",
      message: "totalGasCostWei",
      totalGasCostWei,
      type: typeof totalGasCostWei,
      correct_type: typeof toBN(totalGasCostWei),
      totalGasCostWeiString: totalGasCostWei.toString()
    });