### PR TITLE
feat(relayer fills): Log invalid fills (gated by a config)

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -43,7 +43,8 @@ export class SpokePoolClient {
     readonly configStoreClient: AcrossConfigStoreClient | null,
     readonly chainId: number,
     readonly eventSearchConfig: EventSearchConfig = { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 },
-    readonly spokePoolDeploymentBlock: number = 0
+    readonly spokePoolDeploymentBlock: number = 0,
+    readonly logInvalidFills: boolean = false
   ) {
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
   }
@@ -208,6 +209,18 @@ export class SpokePoolClient {
     Object.keys(deposit).forEach((key) => {
       if (fill[key] !== undefined && deposit[key].toString() !== fill[key].toString()) isValid = false;
     });
+
+    // Log any invalid deposits with same deposit id but different params.
+    if (fill.depositId === deposit.depositId && !isValid && this.logInvalidFills) {
+      this.logger.info({
+        at: "SpokePoolClient",
+        chainId: this.chainId,
+        message: "Invalid fill found",
+        deposit,
+        fill,
+      });
+    }
+
     return isValid;
   }
 

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -56,7 +56,8 @@ export async function constructSpokePoolClientsWithLookback(
   configStoreClient: AcrossConfigStoreClient,
   config: CommonConfig,
   baseSigner: Wallet,
-  initialLookBackOverride: { [chainId: number]: number } = {}
+  initialLookBackOverride: { [chainId: number]: number } = {},
+  logInvalidFills = false
 ): Promise<SpokePoolClientsByChain> {
   const spokePoolClients: SpokePoolClientsByChain = {};
 
@@ -95,7 +96,8 @@ export async function constructSpokePoolClientsWithLookback(
       configStoreClient,
       networkId,
       spokePoolClientSearchSettings,
-      spokePoolDeploymentBlock
+      spokePoolDeploymentBlock,
+      logInvalidFills
     );
   });
 

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -26,7 +26,8 @@ export async function constructRelayerClients(
     commonClients.configStoreClient,
     config,
     baseSigner,
-    config.maxRelayerLookBack
+    config.maxRelayerLookBack,
+    config.logInvalidFills
   );
 
   const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -14,6 +14,7 @@ export class RelayerConfig extends CommonConfig {
   readonly relayerTokens: string[];
   readonly relayerDestinationChains: number[];
   readonly minRelayerFeePct: BigNumber;
+  readonly logInvalidFills: boolean;
 
   constructor(env: ProcessEnv) {
     const {
@@ -25,6 +26,7 @@ export class RelayerConfig extends CommonConfig {
       SEND_RELAYS,
       SEND_SLOW_RELAYS,
       MIN_RELAYER_FEE_PCT,
+      LOG_INVALID_FILLS,
     } = env;
     super(env);
 
@@ -67,5 +69,6 @@ export class RelayerConfig extends CommonConfig {
     this.ignoreTokenPriceFailures = IGNORE_TOKEN_PRICE_FAILURES === "true";
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
+    this.logInvalidFills = LOG_INVALID_FILLS === "true";
   }
 }


### PR DESCRIPTION
Currently the relayer silently ignores invalid fills. We want to have the ability to more explicitly monitor these in case the invalid fills are sent by the same relayer wallet.