### PR TITLE
feat(relayer): Improve log for invalid fills and always log them

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -54,8 +54,7 @@ export class SpokePoolClient {
     readonly configStoreClient: AcrossConfigStoreClient | null,
     readonly chainId: number,
     readonly eventSearchConfig: EventSearchConfig = { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 },
-    readonly spokePoolDeploymentBlock: number = 0,
-    readonly logInvalidFills: boolean = false
+    readonly spokePoolDeploymentBlock: number = 0
   ) {
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
   }
@@ -181,24 +180,23 @@ export class SpokePoolClient {
 
     const { validFills, invalidFills } = fillsForDeposit.reduce(
       (groupedFills: { validFills: Fill[]; invalidFills: Fill[] }, fill: Fill) => {
-        const isValid = this.validateFillForDeposit(fill, deposit);
-        // Log any invalid deposits with same deposit id but different params.
-        if (this.logInvalidFills && !isValid && fill.depositId === deposit.depositId) {
-          this.logger.warn({
-            at: "SpokePoolClient",
-            chainId: this.chainId,
-            message: "Invalid fill found",
-            deposit,
-            fill,
-          });
-        }
-
-        if (isValid) groupedFills.validFills.push(fill);
+        if (this.validateFillForDeposit(fill, deposit)) groupedFills.validFills.push(fill);
         else groupedFills.invalidFills.push(fill);
         return groupedFills;
       },
       { validFills: [], invalidFills: [] }
     );
+
+    // Log any invalid deposits with same deposit id but different params.
+    const invalidFillsForDeposit = invalidFills.filter((x) => x.depositId === deposit.depositId);
+    if (invalidFillsForDeposit.length > 0)
+      this.logger.warn({
+        at: "SpokePoolClient",
+        chainId: this.chainId,
+        message: "Invalid fills found matching deposit ID",
+        deposit,
+        invalidFills: Object.fromEntries(invalidFillsForDeposit.map((x) => [x.relayer, x])),
+      });
 
     // If all fills are invalid we can consider this unfilled.
     if (validFills.length === 0) {

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -56,8 +56,7 @@ export async function constructSpokePoolClientsWithLookback(
   configStoreClient: AcrossConfigStoreClient,
   config: CommonConfig,
   baseSigner: Wallet,
-  initialLookBackOverride: { [chainId: number]: number } = {},
-  logInvalidFills = false
+  initialLookBackOverride: { [chainId: number]: number } = {}
 ): Promise<SpokePoolClientsByChain> {
   const spokePoolClients: SpokePoolClientsByChain = {};
 
@@ -95,8 +94,7 @@ export async function constructSpokePoolClientsWithLookback(
       configStoreClient,
       networkId,
       spokePoolClientSearchSettings,
-      spokePoolDeploymentBlock,
-      logInvalidFills
+      spokePoolDeploymentBlock
     );
   });
 

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -26,8 +26,7 @@ export async function constructRelayerClients(
     commonClients.configStoreClient,
     config,
     baseSigner,
-    config.maxRelayerLookBack,
-    config.logInvalidFills
+    config.maxRelayerLookBack
   );
 
   const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -15,7 +15,6 @@ export class RelayerConfig extends CommonConfig {
   readonly relayerTokens: string[];
   readonly relayerDestinationChains: number[];
   readonly minRelayerFeePct: BigNumber;
-  readonly logInvalidFills: boolean;
   readonly acceptInvalidFills: boolean;
   // Following distances in blocks to guarantee finality on each chain.
   readonly minDepositConfirmations: { [chainId: number]: number };
@@ -30,7 +29,6 @@ export class RelayerConfig extends CommonConfig {
       SEND_RELAYS,
       SEND_SLOW_RELAYS,
       MIN_RELAYER_FEE_PCT,
-      LOG_INVALID_FILLS,
       ACCEPT_INVALID_FILLS,
       MIN_DEPOSIT_CONFIRMATIONS,
     } = env;
@@ -75,7 +73,6 @@ export class RelayerConfig extends CommonConfig {
     this.ignoreTokenPriceFailures = IGNORE_TOKEN_PRICE_FAILURES === "true";
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
-    this.logInvalidFills = LOG_INVALID_FILLS === "true";
     this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";
     this.minDepositConfirmations = MIN_DEPOSIT_CONFIRMATIONS
       ? JSON.parse(MIN_DEPOSIT_CONFIRMATIONS)

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -65,8 +65,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       configStoreClient,
       destinationChainId,
       { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 },
-      0,
-      true
+      0
     );
 
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
@@ -268,7 +267,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     expect(unfilledDeposit.deposit.depositId).to.equal(deposit.depositId);
     expect(unfilledDeposit.invalidFills.length).to.equal(1);
     expect(unfilledDeposit.invalidFills[0].amount).to.equal(toBN(fill.amount));
-    expect(lastSpyLogIncludes(spy, "Invalid fill found")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "Invalid fills found")).to.be.true;
 
     await relayerInstance.checkForUnfilledDepositsAndFill();
     // Relayer shouldn't try to relay the fill even though it's unfilled as there has been one invalid fill from this


### PR DESCRIPTION
The motivation for this is:

1) We should reduce number of configuration variables where possible
2) The specific "invalid fills found" log can be summarized by grouping invalid fills per relayer rather than logging once per invalid fill found
3) I believe we should always log invalid fills found. If this gets super noisy as number of external relayers goes up we can look into changing this logic, but for now we should be aware of invalid fills sent

I think 3 is most contentious point, open to suggestions!
Signed-off-by: nicholaspai <npai.nyc@gmail.com>
