### PR TITLE
fix(dataworker): Address HubPool Client Root Bundle Proposal Denial of Service

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -422,7 +422,18 @@ export class HubPoolClient {
         unclaimedPoolRebalanceLeafCount: pendingRootBundleProposal.unclaimedPoolRebalanceLeafCount,
         challengePeriodEndTimestamp: pendingRootBundleProposal.challengePeriodEndTimestamp,
         bundleEvaluationBlockNumbers: mostRecentProposedRootBundle.bundleEvaluationBlockNumbers.map(
-          (block: BigNumber) => block.toNumber()
+          (block: BigNumber) => {
+            // Ideally, the HubPool.sol contract should limit the size of the elements within the
+            // bundleEvaluationBlockNumbers array. But because it doesn't, we wrap the cast of BN --> Number
+            // in a try/catch statement and return some value that would always be disputable.
+            // This catches the denial of service attack vector where a malicious proposer proposes with bundle block
+            // evaluation block numbers larger than what BigNumber::toNumber() can handle.
+            try {
+              return block.toNumber();
+            } catch {
+              return 0;
+            }
+          }
         ),
         proposalBlockNumber: mostRecentProposedRootBundle.blockNumber,
       };

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -13,7 +13,7 @@ import { Dataworker } from "../src/dataworker/Dataworker";
 let spy: sinon.SinonSpy;
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract;
 let l1Token_1: Contract, hubPool: Contract;
-let depositor: SignerWithAddress;
+let depositor: SignerWithAddress, dataworker: SignerWithAddress;
 
 let hubPoolClient: HubPoolClient, configStoreClient: AcrossConfigStoreClient;
 let dataworkerInstance: Dataworker, multiCallerClient: MultiCallerClient;
@@ -32,6 +32,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
       hubPoolClient,
       l1Token_1,
       depositor,
+      dataworker,
       dataworkerInstance,
       spokePoolClients,
       multiCallerClient,
@@ -291,5 +292,29 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await dataworkerInstance.validatePendingRootBundle(spokePoolClients);
     expect(spy.getCall(-2).lastArg.message).to.equal("Unexpected slow relay root, submitting dispute");
     await multiCallerClient.executeTransactionQueue();
+  });
+  it("Validates root bundle with large bundleEvaluationBlockNumbers", async function () {
+    await updateAllClients();
+
+    // propose root bundle with larger bundleEvaluationBlockNumbers than blockNumber.toNumber() can handle.
+    // This simulates a DOS attack vector on the HubPoolClient's ability to parse a pending proposal.
+    await hubPool
+      .connect(dataworker)
+      .proposeRootBundle(
+        ["0x" + "ff".repeat(32)],
+        1,
+        "0x" + "00".repeat(32),
+        "0x" + "00".repeat(32),
+        "0x" + "00".repeat(32)
+      );
+
+    let success = false;
+    try {
+      await updateAllClients();
+      success = true;
+      // eslint-disable-next-line no-empty
+    } catch {}
+
+    expect(success).to.be.true;
   });
 });

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -4,7 +4,6 @@ import {
   enableRoutesOnHubPool,
   buildDepositStruct,
   signForSpeedUp,
-  getFillRelayUpdatedFeeParams,
 } from "./utils";
 import {
   deploySpokePoolWithToken,

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -192,36 +192,6 @@ describe("Relayer: Unfilled Deposits", async function () {
     expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
       { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: depositWithSpeedUp, fillCount: 1 },
     ]);
-
-    // Fill deposit with modified fee and check the client matches it with original deposit.
-    await spokePool_2.connect(relayer).fillRelayWithUpdatedFee(
-      ...getFillRelayUpdatedFeeParams(
-        {
-          depositor: fill1.depositor,
-          recipient: fill1.recipient,
-          destinationToken: fill1.destinationToken,
-          amount: fill1.amount,
-          originChainId: fill1.originChainId.toString(),
-          destinationChainId: fill1.destinationChainId.toString(),
-          realizedLpFeePct: fill1.realizedLpFeePct,
-          relayerFeePct: fill1.relayerFeePct,
-          depositId: fill1.depositId.toString(),
-        },
-        fill1?.fillAmount,
-        newRelayerFeePct,
-        speedUpSignature
-      )
-    );
-    await updateAllClients();
-    const events = await spokePool_2.queryFilter(spokePool_2.filters.FilledRelay());
-    const lastEvent = events[events.length - 1];
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      {
-        unfilledAmount: deposit1.amount.sub(fill1.fillAmount).sub(lastEvent.args.fillAmount),
-        deposit: depositWithSpeedUp,
-        fillCount: 2,
-      },
-    ]);
   });
 });
 

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -4,6 +4,7 @@ import {
   enableRoutesOnHubPool,
   buildDepositStruct,
   signForSpeedUp,
+  getFillRelayUpdatedFeeParams,
 } from "./utils";
 import {
   deploySpokePoolWithToken,
@@ -190,6 +191,36 @@ describe("Relayer: Unfilled Deposits", async function () {
     const depositWithSpeedUp = { ...deposit1Complete, newRelayerFeePct, speedUpSignature };
     expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
       { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: depositWithSpeedUp, fillCount: 1 },
+    ]);
+
+    // Fill deposit with modified fee and check the client matches it with original deposit.
+    await spokePool_2.connect(relayer).fillRelayWithUpdatedFee(
+      ...getFillRelayUpdatedFeeParams(
+        {
+          depositor: fill1.depositor,
+          recipient: fill1.recipient,
+          destinationToken: fill1.destinationToken,
+          amount: fill1.amount,
+          originChainId: fill1.originChainId.toString(),
+          destinationChainId: fill1.destinationChainId.toString(),
+          realizedLpFeePct: fill1.realizedLpFeePct,
+          relayerFeePct: fill1.relayerFeePct,
+          depositId: fill1.depositId.toString(),
+        },
+        fill1?.fillAmount,
+        newRelayerFeePct,
+        speedUpSignature
+      )
+    );
+    await updateAllClients();
+    const events = await spokePool_2.queryFilter(spokePool_2.filters.FilledRelay());
+    const lastEvent = events[events.length - 1];
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
+      {
+        unfilledAmount: deposit1.amount.sub(fill1.fillAmount).sub(lastEvent.args.fillAmount),
+        deposit: depositWithSpeedUp,
+        fillCount: 2,
+      },
     ]);
   });
 });


