### PR TITLE
chore: Ignore bundles on chain 1 with USDT payments

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -98,7 +98,7 @@ export const l2TokensToL1TokenValidation = {
 // Maps chain ID to root bundle ID to ignore because the roots are known to be invalid from the perspective of the
 // latest dataworker code, or there is no matching L1 root bundle, because the root bundle was relayed by an admin.
 export const IGNORED_SPOKE_BUNDLES = {
-  1: [104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
+  1: [357, 322, 321, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
   10: [105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
   137: [105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
   288: [96, 93, 90, 85, 78, 72, 68, 67, 65, 2],


### PR DESCRIPTION
Admin bundle 357 replaces bundles 322 and 321 that cannot be executed on current Ethereum_SpokePool. 357 is executed but won't be able to be reproduced by dataworker since its construction bypasses dataworker logic. When Ethereum_SpokePool is upgraded so that 322 and 321 could be executed, we should NOT execute these or it will result in a deficit of USDT and excess payment to the relayer