### PR TITLE
improve(dataworker): Output token symbol in dataworker's leaf execution logs

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -7,6 +7,7 @@ import {
   MerkleTree,
   toBN,
   sortEventsAscending,
+  getNetworkName,
 } from "../utils";
 import { toBNWei, getFillsInRange, ZERO_ADDRESS } from "../utils";
 import { DepositWithBlock, FillsToRefund, FillWithBlock, UnfilledDeposit } from "../interfaces";
@@ -1165,6 +1166,8 @@ export class Dataworker {
           const fundedLeaves = (
             await Promise.all(
               unexecutedLeaves.map(async (leaf) => {
+                const l1TokenInfo = this.clients.hubPoolClient.getL1TokenInfoForL2Token(leaf.l2TokenAddress, chainId);
+                const networkName = getNetworkName(chainId);
                 const refundSum = leaf.refundAmounts.reduce((acc, curr) => acc.add(curr), BigNumber.from(0));
                 const totalSent = refundSum.add(leaf.amountToReturn.gte(0) ? leaf.amountToReturn : BigNumber.from(0));
                 const success = await balanceAllocator.requestBalanceAllocation(
@@ -1181,7 +1184,8 @@ export class Dataworker {
                     root: rootBundleRelay.relayerRefundRoot,
                     bundle: rootBundleRelay.rootBundleId,
                     leafId: leaf.leafId,
-                    token: leaf.l2TokenAddress,
+                    token: l1TokenInfo.symbol,
+                    network: networkName,
                     chainId: leaf.chainId,
                     amountToReturn: leaf.amountToReturn,
                     refunds: leaf.refundAmounts,
@@ -1194,10 +1198,13 @@ export class Dataworker {
           ).filter((element) => element !== undefined);
 
           fundedLeaves.forEach((leaf) => {
+            const l1TokenInfo = this.clients.hubPoolClient.getL1TokenInfoForL2Token(leaf.l2TokenAddress, chainId);
+            const networkName = getNetworkName(chainId);
+
             const mrkdwn = `rootBundleId: ${rootBundleRelay.rootBundleId}\nrelayerRefundRoot: ${
               rootBundleRelay.relayerRefundRoot
-            }\nLeaf: ${leaf.leafId}\nchainId: ${chainId}\ntoken: ${
-              leaf.l2TokenAddress
+            }\nLeaf: ${leaf.leafId}\nnetwork: ${networkName}(${chainId})\ntoken: ${
+              l1TokenInfo.symbol
             }\namount: ${leaf.amountToReturn.toString()}`;
             if (submitExecution)
               this.clients.multiCallerClient.enqueueTransaction({

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -7,7 +7,6 @@ import {
   MerkleTree,
   toBN,
   sortEventsAscending,
-  getNetworkName,
 } from "../utils";
 import { toBNWei, getFillsInRange, ZERO_ADDRESS } from "../utils";
 import { DepositWithBlock, FillsToRefund, FillWithBlock, UnfilledDeposit } from "../interfaces";
@@ -1167,7 +1166,6 @@ export class Dataworker {
             await Promise.all(
               unexecutedLeaves.map(async (leaf) => {
                 const l1TokenInfo = this.clients.hubPoolClient.getL1TokenInfoForL2Token(leaf.l2TokenAddress, chainId);
-                const networkName = getNetworkName(chainId);
                 const refundSum = leaf.refundAmounts.reduce((acc, curr) => acc.add(curr), BigNumber.from(0));
                 const totalSent = refundSum.add(leaf.amountToReturn.gte(0) ? leaf.amountToReturn : BigNumber.from(0));
                 const success = await balanceAllocator.requestBalanceAllocation(
@@ -1185,7 +1183,6 @@ export class Dataworker {
                     bundle: rootBundleRelay.rootBundleId,
                     leafId: leaf.leafId,
                     token: l1TokenInfo.symbol,
-                    network: networkName,
                     chainId: leaf.chainId,
                     amountToReturn: leaf.amountToReturn,
                     refunds: leaf.refundAmounts,
@@ -1199,11 +1196,10 @@ export class Dataworker {
 
           fundedLeaves.forEach((leaf) => {
             const l1TokenInfo = this.clients.hubPoolClient.getL1TokenInfoForL2Token(leaf.l2TokenAddress, chainId);
-            const networkName = getNetworkName(chainId);
 
             const mrkdwn = `rootBundleId: ${rootBundleRelay.rootBundleId}\nrelayerRefundRoot: ${
               rootBundleRelay.relayerRefundRoot
-            }\nLeaf: ${leaf.leafId}\nnetwork: ${networkName}(${chainId})\ntoken: ${
+            }\nLeaf: ${leaf.leafId}\nchainId: ${chainId}\ntoken: ${
               l1TokenInfo.symbol
             }\namount: ${leaf.amountToReturn.toString()}`;
             if (submitExecution)


### PR DESCRIPTION
Current log requires more work to understand which token is involved:

1-4. Executed RelayerRefundLeaf :herb:!: rootBundleId: 384
relayerRefundRoot: 0x1c4d6a3e3bc7fc3fc1f9e7d71333333a7673cb41892f098d24b7aa647bd4eeb4
Leaf: 16
chainId: 42161
token: 0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8
amount: 908438221
tx: [0x9dc...edff4e](https://arbiscan.io/tx/0x9dc7bdb229c9907ff4f749dac789c41b52cae4a527a6114da85a12734dedff4e)

This PR would make it easier by printing out the token symbol instead of address.