### PR TITLE
fix: Temporarily log out saved pendingProposal

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -449,7 +449,11 @@ export class HubPoolClient {
     this.isUpdated = true;
     this.firstBlockToSearch = searchConfig.toBlock + 1; // Next iteration should start off from where this one ended.
 
-    this.logger.debug({ at: "HubPoolClient", message: "HubPool client updated!" });
+    this.logger.debug({
+      at: "HubPoolClient",
+      message: "HubPool client updated!",
+      pendingRootBundle: this.pendingRootBundle,
+    });
   }
 
   private async fetchTokenInfoFromContract(address: string): Promise<L1Token> {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -342,6 +342,7 @@ export class HubPoolClient {
       at: "HubPoolClient#update",
       message: `Updated HubPool information @ ${currentTime}.`,
       pendingRootBundleProposal,
+      pendingRootBundleProposalKeys: Object.keys(pendingRootBundleProposal),
     });
 
     for (const event of crossChainContractsSetEvents) {


### PR DESCRIPTION
In prod, the HubPoolClient is correctly fetching the `HubPool.rootBundleProposal()` but not saving it into memory correctly until some amount of time after the proposal.

This log should help debug what's being stored.