### PR TITLE
fix(inventory): Fix the adapter event search config's from address or WETH transfer finalization on Optimism

### DIFF
--- a/src/clients/bridges/OptimismAdapter.ts
+++ b/src/clients/bridges/OptimismAdapter.ts
@@ -55,7 +55,7 @@ export class OptimismAdapter extends BaseAdapter {
         const l1Bridge = this.getL1Bridge(l1Token);
         const l2Bridge = this.getL2Bridge(l1Token);
         // Transfers might have come from the monitored address itself or another sender address (if specified).
-        const senderAddress = this.senderAddress || monitoredAddress;
+        const senderAddress = this.senderAddress || atomicDepositorAddress;
         const adapterSearchConfig = [ZERO_ADDRESS, undefined, senderAddress];
         promises.push(
           paginatedEventQuery(l1Bridge, l1Bridge.filters[l1Method](...l1SearchFilter), this.l1SearchConfig),


### PR DESCRIPTION
Our DepositFinalized event query logic in Optimism is fairly complex, as it needs to filter by the from address, which can be different for different cases:
1. For relayer inventory management, from is the relayer itself for ERC-20 tokens and a special atomic weth depositor contract for WETH.
2. For hub pool -> spoke pool, from is the hubpool

We have a bug in (1) where for weth transfer, we're missing events with from = atomic weth depositor. This causes the relayer to miss the finalization event and thinks WETH transfers are stuck.