### PR TITLE
improve(ProviderUtils): Temp. logging of 429 replies

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -118,7 +118,7 @@ export async function constructClients(
   config: CommonConfig,
   baseSigner: Wallet
 ): Promise<Clients> {
-  const hubSigner = baseSigner.connect(getProvider(config.hubPoolChainId));
+  const hubSigner = baseSigner.connect(getProvider(config.hubPoolChainId, logger));
 
   // Create contract instances for each chain for each required contract.
   const hubPool = getDeployedContract("HubPool", config.hubPoolChainId, hubSigner);

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -1,7 +1,11 @@
 import { ethers } from "ethers";
 import lodash from "lodash";
+import winston from "winston";
 import { isPromiseFulfulled, isPromiseRejected } from "./TypeGuards";
 import createQueue, { QueueObject } from "async/queue";
+
+let logger: winston.Logger;
+let maxConcurrency: number;
 
 // The async/queue library has a task-based interface for building a concurrent queue.
 // This is the type we pass to define a request "task".
@@ -236,14 +240,33 @@ class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
   }
 }
 
-export function getProvider(chainId: number) {
+async function rpcRateLimited(attempt: number, url: string): Promise<boolean> {
+  // Make an effort to filter out any api keys.
+  const regex = url.match(/https:..([\w-.]+)\/.*/d);
+  logger.debug({
+    at: "ProviderUtils#rpcRateLimited",
+    message: `Got 429 on attempt ${attempt}.`,
+    rpc: regex[1] || url,
+    workers: maxConcurrency,
+  });
+
+  return true;
+}
+
+export function getProvider(chainId: number, _logger?: winston.Logger) {
+  logger ??= _logger;
   const { NODE_RETRIES, NODE_RETRY_DELAY, NODE_QUORUM, NODE_TIMEOUT, NODE_MAX_CONCURRENCY } = process.env;
 
   const timeout = Number(process.env[`NODE_TIMEOUT_${chainId}`] || NODE_TIMEOUT || defaultTimeout);
 
-  const constructorArgumentLists = getNodeUrlList(chainId).map(
-    (nodeUrl): [{ url: string; timeout: number }, number] => [{ url: nodeUrl, timeout }, chainId]
-  );
+  const constructorArgumentLists = getNodeUrlList(chainId).map((nodeUrl): [ethers.utils.ConnectionInfo, number] => [
+    {
+      url: nodeUrl,
+      timeout,
+      throttleCallback: rpcRateLimited,
+    },
+    chainId,
+  ]);
 
   // Default to 2 retries.
   const retries = Number(process.env[`NODE_RETRIES_${chainId}`] || NODE_RETRIES || "3");
@@ -255,7 +278,9 @@ export function getProvider(chainId: number) {
   const nodeQuorumThreshold = Number(process.env[`NODE_QUORUM_${chainId}`] || NODE_QUORUM || "1");
 
   // Default to a max concurrency of 1000 requests per node.
-  const nodeMaxConcurrency = Number(process.env[`NODE_MAX_CONCURRENCY_${chainId}`] || NODE_MAX_CONCURRENCY || "1000");
+  const nodeMaxConcurrency = (maxConcurrency = Number(
+    process.env[`NODE_MAX_CONCURRENCY_${chainId}`] || NODE_MAX_CONCURRENCY || "1000"
+  ));
 
   return new RetryProvider(
     constructorArgumentLists,


### PR DESCRIPTION
This change simply adds logging of 429 (too many requests) responses from RPC providers. The logging is intended to be temporary, and should aid enable additional data about rate-limiting to be collected.

Based on local testing against free-tier RPC plans, rate-limiting responses seem very common once NODE_MAX_CONCURRENCY exceeds 2. The v2 bots are primarily using Infura, but Infura unfortunately has extremely little to report on 429 responses. Alchemy, in contrast, provides excellent logging information and guides on tuning.

My gut feeling is that Across bots are probably subject to quite a bit of rate-limiting.