### PR TITLE
improve: Remove less useful Relayer logs

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -252,7 +252,6 @@ export class InventoryClient {
       }
 
       if (Object.keys(rebalancesRequired).length === 0) {
-        this.log("No rebalances required");
         return;
       }
 
@@ -372,7 +371,6 @@ export class InventoryClient {
           ])
         )
       );
-      this.log("Checking WETH unwrap thresholds for chains with thresholds set", { nativeBalances });
 
       for (const chainId of Object.keys(nativeBalances)) {
         const l2WethBalance =
@@ -390,7 +388,6 @@ export class InventoryClient {
       this.log("Considered WETH unwraps", { unwrapsRequired, unexecutedUnwraps });
 
       if (Object.keys(unwrapsRequired).length === 0) {
-        this.log("No unwraps required");
         return;
       }
 
@@ -489,13 +486,11 @@ export class InventoryClient {
   async setL1TokenApprovals() {
     if (!this.isInventoryManagementEnabled()) return;
     const l1Tokens = this.getL1Tokens();
-    this.log("Checking token approvals", { l1Tokens });
     await this.adapterManager.setL1TokenApprovals(this.relayer, l1Tokens);
   }
 
   async wrapL2EthIfAboveThreshold() {
     if (!this.isInventoryManagementEnabled()) return;
-    this.log("Checking ETH->WETH Wrap status");
     await this.adapterManager.wrapEthIfAboveThreshold(this.inventoryConfig.wrapEtherThreshold);
   }
 

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -59,14 +59,6 @@ export class MultiCallerClient {
       // Filter out transactions that revert for expected reasons. For example, the "relay filled" error
       // will occur frequently if there are multiple relayers running at the same time because only one relay
       // can go through. This is a non critical error we can ignore to filter out the noise.
-      this.logger.debug({
-        at: "MultiCallerClient",
-        message: `Filtering out ${
-          _transactionsSucceed.filter((txn) => !txn.succeed && txn.reason === "relay filled").length
-        } relay transactions that will fail because the relay has already been filled`,
-        totalTransactions: _transactionsSucceed.length,
-        relayFilledReverts: _transactionsSucceed.filter((txn) => !txn.succeed && txn.reason === "relay filled").length,
-      });
       const transactionsSucceed = _transactionsSucceed.filter(
         (transaction) => transaction.succeed || transaction.reason !== "relay filled"
       );

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -196,14 +196,6 @@ export class ProfitClient {
       }
     });
 
-    if (newTokens.length > 0) {
-      this.logger.debug({
-        at: "ProfitClient",
-        message: "Initialised tokens to price 0.",
-        tokens: newTokens.join(", "),
-      });
-    }
-
     let cgPrices: CoinGeckoPrice[] = [];
     try {
       cgPrices = await this.coingeckoPrices(Object.keys(l1Tokens));

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -108,7 +108,6 @@ export class TokenClient {
       });
     });
     if (tokensToApprove.length === 0) {
-      this.logger.debug({ at: "TokenBalanceClient", message: "All token approvals set for non-zero balances" });
       return;
     }
 

--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -37,7 +37,6 @@ export class AdapterManager {
     chainId: number,
     l1Tokens: string[]
   ): Promise<OutstandingTransfers> {
-    this.logger.debug({ at: "AdapterManager", message: "Getting outstandingCrossChainTransfers", chainId, l1Tokens });
     return await this.adapters[chainId].getOutstandingCrossChainTransfers(l1Tokens);
   }
 

--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -58,7 +58,11 @@ export class ArbitrumAdapter extends BaseAdapter {
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]) {
     this.updateSearchConfigs();
-    this.log("Getting Arbitrum cross-chain txs", { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
+    this.log("Getting Arbitrum cross-chain txs", {
+      l1Tokens,
+      l1Config: this.l1SearchConfig,
+      l2Config: this.l2SearchConfig,
+    });
 
     const promises = [];
     const validTokens = [];

--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -58,7 +58,7 @@ export class ArbitrumAdapter extends BaseAdapter {
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]) {
     this.updateSearchConfigs();
-    this.log("Getting cross-chain txs", { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
+    this.log("Getting Arbitrum cross-chain txs", { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
 
     const promises = [];
     const validTokens = [];

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -45,7 +45,6 @@ export class BaseAdapter {
   }
 
   async checkAndSendTokenApprovals(address: string, l1Tokens: string[], associatedL1Bridges: string[]) {
-    this.log("Checking and sending token approvals", { l1Tokens, associatedL1Bridges });
     const tokensToApprove: { l1Token: Contract; targetContract: string }[] = [];
     const l1TokenContracts = l1Tokens.map((l1Token) => new Contract(l1Token, ERC20.abi, this.getSigner(1)));
     const allowances = await Promise.all(
@@ -65,7 +64,6 @@ export class BaseAdapter {
     });
 
     if (tokensToApprove.length == 0) {
-      this.log("No token bridge approvals needed", { l1Tokens });
       return;
     }
 

--- a/src/clients/bridges/OptimismAdapter.ts
+++ b/src/clients/bridges/OptimismAdapter.ts
@@ -39,7 +39,7 @@ export class OptimismAdapter extends BaseAdapter {
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]) {
     this.updateSearchConfigs();
-    this.log("Getting cross-chain txs", { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
+    this.log(`Getting ${this.isOptimism ? "Optimism" : "Boba"} cross-chain txs`, { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
 
     const promises = [];
     // Fetch bridge events for all monitored addresses.

--- a/src/clients/bridges/OptimismAdapter.ts
+++ b/src/clients/bridges/OptimismAdapter.ts
@@ -39,7 +39,11 @@ export class OptimismAdapter extends BaseAdapter {
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]) {
     this.updateSearchConfigs();
-    this.log(`Getting ${this.isOptimism ? "Optimism" : "Boba"} cross-chain txs`, { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
+    this.log(`Getting ${this.isOptimism ? "Optimism" : "Boba"} cross-chain txs`, {
+      l1Tokens,
+      l1Config: this.l1SearchConfig,
+      l2Config: this.l2SearchConfig,
+    });
 
     const promises = [];
     // Fetch bridge events for all monitored addresses.

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -95,7 +95,7 @@ export class PolygonAdapter extends BaseAdapter {
   // On polygon a bridge transaction looks like a transfer from address(0) to the target.
   async getOutstandingCrossChainTransfers(l1Tokens: string[]) {
     this.updateSearchConfigs();
-    this.log("Getting cross-chain txs", { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
+    this.log("Getting Polygon cross-chain txs", { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
 
     const promises = [];
     const validTokens = [];

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -95,7 +95,11 @@ export class PolygonAdapter extends BaseAdapter {
   // On polygon a bridge transaction looks like a transfer from address(0) to the target.
   async getOutstandingCrossChainTransfers(l1Tokens: string[]) {
     this.updateSearchConfigs();
-    this.log("Getting Polygon cross-chain txs", { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
+    this.log("Getting Polygon cross-chain txs", {
+      l1Tokens,
+      l1Config: this.l1SearchConfig,
+      l2Config: this.l2SearchConfig,
+    });
 
     const promises = [];
     const validTokens = [];


### PR DESCRIPTION
We have a lot of debug level logs that aren't that useful in practice and add to noise in production. We can selectively add these back in future if neccessary