### PR TITLE
feat: add retries to cloud storage

### DIFF
--- a/src/utils/GckmsUtils.ts
+++ b/src/utils/GckmsUtils.ts
@@ -17,6 +17,15 @@ export interface GckmsConfig {
   };
 }
 
+const { GCP_STORAGE_CONFIG } = process.env;
+ 
+// Allows the environment to customize the config that's used to interact with google cloud storage.
+// Relevant options can be found here: https://googleapis.dev/nodejs/storage/latest/global.html#StorageOptions.
+// Specific fields on interest:
+// - timeout: allows the env to set the timeout for all http requests.
+// - retryOptions: object that allows the caller to specify how the library retries.
+const storageConfig = process.env.GCP_STORAGE_CONFIG ? JSON.parse(process.env.GCP_STORAGE_CONFIG) : undefined;
+
 export function getGckmsConfig(keys) {
   let configOverride: GckmsConfig = {};
   if (process.env.GCKMS_CONFIG) {
@@ -40,7 +49,7 @@ export function getGckmsConfig(keys) {
 export async function retrieveGckmsKeys(gckmsConfigs: KeyConfig[]): Promise<string[]> {
   return await Promise.all(
     gckmsConfigs.map(async (config) => {
-      const storage = new Storage();
+      const storage = new Storage(storageConfig);
       const keyMaterialBucket = storage.bucket(config.ciphertextBucket);
       const ciphertextFile = keyMaterialBucket.file(config.ciphertextFilename);
       const contentsBuffer = (await ciphertextFile.download())[0];

--- a/src/utils/GckmsUtils.ts
+++ b/src/utils/GckmsUtils.ts
@@ -21,7 +21,7 @@ const { GCP_STORAGE_CONFIG } = process.env;
  
 // Allows the environment to customize the config that's used to interact with google cloud storage.
 // Relevant options can be found here: https://googleapis.dev/nodejs/storage/latest/global.html#StorageOptions.
-// Specific fields on interest:
+// Specific fields of interest:
 // - timeout: allows the env to set the timeout for all http requests.
 // - retryOptions: object that allows the caller to specify how the library retries.
 const storageConfig = process.env.GCP_STORAGE_CONFIG ? JSON.parse(process.env.GCP_STORAGE_CONFIG) : undefined;

--- a/src/utils/GckmsUtils.ts
+++ b/src/utils/GckmsUtils.ts
@@ -18,13 +18,13 @@ export interface GckmsConfig {
 }
 
 const { GCP_STORAGE_CONFIG } = process.env;
- 
+
 // Allows the environment to customize the config that's used to interact with google cloud storage.
 // Relevant options can be found here: https://googleapis.dev/nodejs/storage/latest/global.html#StorageOptions.
 // Specific fields of interest:
 // - timeout: allows the env to set the timeout for all http requests.
 // - retryOptions: object that allows the caller to specify how the library retries.
-const storageConfig = process.env.GCP_STORAGE_CONFIG ? JSON.parse(process.env.GCP_STORAGE_CONFIG) : undefined;
+const storageConfig = GCP_STORAGE_CONFIG ? JSON.parse(GCP_STORAGE_CONFIG) : undefined;
 
 export function getGckmsConfig(keys) {
   let configOverride: GckmsConfig = {};


### PR DESCRIPTION
This PR allows us to provide a custom configuration to the cloud storage initialization used for GCKMS retrieval. This should enable us to quickly deal with retry issues on the fly.