### PR TITLE
fix(relayer): Make decision to skip deposits with invalid fills from same relayer configurable by environment variable

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -79,7 +79,7 @@ export class Relayer {
 
       // Skip deposits that contain invalid fills from the same relayer. This prevents potential corrupted data from
       // making the same relayer fill a deposit multiple times.
-      if (invalidFills.some((fill) => fill.relayer === this.relayerAddress)) {
+      if (this.config.skipInvalidFills && invalidFills.some((fill) => fill.relayer === this.relayerAddress)) {
         this.logger.error({
           at: "Relayer",
           message: "👨‍👧‍👦 Skipping deposit with invalid fills from the same relayer",

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -79,7 +79,7 @@ export class Relayer {
 
       // Skip deposits that contain invalid fills from the same relayer. This prevents potential corrupted data from
       // making the same relayer fill a deposit multiple times.
-      if (this.config.skipInvalidFills && invalidFills.some((fill) => fill.relayer === this.relayerAddress)) {
+      if (!this.config.acceptInvalidFills && invalidFills.some((fill) => fill.relayer === this.relayerAddress)) {
         this.logger.error({
           at: "Relayer",
           message: "👨‍👧‍👦 Skipping deposit with invalid fills from the same relayer",

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -16,6 +16,7 @@ export class RelayerConfig extends CommonConfig {
   readonly relayerDestinationChains: number[];
   readonly minRelayerFeePct: BigNumber;
   readonly logInvalidFills: boolean;
+  readonly skipInvalidFills: boolean;
 
   constructor(env: ProcessEnv) {
     const {
@@ -28,6 +29,7 @@ export class RelayerConfig extends CommonConfig {
       SEND_SLOW_RELAYS,
       MIN_RELAYER_FEE_PCT,
       LOG_INVALID_FILLS,
+      SKIP_INVALID_FILLS,
     } = env;
     super(env);
 
@@ -71,5 +73,6 @@ export class RelayerConfig extends CommonConfig {
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
     this.logInvalidFills = LOG_INVALID_FILLS === "true";
+    this.skipInvalidFills = SKIP_INVALID_FILLS === "true";
   }
 }

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -16,7 +16,7 @@ export class RelayerConfig extends CommonConfig {
   readonly relayerDestinationChains: number[];
   readonly minRelayerFeePct: BigNumber;
   readonly logInvalidFills: boolean;
-  readonly skipInvalidFills: boolean;
+  readonly acceptInvalidFills: boolean;
 
   constructor(env: ProcessEnv) {
     const {
@@ -29,7 +29,7 @@ export class RelayerConfig extends CommonConfig {
       SEND_SLOW_RELAYS,
       MIN_RELAYER_FEE_PCT,
       LOG_INVALID_FILLS,
-      SKIP_INVALID_FILLS,
+      ACCEPT_INVALID_FILLS,
     } = env;
     super(env);
 
@@ -73,6 +73,6 @@ export class RelayerConfig extends CommonConfig {
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
     this.logInvalidFills = LOG_INVALID_FILLS === "true";
-    this.skipInvalidFills = SKIP_INVALID_FILLS === "true";
+    this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";
   }
 }

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -87,7 +87,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        acceptInvalidFills: true,
+        acceptInvalidFills: false,
       } as RelayerConfig
     );
 

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -87,7 +87,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        skipInvalidFills: true
+        skipInvalidFills: true,
       } as RelayerConfig
     );
 

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -87,7 +87,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        skipInvalidFills: true,
+        acceptInvalidFills: true,
       } as RelayerConfig
     );
 

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -79,7 +79,7 @@ describe("Relayer: Unfilled Deposits", async function () {
         spokePoolClients,
         hubPoolClient,
         configStoreClient,
-        profitClient: new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, false, []),
+        profitClient: new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, true, []),
         tokenClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),


### PR DESCRIPTION
There is a possibility that a Relayer has incorrectly submitted a fill, and then its code is patched, and then it is attempting to submit a valid fill, but the current logic would have the relayer skip this situation. This behavior should be able to be overridden manually by a bot runner.

Additionally, this PR fixes a false positive test that was succeeding for an unexpected reason