### PR TITLE
improve(relayer): Move follow distance logic to Relayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@typescript-eslint/eslint-plugin": "^4.29.1",
     "@typescript-eslint/parser": "^4.29.1",
     "chai": "^4.2.0",
+    "chai-exclude": "^2.1.0",
     "dotenv": "^10.0.0",
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -249,8 +249,7 @@ export class SpokePoolClient {
     );
 
     // Require that all Deposits meet the minimum specified number of confirmations.
-    this.latestBlockNumber =
-      (await this.spokePool.provider.getBlockNumber()) - (this.eventSearchConfig.minDepositConfirmations ?? 0);
+    this.latestBlockNumber = await this.spokePool.provider.getBlockNumber();
     const searchConfig = {
       fromBlock: this.firstBlockToSearch,
       toBlock: this.eventSearchConfig.toBlock || this.latestBlockNumber,

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -88,7 +88,6 @@ export async function constructSpokePoolClientsWithLookback(
         : spokePoolDeploymentBlock,
       toBlock: null,
       maxBlockLookBack: config.maxBlockLookBack[networkId],
-      minDepositConfirmations: config.minDepositConfirmations[networkId],
     };
     spokePoolClients[networkId] = new SpokePoolClient(
       logger,

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -17,8 +17,6 @@ export class CommonConfig {
   readonly bundleRefundLookback: number;
   readonly maxRelayerLookBack: { [chainId: number]: number };
   readonly maxRelayerUnfilledDepositLookBack: { [chainId: number]: number };
-  // Following distances in blocks to guarantee finality on each chain.
-  readonly minDepositConfirmations: { [chainId: number]: number };
 
   constructor(env: ProcessEnv) {
     const {
@@ -32,7 +30,6 @@ export class CommonConfig {
       SEND_TRANSACTIONS,
       REDIS_URL,
       BUNDLE_REFUND_LOOKBACK,
-      MIN_DEPOSIT_CONFIRMATIONS,
     } = env;
 
     // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
@@ -62,16 +59,5 @@ export class CommonConfig {
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
     this.redisUrl = REDIS_URL;
     this.bundleRefundLookback = BUNDLE_REFUND_LOOKBACK ? Number(BUNDLE_REFUND_LOOKBACK) : 2;
-    this.minDepositConfirmations = MIN_DEPOSIT_CONFIRMATIONS
-      ? JSON.parse(MIN_DEPOSIT_CONFIRMATIONS)
-      : Constants.MIN_DEPOSIT_CONFIRMATIONS;
-
-    this.spokePoolChains.forEach((chainId) => {
-      const nBlocks: number = this.minDepositConfirmations[chainId];
-      assert(
-        !isNaN(nBlocks) && nBlocks >= 0,
-        `Chain ${chainId} minimum deposit confirmations missing or invalid (${nBlocks}).`
-      );
-    });
   }
 }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -35,10 +35,19 @@ export class Relayer {
     // Fetch all unfilled deposits, order by total earnable fee.
     // TODO: Note this does not consider the price of the token which will be added once the profitability module is
     // added to this bot.
-    const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.maxUnfilledDepositLookBack).sort(
-      (a, b) =>
+
+    // Require that all fillable deposits meet the minimum specified number of confirmations.
+    const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.maxUnfilledDepositLookBack)
+      .filter((x) => {
+        return (
+          x.deposit.originBlockNumber <=
+            this.clients.spokePoolClients[x.deposit.originChainId].latestBlockNumber -
+              this.config.minDepositConfirmations[x.deposit.originChainId] ?? 0
+        );
+      })
+      .sort((a, b) =>
         a.unfilledAmount.mul(a.deposit.relayerFeePct).lt(b.unfilledAmount.mul(b.deposit.relayerFeePct)) ? 1 : -1
-    );
+      );
     if (unfilledDeposits.length > 0) {
       this.logger.debug({ at: "Relayer", message: "Unfilled deposits found", number: unfilledDeposits.length });
     } else {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -42,7 +42,7 @@ export class Relayer {
         return (
           x.deposit.originBlockNumber <=
           this.clients.spokePoolClients[x.deposit.originChainId].latestBlockNumber -
-            (this.config.minDepositConfirmations[x.deposit.originChainId] ?? 0)
+            this.config.minDepositConfirmations[x.deposit.originChainId]
         );
       })
       .sort((a, b) =>

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -41,8 +41,8 @@ export class Relayer {
       .filter((x) => {
         return (
           x.deposit.originBlockNumber <=
-            this.clients.spokePoolClients[x.deposit.originChainId].latestBlockNumber -
-              this.config.minDepositConfirmations[x.deposit.originChainId] ?? 0
+          this.clients.spokePoolClients[x.deposit.originChainId].latestBlockNumber -
+            (this.config.minDepositConfirmations[x.deposit.originChainId] ?? 0)
         );
       })
       .sort((a, b) =>

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -17,6 +17,8 @@ export class RelayerConfig extends CommonConfig {
   readonly minRelayerFeePct: BigNumber;
   readonly logInvalidFills: boolean;
   readonly acceptInvalidFills: boolean;
+  // Following distances in blocks to guarantee finality on each chain.
+  readonly minDepositConfirmations: { [chainId: number]: number };
 
   constructor(env: ProcessEnv) {
     const {
@@ -30,6 +32,7 @@ export class RelayerConfig extends CommonConfig {
       MIN_RELAYER_FEE_PCT,
       LOG_INVALID_FILLS,
       ACCEPT_INVALID_FILLS,
+      MIN_DEPOSIT_CONFIRMATIONS,
     } = env;
     super(env);
 
@@ -74,5 +77,15 @@ export class RelayerConfig extends CommonConfig {
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
     this.logInvalidFills = LOG_INVALID_FILLS === "true";
     this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";
+    this.minDepositConfirmations = MIN_DEPOSIT_CONFIRMATIONS
+      ? JSON.parse(MIN_DEPOSIT_CONFIRMATIONS)
+      : Constants.MIN_DEPOSIT_CONFIRMATIONS;
+    this.spokePoolChains.forEach((chainId) => {
+      const nBlocks: number = this.minDepositConfirmations[chainId];
+      assert(
+        !isNaN(nBlocks) && nBlocks >= 0,
+        `Chain ${chainId} minimum deposit confirmations missing or invalid (${nBlocks}).`
+      );
+    });
   }
 }

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -28,9 +28,6 @@ export function spreadEvent(event: Event) {
 export interface EventSearchConfig {
   fromBlock: number;
   toBlock: number | null;
-  // Number of blocks to subtract from latest block the provider returns. This helps avoid fork reorgs that can lead
-  // to double filling of the same deposit.
-  minDepositConfirmations?: number;
   maxBlockLookBack?: number;
   concurrency?: number | null;
 }

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -151,9 +151,13 @@ export function getFillsInRange(
 export function getUnfilledDeposits(
   spokePoolClients: SpokePoolClientsByChain,
   maxUnfilledDepositLookBack: { [chainId: number]: number } = {}
-): { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] }[] {
-  const unfilledDeposits: { deposit: Deposit; unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] }[] =
-    [];
+): { deposit: DepositWithBlock; unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] }[] {
+  const unfilledDeposits: {
+    deposit: DepositWithBlock;
+    unfilledAmount: BigNumber;
+    fillCount: number;
+    invalidFills: Fill[];
+  }[] = [];
   // Iterate over each chainId and check for unfilled deposits.
   const chainIds = Object.keys(spokePoolClients);
   for (const originChain of chainIds) {
@@ -174,10 +178,8 @@ export function getUnfilledDeposits(
           return lookback === undefined || deposit.originBlockNumber >= latestBlockForOriginChain - lookback;
         })
         .map((deposit) => {
-          // Remove block number that we don't need anymore and because function expects to return a Deposit type.
-          const { blockNumber, originBlockNumber, ...depositData } = deposit;
           // eslint-disable-next-line no-console
-          return { ...destinationClient.getValidUnfilledAmountForDeposit(deposit), deposit: depositData };
+          return { ...destinationClient.getValidUnfilledAmountForDeposit(deposit), deposit };
         });
       // Remove any deposits that have no unfilled amount and append the remaining deposits to unfilledDeposits array.
       unfilledDeposits.push(...unfilledDepositsForDestinationChain.filter((deposit) => deposit.unfilledAmount.gt(0)));

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -70,7 +70,6 @@ describe("Monitor", async function () {
     ));
 
     const configuredNetworks = [1, repaymentChainId, originChainId, destinationChainId];
-    const minDepositConfirmations = Object.fromEntries(configuredNetworks.map((chainId) => [chainId, 0]));
 
     const monitorConfig = new MonitorConfig({
       STARTING_BLOCK_NUMBER: "0",
@@ -85,7 +84,6 @@ describe("Monitor", async function () {
       MONITOR_REPORT_INTERVAL: "10",
       MONITORED_RELAYERS: `["${depositor.address}"]`,
       CONFIGURED_NETWORKS: JSON.stringify(configuredNetworks),
-      MIN_DEPOSIT_CONFIRMATIONS: JSON.stringify(minDepositConfirmations),
     });
 
     const chainIds = [1, repaymentChainId, originChainId, destinationChainId];

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -76,8 +76,8 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        minDepositConfirmations: {},
-      } as RelayerConfig
+        minDepositConfirmations: { [originChainId]: 0, [destinationChainId]: 0 },
+      } as unknown as RelayerConfig
     );
 
     await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // Seed owner to LP.
@@ -208,8 +208,8 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [originChainId],
-        minDepositConfirmations: {},
-      } as RelayerConfig
+        minDepositConfirmations: { [originChainId]: 0, [destinationChainId]: 0 },
+      } as unknown as RelayerConfig
     );
 
     // Deposit is not on a whitelisted destination chain so relayer shouldn't fill it.

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -76,6 +76,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        minDepositConfirmations: {},
       } as RelayerConfig
     );
 
@@ -207,6 +208,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [originChainId],
+        minDepositConfirmations: {},
       } as RelayerConfig
     );
 

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -72,6 +72,7 @@ describe.skip("Relayer: Iterative fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        minDepositConfirmations: {},
       } as RelayerConfig
     );
 

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -73,7 +73,7 @@ describe.skip("Relayer: Iterative fill", async function () {
         relayerTokens: [],
         relayerDestinationChains: [],
         minDepositConfirmations: {},
-      } as RelayerConfig
+      } as unknown as RelayerConfig
     );
 
     let depositCount = 0;

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -66,6 +66,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        minDepositConfirmations: {},
       } as RelayerConfig
     );
 

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -66,8 +66,8 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        minDepositConfirmations: {},
-      } as RelayerConfig
+        minDepositConfirmations: { [originChainId]: 0, [destinationChainId]: 0 },
+      } as unknown as RelayerConfig
     );
 
     await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // Seed owner to LP.

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -64,6 +64,7 @@ describe("Relayer: Token balance shortfall", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        minDepositConfirmations: {},
       } as RelayerConfig
     );
 

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -64,8 +64,8 @@ describe("Relayer: Token balance shortfall", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        minDepositConfirmations: {},
-      } as RelayerConfig
+        minDepositConfirmations: { [originChainId]: 0, [destinationChainId]: 0 },
+      } as unknown as RelayerConfig
     );
 
     // Seed Owner and depositor wallets but dont seed relayer to test how the relayer handles being out of funds.

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -87,6 +87,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        minDepositConfirmations: {},
         acceptInvalidFills: false,
       } as RelayerConfig
     );
