### PR TITLE
feat(relayer): Skip deposits with invalid fills from the same relayer

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -177,15 +177,37 @@ export class SpokePoolClient {
       : undefined;
   }
 
-  getValidUnfilledAmountForDeposit(deposit: Deposit): { unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] } {
-    const invalidFills: Fill[] = [];
+  getValidUnfilledAmountForDeposit(deposit: Deposit): {
+    unfilledAmount: BigNumber;
+    fillCount: number;
+    invalidFills: Fill[];
+  } {
     const fillsForDeposit = this.depositHashesToFills[this.getDepositHash(deposit)];
     // If no fills then the full amount is remaining.
     if (fillsForDeposit === undefined || fillsForDeposit.length === 0) {
-      return { unfilledAmount: toBN(deposit.amount), fillCount: 0, invalidFills };
+      return { unfilledAmount: toBN(deposit.amount), fillCount: 0, invalidFills: [] };
     }
 
-    const validFills: Fill[] = [];
+    const { validFills, invalidFills } = fillsForDeposit.reduce(
+      (groupedFills: { validFills: Fill[]; invalidFills: Fill[] }, fill: Fill) => {
+        const isValid = this.validateFillForDeposit(fill, deposit);
+        // Log any invalid deposits with same deposit id but different params.
+        if (this.logInvalidFills && !isValid && fill.depositId === deposit.depositId) {
+          this.logger.warn({
+            at: "SpokePoolClient",
+            chainId: this.chainId,
+            message: "Invalid fill found",
+            deposit,
+            fill,
+          });
+        }
+
+        if (isValid) groupedFills.validFills.push(fill);
+        else groupedFills.invalidFills.push(fill);
+        return groupedFills;
+      },
+      { validFills: [], invalidFills: [] }
+    );
     for (const fill of fillsForDeposit) {
       const isValid = this.validateFillForDeposit(fill, deposit);
       // Log any invalid deposits with same deposit id but different params.
@@ -218,7 +240,11 @@ export class SpokePoolClient {
     );
 
     const lastFill = fillsOrderedByTotalFilledAmount[0];
-    return { unfilledAmount: toBN(lastFill.amount.sub(lastFill.totalFilledAmount)), fillCount: validFills.length, invalidFills };
+    return {
+      unfilledAmount: toBN(lastFill.amount.sub(lastFill.totalFilledAmount)),
+      fillCount: validFills.length,
+      invalidFills,
+    };
   }
 
   // Ensure that each deposit element is included with the same value in the fill. This includes all elements defined

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -208,22 +208,6 @@ export class SpokePoolClient {
       },
       { validFills: [], invalidFills: [] }
     );
-    for (const fill of fillsForDeposit) {
-      const isValid = this.validateFillForDeposit(fill, deposit);
-      // Log any invalid deposits with same deposit id but different params.
-      if (this.logInvalidFills && !isValid && fill.depositId === deposit.depositId) {
-        this.logger.warn({
-          at: "SpokePoolClient",
-          chainId: this.chainId,
-          message: "Invalid fill found",
-          deposit,
-          fill,
-        });
-      }
-
-      if (isValid) validFills.push(fill);
-      else invalidFills.push(fill);
-    }
 
     // If all fills are invalid we can consider this unfilled.
     if (validFills.length === 0) {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -59,7 +59,7 @@ export class Relayer {
         !this.config.relayerTokens.includes(l1Token.address) &&
         !this.config.relayerTokens.includes(l1Token.address.toLowerCase())
       ) {
-        this.logger.debug({ at: "Relayer", message: "Skipping deposit for unwhitelisted token", deposit, l1Token });
+        this.logger.debug({ at: "Relayer", message: "👨‍👧‍👦 Skipping deposit for unwhitelisted token", deposit, l1Token });
         continue;
       }
 
@@ -79,7 +79,7 @@ export class Relayer {
 
       // Skip deposits that contain invalid fills from the same relayer. This prevents potential corrupted data from
       // making the same relayer fill a deposit multiple times.
-      if (invalidFills.filter((fill) => fill.relayer === this.relayerAddress).length > 0) {
+      if (invalidFills.some((fill) => fill.relayer === this.relayerAddress)) {
         this.logger.error({
           at: "Relayer",
           message: "Skipping deposit with invalid fills from the same relayer",

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -59,7 +59,7 @@ export class Relayer {
         !this.config.relayerTokens.includes(l1Token.address) &&
         !this.config.relayerTokens.includes(l1Token.address.toLowerCase())
       ) {
-        this.logger.debug({ at: "Relayer", message: "👨‍👧‍👦 Skipping deposit for unwhitelisted token", deposit, l1Token });
+        this.logger.debug({ at: "Relayer", message: "Skipping deposit for unwhitelisted token", deposit, l1Token });
         continue;
       }
 
@@ -82,7 +82,7 @@ export class Relayer {
       if (invalidFills.some((fill) => fill.relayer === this.relayerAddress)) {
         this.logger.error({
           at: "Relayer",
-          message: "Skipping deposit with invalid fills from the same relayer",
+          message: "👨‍👧‍👦 Skipping deposit with invalid fills from the same relayer",
           deposit,
           invalidFills,
           destinationChain: getNetworkName(destinationChainId),

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -151,8 +151,8 @@ export function getFillsInRange(
 export function getUnfilledDeposits(
   spokePoolClients: SpokePoolClientsByChain,
   maxUnfilledDepositLookBack: { [chainId: number]: number } = {}
-): { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number }[] {
-  const unfilledDeposits: { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number }[] = [];
+): { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] }[] {
+  const unfilledDeposits: { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] }[] = [];
   // Iterate over each chainId and check for unfilled deposits.
   const chainIds = Object.keys(spokePoolClients);
   for (const originChain of chainIds) {

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -152,7 +152,8 @@ export function getUnfilledDeposits(
   spokePoolClients: SpokePoolClientsByChain,
   maxUnfilledDepositLookBack: { [chainId: number]: number } = {}
 ): { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] }[] {
-  const unfilledDeposits: { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] }[] = [];
+  const unfilledDeposits: { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] }[] =
+    [];
   // Iterate over each chainId and check for unfilled deposits.
   const chainIds = Object.keys(spokePoolClients);
   for (const originChain of chainIds) {

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -49,7 +49,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     hubPoolClient = new HubPoolClient(spyLogger, hubPool);
     configStoreClient = new AcrossConfigStoreClient(spyLogger, configStore, hubPoolClient);
 
-    multiCallerClient = new MultiCallerClient(spyLogger); // leave out the gasEstimator for now.
+    multiCallerClient = new MultiCallerClient(spyLogger);
 
     spokePoolClient_1 = new SpokePoolClient(spyLogger, spokePool_1.connect(relayer), configStoreClient, originChainId);
     spokePoolClient_2 = new SpokePoolClient(

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -118,8 +118,8 @@ describe("Relayer: Unfilled Deposits", async function () {
     const deposit2Complete = await buildDepositStruct(deposit2, hubPoolClient, configStoreClient, l1Token);
 
     expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: deposit1.amount, deposit: deposit1Complete, fillCount: 0 },
-      { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0 },
+      { unfilledAmount: deposit1.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
+      { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
     ]);
   });
 
@@ -137,8 +137,13 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
     // Validate the relayer correctly computes the unfilled amount.
     expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: deposit1Complete, fillCount: 1 },
-      { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0 },
+      {
+        unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
+        deposit: deposit1Complete,
+        fillCount: 1,
+        invalidFills: [],
+      },
+      { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
     ]);
 
     // Partially fill the same deposit another two times.
@@ -148,8 +153,8 @@ describe("Relayer: Unfilled Deposits", async function () {
     // Deposit 1 should now be partially filled by all three fills. This should be correctly reflected.
     const unfilledAmount = deposit1.amount.sub(fill1.fillAmount.add(fill2.fillAmount).add(fill3.fillAmount));
     expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: unfilledAmount, deposit: deposit1Complete, fillCount: 3 },
-      { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0 },
+      { unfilledAmount: unfilledAmount, deposit: deposit1Complete, fillCount: 3, invalidFills: [] },
+      { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
     ]);
 
     // Fill the reminding amount on the deposit. It should thus be removed from the unfilledDeposits list.
@@ -157,7 +162,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     expect(fill4.totalFilledAmount).to.equal(deposit1.amount); // should be 100% filled at this point.
     await updateAllClients();
     expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: deposit2Complete.amount, deposit: deposit2Complete, fillCount: 0 },
+      { unfilledAmount: deposit2Complete.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
     ]);
   });
 
@@ -171,7 +176,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
     // The deposit should show up as unfilled, since the fill was incorrectly applied to the wrong deposit.
     expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: deposit1Complete.amount, deposit: deposit1Complete, fillCount: 0 },
+      { unfilledAmount: deposit1Complete.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
     ]);
   });
 
@@ -201,7 +206,12 @@ describe("Relayer: Unfilled Deposits", async function () {
     const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
     await updateAllClients();
     expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: deposit1Complete, fillCount: 1 },
+      {
+        unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
+        deposit: deposit1Complete,
+        fillCount: 1,
+        invalidFills: [],
+      },
     ]);
 
     // Speed up deposit, and check that unfilled amount is still the same.
@@ -211,7 +221,12 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
     const depositWithSpeedUp = { ...deposit1Complete, newRelayerFeePct, speedUpSignature };
     expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: deposit1.amount.sub(fill1.fillAmount), deposit: depositWithSpeedUp, fillCount: 1 },
+      {
+        unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
+        deposit: depositWithSpeedUp,
+        fillCount: 1,
+        invalidFills: [],
+      },
     ]);
   });
 
@@ -234,6 +249,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const unfilledDeposit = getUnfilledDeposits(relayerInstance.clients.spokePoolClients)[0];
     expect(unfilledDeposit.unfilledAmount).to.equal(deposit.amount);
     expect(unfilledDeposit.deposit).to.deep.equal(depositComplete);
+    expect(unfilledDeposit.invalidFills.length).to.equal(1);
     expect(unfilledDeposit.invalidFills[0].amount).to.equal(toBN(fill.amount));
     expect(lastSpyLogIncludes(spy, "Invalid fill found")).to.be.true;
 


### PR DESCRIPTION
Currently the relayer could fill a deposit multiple times if their previous fills were considered invalid. This PR adds protection against potentially making multiple invalid fills for the same deposit.