### PR DESCRIPTION
## Description

During the HubPool client update, it processes `ProposeRootBundle` events emitted by the `HubPool.sol` contract ([HubPoolClient.ts#L415](https://github.com/across-protocol/relayer-v2/blob/b73390d6955ceea77ec06c7ad62bc504668c8330/src/clients/HubPoolClient.ts#L415)). During this process, it attempts to cast each element in the `bundleEvaluationBlockNumbers` array of the proposed bundle to a `Number` using `toNumber()` ([HubPoolClient.ts#L425](https://github.com/across-protocol/relayer-v2/blob/b73390d6955ceea77ec06c7ad62bc504668c8330/src/clients/HubPoolClient.ts#L425)).

However, the `proposeRootBundle()` function in `HubPool.sol` types the `bundleEvaluationBlockNumbers` array as `uint256[]` ([HubPool.sol#L567](https://github.com/across-protocol/contracts-v2/blob/9656a972da602243943bd7e20c06545daa3fbfcb/contracts/HubPool.sol#L567)), which is significantly larger than what `BigNumber::toNumber()` can safely cast. As such, when supplying a `bundleEvaluationBlockNumbers` array with sufficiently large numbers, the HubPool client will throw an exception during the casting operation, resulting in the process crashing.

## Attack

This issue can be exploited by an attacker by calling `HubPool::proposeRootBundle()` with values larger than what `BigNumber::toNumber()` can handle. This is illustrated in the attached test, where `HubPool::proposeRootBundle()` is called with `bundleEvaluationBlockNumbers = [0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff]`.

A unit test is included that simulatest this attack vector

## Suggested Remediation

Ideally, the `HubPool.sol` contract should limit the size of the elements within the `bundleEvaluationBlockNumbers` array. However, if this isn't possible, the HubPool client could wrap the cast in a `try/catch` statement and return some value that would later in the pipeline be considered invalid. An example of this is shown below, where the value is set to zero in the event that an invalid cast occurs.

```ts
        bundleEvaluationBlockNumbers: mostRecentProposedRootBundle.bundleEvaluationBlockNumbers.map(
          (block: BigNumber) => {
            try {
              return block.toNumber();
            } catch {
              return 0;
            }
          }
        ),
```
Signed-off-by: nicholaspai <npai.nyc@gmail.com>