### PR TITLE
fix(relayer): Correctly return 0 for total gas cost when it's not set

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -81,7 +81,7 @@ export class ProfitClient {
 
   getTotalGasCost(chainId: number): BigNumber {
     // TODO: Figure out where the mysterious BigNumber -> string conversion happens.
-    return toBN(this.totalGasCosts[chainId]) ?? toBN(0);
+    return this.totalGasCosts[chainId] ? toBN(this.totalGasCosts[chainId]) : toBN(0);
   }
 
   getUnprofitableFills() {

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -49,6 +49,11 @@ describe("ProfitClient: Consider relay profit", async function () {
     expect(profitClient.isFillProfitable(relay, relaySize)).to.be.false;
   });
 
+  it("Return 0 when gas cost fails to be fetched", async function () {
+    profitClient.setGasCosts({ 137: undefined });
+    expect(profitClient.getTotalGasCost(137)).to.equal(toBN(0));
+  });
+
   it("Handles non-standard token decimals when considering a relay profitability", async function () {
     // Create a relay that is clearly profitable. Currency of the relay is USDC with a fill amount of 1000 USDC with a
     // price per USDC of 1 USD. Set the relayer Fee to 10% should make this clearly relayable.


### PR DESCRIPTION
We would still error out if the total gas cost failed to fetch for any chain, but the error message would be more meaningful rather than a read property of undefined error.