### PR TITLE
improve(relayer): Default to reasonable following distances

### DIFF
--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -62,6 +62,6 @@ export class CommonConfig {
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
     this.redisUrl = REDIS_URL;
     this.bundleRefundLookback = BUNDLE_REFUND_LOOKBACK ? Number(BUNDLE_REFUND_LOOKBACK) : 2;
-    this.followingDistances = FOLLOWING_DISTANCES ? JSON.parse(FOLLOWING_DISTANCES) : {};
+    this.followingDistances = FOLLOWING_DISTANCES ? JSON.parse(FOLLOWING_DISTANCES) : Constants.FOLLOWING_DISTANCES;
   }
 }

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -22,6 +22,15 @@ export const CHAIN_MAX_BLOCK_LOOKBACK = {
   42161: 99990,
 };
 
+// Default blocks to follow HEAD to account for orphaned events originating from chain reorganisations.
+export const FOLLOWING_DISTANCES: { [chainId: number]: number } = {
+  1: 3,
+  10: 0,
+  137: 100,
+  288: 0,
+  42161: 0,
+};
+
 export const BUNDLE_END_BLOCK_BUFFERS = {
   1: 100, // At 15s/block, 100 blocks = 20 mins
   10: 3000, // At a conservative 10 TPS, 300 seconds = 3000 transactions. And 1 block per txn.


### PR DESCRIPTION
Relayers should be able to fill deposits with minimal risk of filling orphaned deposits without having to set the `FOLLOWING_DISTANCES` environment variable. This PR is in accordance with our philosophy that bot runners should have to set minimal environment variables and in most cases only "Pro/professional" bot runners should modify the environment variables.