@@ -119,10 +120,12 @@ describe("Relayer: Unfilled Deposits", async function () {
     const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
     const deposit2Complete = await buildDepositStruct(deposit2, hubPoolClient, configStoreClient, l1Token);
 
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: deposit1.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
-      { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
-    ]);
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+      .excludingEvery(["blockNumber", "originBlockNumber"])
+      .to.deep.equal([
+        { unfilledAmount: deposit1.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
+        { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
+      ]);
   });
 
   it("Correctly fetches partially filled deposits", async function () {
@@ -138,15 +141,17 @@ describe("Relayer: Unfilled Deposits", async function () {
     const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
     await updateAllClients();
     // Validate the relayer correctly computes the unfilled amount.
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      {
-        unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
-        deposit: deposit1Complete,
-        fillCount: 1,
-        invalidFills: [],
-      },
-      { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
-    ]);
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+      .excludingEvery(["blockNumber", "originBlockNumber"])
+      .to.deep.equal([
+        {
+          unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
+          deposit: deposit1Complete,
+          fillCount: 1,
+          invalidFills: [],
+        },
+        { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
+      ]);
 
     // Partially fill the same deposit another two times.
     const fill2 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
@@ -154,18 +159,22 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
     // Deposit 1 should now be partially filled by all three fills. This should be correctly reflected.
     const unfilledAmount = deposit1.amount.sub(fill1.fillAmount.add(fill2.fillAmount).add(fill3.fillAmount));
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: unfilledAmount, deposit: deposit1Complete, fillCount: 3, invalidFills: [] },
-      { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
-    ]);
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+      .excludingEvery(["blockNumber", "originBlockNumber"])
+      .to.deep.equal([
+        { unfilledAmount: unfilledAmount, deposit: deposit1Complete, fillCount: 3, invalidFills: [] },
+        { unfilledAmount: deposit2.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
+      ]);
 
     // Fill the reminding amount on the deposit. It should thus be removed from the unfilledDeposits list.
     const fill4 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete, unfilledAmount);
     expect(fill4.totalFilledAmount).to.equal(deposit1.amount); // should be 100% filled at this point.
     await updateAllClients();
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: deposit2Complete.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
-    ]);
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+      .excludingEvery(["blockNumber", "originBlockNumber"])
+      .to.deep.equal([
+        { unfilledAmount: deposit2Complete.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
+      ]);
   });
 
   it("Correctly excludes fills that are incorrectly applied to a deposit", async function () {
@@ -177,9 +186,11 @@ describe("Relayer: Unfilled Deposits", async function () {
     await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, { ...deposit1Complete, depositId: 1337 });
     await updateAllClients();
     // The deposit should show up as unfilled, since the fill was incorrectly applied to the wrong deposit.
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      { unfilledAmount: deposit1Complete.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
-    ]);
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+      .excludingEvery(["blockNumber", "originBlockNumber"])
+      .to.deep.equal([
+        { unfilledAmount: deposit1Complete.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
+      ]);
   });
 
   it("Correctly selects unfilled deposit with updated fee", async function () {
@@ -207,14 +218,16 @@ describe("Relayer: Unfilled Deposits", async function () {
     const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
     const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
     await updateAllClients();
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      {
-        unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
-        deposit: deposit1Complete,
-        fillCount: 1,
-        invalidFills: [],
-      },
-    ]);
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+      .excludingEvery(["blockNumber", "originBlockNumber"])
+      .to.deep.equal([
+        {
+          unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
+          deposit: deposit1Complete,
+          fillCount: 1,
+          invalidFills: [],
+        },
+      ]);
 
     // Speed up deposit, and check that unfilled amount is still the same.
     const newRelayerFeePct = toBNWei(0.1337);
@@ -222,14 +235,16 @@ describe("Relayer: Unfilled Deposits", async function () {
     await spokePool_1.speedUpDeposit(depositor.address, newRelayerFeePct, deposit1.depositId, speedUpSignature);
     await updateAllClients();
     const depositWithSpeedUp = { ...deposit1Complete, newRelayerFeePct, speedUpSignature };
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients)).to.deep.equal([
-      {
-        unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
-        deposit: depositWithSpeedUp,
-        fillCount: 1,
-        invalidFills: [],
-      },
-    ]);
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+      .excludingEvery(["blockNumber", "originBlockNumber"])
+      .to.deep.equal([
+        {
+          unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
+          deposit: depositWithSpeedUp,
+          fillCount: 1,
+          invalidFills: [],
+        },
+      ]);
   });
 
   it("Skip invalid fills from the same relayer", async function () {
@@ -250,7 +265,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     // getUnfilledDeposit still returns the deposit as unfilled but with the invalid fill.
     const unfilledDeposit = getUnfilledDeposits(relayerInstance.clients.spokePoolClients)[0];
     expect(unfilledDeposit.unfilledAmount).to.equal(deposit.amount);
-    expect(unfilledDeposit.deposit).to.deep.equal(depositComplete);
+    expect(unfilledDeposit.deposit.depositId).to.equal(deposit.depositId);
     expect(unfilledDeposit.invalidFills.length).to.equal(1);
     expect(unfilledDeposit.invalidFills[0].amount).to.equal(toBN(fill.amount));
     expect(lastSpyLogIncludes(spy, "Invalid fill found")).to.be.true;

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -87,9 +87,9 @@ describe("Relayer: Unfilled Deposits", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        minDepositConfirmations: {},
+        minDepositConfirmations: { [originChainId]: 0, [destinationChainId]: 0 },
         acceptInvalidFills: false,
-      } as RelayerConfig
+      } as unknown as RelayerConfig
     );
 
     await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // seed the owner to LP.

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -18,6 +18,8 @@ import { buildRelayerRefundTree, toBN, toBNWei, utf8ToHex } from "../../src/util
 import winston from "winston";
 import sinon from "sinon";
 import chai from "chai";
+import chaiExclude from "chai-exclude";
+chai.use(chaiExclude);
 export { winston, sinon };
 
 const assert = chai.assert;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5564,6 +5564,13 @@ cbor@^8.0.0:
   dependencies:
     nofilter "^3.1.0"
 
+chai-exclude@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chai-exclude/-/chai-exclude-2.1.0.tgz#653d1218144eafb49b563684ad90b76d12bbc3f9"
+  integrity sha512-IBnm50Mvl3O1YhPpTgbU8MK0Gw7NHcb18WT2TxGdPKOMtdtZVKLHmQwdvOF7mTlHVQStbXuZKFwkevFtbHjpVg==
+  dependencies:
+    fclone "^1.0.11"
+
 chai@^4.2.0, chai@^4.3.4:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
@@ -8285,6 +8292,11 @@ fastq@^1.6.0:
   integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
   dependencies:
     reusify "^1.0.4"
+
+fclone@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/fclone/-/fclone-1.0.11.tgz#10e85da38bfea7fc599341c296ee1d77266ee640"
+  integrity sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==
 
 fecha@^4.2.0:
   version "4.2.2"


### PR DESCRIPTION
This PR was motivated by a finding that the Relayer was submitting duplicate partial fills because it could not see its own fills due to the follow distance applied to ALL events in the SpokePoolClient.

This PR (1) applies the follow distance only to Deposit events and (2) isolates the logic to the Relayer bot so other bots are not affected
