### PR TITLE
improve: improve typing in src/clients/bridges/

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,8 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
 
   // todo Make the mode of operation an operand, rather than an option.
   // i.e. ts-node ./index.ts [options] <relayer|...>
-  const cmd = Object.keys(cmds).find((_cmd) => !!args[_cmd]);
+  // Note: ts does not produce a narrow type from Object.keys, so we have to help.
+  const cmd = (Object.keys(cmds) as (keyof typeof cmds)[]).find((_cmd) => !!args[_cmd]);
 
   if (cmd === "help") cmds[cmd](); // no return
   else if (cmd === undefined) usage(""); // no return
@@ -53,6 +54,7 @@ if (require.main === module) {
     alias: { h: "help" },
     unknown: usage,
   };
+
   const args = minimist(process.argv.slice(2), opts);
 
   run(args)

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/async-retry": "^1.4.3",
     "@types/bluebird": "^3.5.36",
     "@types/chai": "^4.2.21",
+    "@types/minimist": "^1.2.2",
     "@types/mocha": "^9.0.0",
     "@types/node": "^12.0.0",
     "@typescript-eslint/eslint-plugin": "^4.29.1",

--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -42,6 +42,7 @@ export class AdapterManager {
   }
 
   async sendTokenCrossChain(address: string, chainId: number | string, l1Token: string, amount: BigNumber) {
+    chainId = Number(chainId); // Ensure chainId is a number before using.
     this.logger.debug({ at: "AdapterManager", message: "Sending token cross-chain", chainId, l1Token, amount });
     const l2Token = this.l2TokenForL1Token(l1Token, Number(chainId));
     return await this.adapters[chainId].sendTokenToTargetChain(address, l1Token, l2Token, amount);

--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -7,13 +7,13 @@ import {
   spreadEventWithBlockNumber,
   winston,
 } from "../../utils";
-import { toBN, toWei, paginatedEventQuery, Promise } from "../../utils";
+import { toBN, toWei, paginatedEventQuery, Promise, Event } from "../../utils";
 import { SpokePoolClient } from "../../clients";
 import { BaseAdapter } from "./BaseAdapter";
 import { arbitrumL2Erc20GatewayInterface, arbitrumL1Erc20GatewayInterface } from "./ContractInterfaces";
 
 // These values are obtained from Arbitrum's gateway router contract.
-const l1Gateways = {
+const l1Gateways: { [tokenAddress: string]: string } = {
   "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "0xcEe284F754E854890e311e3280b767F80797180d", // USDC
   "0xdAC17F958D2ee523a2206206994597C13D831ec7": "0xcEe284F754E854890e311e3280b767F80797180d", // USDT
   "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "0xd92023E9d9911199a6711321D1277285e6d4e2db", // WETH
@@ -26,7 +26,7 @@ const l1Gateways = {
 
 const l1GatewayRouter = "0x72Ce9c846789fdB6fC1f34aC4AD25Dd9ef7031ef";
 
-const l2Gateways = {
+const l2Gateways: { [tokenAddress: string]: string } = {
   "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": "0x096760F208390250649E3e8763348E783AEF5562", // USDC
   "0xdAC17F958D2ee523a2206206994597C13D831ec7": "0x096760F208390250649E3e8763348E783AEF5562", // USDT
   "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": "0x6c411aD3E74De3E7Bd422b94A27770f5B86C623B", // WETH
@@ -60,18 +60,22 @@ export class ArbitrumAdapter extends BaseAdapter {
     this.updateSearchConfigs();
     this.log("Getting cross-chain txs", { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
 
-    const promises = [];
-    const validTokens = [];
+    const promises: Promise<Event[]>[] = [];
+    const validTokens: string[] = [];
     // Fetch bridge events for all monitored addresses.
     for (const monitoredAddress of this.monitoredAddresses) {
       for (const l1Token of l1Tokens) {
         // Skip the token if we can't find the corresponding bridge.
         // This is a valid use case as it's more convenient to check cross chain transfers for all tokens
         // rather than maintaining a list of native bridge-supported tokens.
-        if (l1Gateways[l1Token] === undefined || l2Gateways[l1Token] === null) continue;
+        if (l1Gateways[l1Token] === undefined || l2Gateways[l1Token] === undefined) continue;
 
         const l1Bridge = this.getL1Bridge(l1Token);
         const l2Bridge = this.getL2Bridge(l1Token);
+
+        // If either of the above calls errors out, an error log will be sent, but the loop cannot be completed without a bridge.
+        if (l1Bridge === null || l2Bridge === null) continue;
+
         // l1Token is not an indexed field on deposit events in L1 but is on finalization events on Arb.
         // This unfortunately leads to fetching of all deposit events for all tokens multiple times, one per l1Token.
         // There's likely not much we can do here as the deposit events don't have l1Token as an indexed field.

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -1,22 +1,25 @@
 import { Provider } from "@ethersproject/abstract-provider";
 import { Signer } from "@ethersproject/abstract-signer";
 import { SpokePoolClient } from "../../clients";
-import { toBN, MAX_SAFE_ALLOWANCE, Contract, ERC20 } from "../../utils";
+import { toBN, MAX_SAFE_ALLOWANCE, Contract, ERC20, winston, EventSearchConfig, DefaultLogLevels } from "../../utils";
 import { etherscanLink, getNetworkName, MAX_UINT_VAL, runTransaction } from "../../utils";
 import { OutstandingTransfers } from "../../interfaces/Bridge";
 
 export class BaseAdapter {
   chainId: number;
-  l1SearchConfig;
-  l2SearchConfig;
-  monitoredAddresses: string[];
-  logger;
+  l1SearchConfig: EventSearchConfig;
+  l2SearchConfig: EventSearchConfig;
 
   l1DepositInitiatedEvents: { [address: string]: { [l1Token: string]: any[] } } = {};
   l2DepositFinalizedEvents: { [address: string]: { [l1Token: string]: any[] } } = {};
   l2DepositFinalizedEvents_DepositAdapter: { [address: string]: { [l1Token: string]: any[] } } = {};
 
-  constructor(readonly spokePoolClients: { [chainId: number]: SpokePoolClient }, _chainId: number) {
+  constructor(
+    readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
+    _chainId: number,
+    readonly monitoredAddresses: string[],
+    readonly logger: winston.Logger
+  ) {
     this.chainId = _chainId;
     this.l1SearchConfig = { ...this.getSearchConfig(1) };
     this.l2SearchConfig = { ...this.getSearchConfig(this.chainId) };
@@ -146,7 +149,7 @@ export class BaseAdapter {
     return outstandingTransfers;
   }
 
-  log(message: string, data?: any, level = "debug") {
+  log(message: string, data?: any, level: DefaultLogLevels = "debug") {
     this.logger[level]({ at: this.getName(), message, ...data });
   }
 

--- a/src/clients/bridges/CrossChainTransferClient.ts
+++ b/src/clients/bridges/CrossChainTransferClient.ts
@@ -1,4 +1,4 @@
-import { BigNumber, winston, assign, toBN } from "../../utils";
+import { BigNumber, winston, assign, toBN, DefaultLogLevels } from "../../utils";
 import { AdapterManager } from "./AdapterManager";
 import { OutstandingTransfers } from "../../interfaces/Bridge";
 
@@ -69,7 +69,7 @@ export class CrossChainTransferClient {
     this.log("Updated cross chain transfers", { outstandingCrossChainTransfers: this.outstandingCrossChainTransfers });
   }
 
-  log(message: string, data?: any, level = "debug") {
+  log(message: string, data?: any, level: DefaultLogLevels = "debug") {
     if (this.logger) this.logger[level]({ at: "CrossChainTransferClient", message, ...data });
   }
 }

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -123,7 +123,7 @@ export class PolygonAdapter extends BaseAdapter {
 
         const l2Token = this.getL2Token(l1Token);
 
-        if (l2Token == null) continue;
+        if (l2Token === null) continue;
         if (!this.isSupportedToken(l1Token)) continue;
 
         const l1Method = tokenToBridge[l1Token].l1Method;

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -1,8 +1,19 @@
-import { runTransaction, assign, Contract, BigNumber, bnToHex, winston } from "../../utils";
+import {
+  runTransaction,
+  assign,
+  Contract,
+  BigNumber,
+  bnToHex,
+  winston,
+  Event,
+  isDefined,
+  BigNumberish,
+} from "../../utils";
 import { ZERO_ADDRESS, spreadEventWithBlockNumber, paginatedEventQuery, Promise } from "../../utils";
 import { SpokePoolClient } from "../../clients";
 import { BaseAdapter, polygonL1BridgeInterface, polygonL2BridgeInterface } from "./";
 import { polygonL1RootChainManagerInterface, atomicDepositorInterface } from "./";
+import { SortableEvent } from "../../interfaces";
 
 // ether bridge = 0x8484Ef722627bf18ca5Ae6BcF031c23E6e922B30
 // erc20 bridge = 0x40ec5B33f54e0E8A33A975908C5BA1c14e5BbbDf
@@ -79,17 +90,19 @@ const tokenToBridge = {
     l1AmountProp: "amountOrNFTId",
     l2AmountProp: "amount",
   }, // MATIC
-};
+} as const;
+
+type SupportedL1Token = keyof typeof tokenToBridge;
 
 const atomicDepositorAddress = "0x26eaf37ee5daf49174637bdcd2f7759a25206c34";
 
 export class PolygonAdapter extends BaseAdapter {
   constructor(
-    readonly logger: winston.Logger,
+    logger: winston.Logger,
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
-    readonly monitoredAddresses: string[]
+    monitoredAddresses: string[]
   ) {
-    super(spokePoolClients, 137);
+    super(spokePoolClients, 137, monitoredAddresses, logger);
   }
 
   // On polygon a bridge transaction looks like a transfer from address(0) to the target.
@@ -97,8 +110,8 @@ export class PolygonAdapter extends BaseAdapter {
     this.updateSearchConfigs();
     this.log("Getting cross-chain txs", { l1Tokens, l1Config: this.l1SearchConfig, l2Config: this.l2SearchConfig });
 
-    const promises = [];
-    const validTokens = [];
+    const promises: Promise<Event[]>[] = [];
+    const validTokens: SupportedL1Token[] = [];
     // Fetch bridge events for all monitored addresses.
     for (const monitoredAddress of this.monitoredAddresses) {
       for (const l1Token of l1Tokens) {
@@ -110,14 +123,17 @@ export class PolygonAdapter extends BaseAdapter {
 
         const l2Token = this.getL2Token(l1Token);
 
+        if (l2Token == null) continue;
+        if (!this.isSupportedToken(l1Token)) continue;
+
         const l1Method = tokenToBridge[l1Token].l1Method;
-        let l1SearchFilter = [];
+        let l1SearchFilter: (string | undefined)[] = [];
         if (l1Method === "LockedERC20") l1SearchFilter = [monitoredAddress, undefined, l1Token];
         if (l1Method === "LockedEther") l1SearchFilter = [undefined, monitoredAddress];
         if (l1Method === "NewDepositBlock") l1SearchFilter = [monitoredAddress, l1MaticAddress];
 
         const l2Method = l1Token === l1MaticAddress ? "TokenDeposited" : "Transfer";
-        let l2SearchFilter = [];
+        let l2SearchFilter: (string | undefined)[] = [];
         if (l2Method === "Transfer") l2SearchFilter = [ZERO_ADDRESS, monitoredAddress];
         if (l2Method === "TokenDeposited") l2SearchFilter = [l1MaticAddress, ZERO_ADDRESS, monitoredAddress];
 
@@ -149,9 +165,12 @@ export class PolygonAdapter extends BaseAdapter {
         const l1Token = validTokens[Math.floor(index / 2)];
         const amountProp = index % 2 === 0 ? tokenToBridge[l1Token].l1AmountProp : tokenToBridge[l1Token].l2AmountProp;
         const events = result.map((event) => {
-          const eventSpread = spreadEventWithBlockNumber(event);
+          // Hacky typing here. We should probably rework the structure of this function to improve.
+          const eventSpread = spreadEventWithBlockNumber(event) as unknown as SortableEvent & {
+            [amount in typeof amountProp]?: BigNumberish;
+          } & { depositReceiver: string };
           return {
-            amount: eventSpread[amountProp],
+            amount: eventSpread[amountProp]!,
             to: eventSpread["depositReceiver"],
             ...eventSpread,
           };
@@ -182,46 +201,52 @@ export class PolygonAdapter extends BaseAdapter {
   }
 
   async checkTokenApprovals(address: string, l1Tokens: string[]) {
-    const associatedL1Bridges = l1Tokens.map((l1Token) => {
-      if (this.isWeth(l1Token)) return this.getL1TokenGateway(l1Token)?.address;
-      return this.getL1Bridge(l1Token)?.address;
-    });
+    const associatedL1Bridges = l1Tokens
+      .map((l1Token) => {
+        if (this.isWeth(l1Token)) return this.getL1TokenGateway(l1Token)?.address;
+        return this.getL1Bridge(l1Token)?.address;
+      })
+      .filter(isDefined);
     await this.checkAndSendTokenApprovals(address, l1Tokens, associatedL1Bridges);
   }
 
   getL1Bridge(l1Token: string): Contract | null {
-    if (tokenToBridge[l1Token] === undefined) return null;
-
-    try {
+    if (this.isSupportedToken(l1Token))
       return new Contract(tokenToBridge[l1Token].l1BridgeAddress, polygonL1BridgeInterface, this.getSigner(1));
-    } catch (error) {
-      this.log("Could not construct l1Bridge. Likely misconfiguration", { l1Token, error, tokenToBridge }, "error");
+    else {
+      this.log(
+        "Could not construct l1Bridge due to unsupported l1Token. Likely misconfiguration",
+        { l1Token, tokenToBridge },
+        "error"
+      );
       return null;
     }
   }
 
-  getL1TokenGateway(l1Token: string): Contract | null {
+  getL1TokenGateway(l1Token: string): Contract {
     if (this.isWeth(l1Token)) return new Contract(atomicDepositorAddress, atomicDepositorInterface, this.getSigner(1));
-    else
-      try {
-        return new Contract(l1RootChainManager, polygonL1RootChainManagerInterface, this.getSigner(1));
-      } catch (error) {
-        this.log("Could not construct l1Bridge. Likely misconfiguration", { l1Token, error, tokenToBridge }, "error");
-        return null;
-      }
+    else return new Contract(l1RootChainManager, polygonL1RootChainManagerInterface, this.getSigner(1));
   }
 
   // Note that on polygon we dont query events on the L2 bridge. rather, we look for mint events on the L2 token.
   getL2Token(l1Token: string): Contract | null {
-    try {
+    if (this.isSupportedToken(l1Token))
       return new Contract(
         tokenToBridge[l1Token].l2TokenAddress,
         polygonL2BridgeInterface,
         this.getSigner(this.chainId)
       );
-    } catch (error) {
-      this.log("Could not construct l2Token. Likely misconfiguration", { l1Token, error, tokenToBridge }, "error");
+    else {
+      this.log(
+        "Could not construct l2Token due to unsupported l1Token. Likely misconfiguration",
+        { l1Token, tokenToBridge },
+        "error"
+      );
       return null;
     }
+  }
+
+  private isSupportedToken(l1Token: string): l1Token is SupportedL1Token {
+    return l1Token in tokenToBridge;
   }
 }

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -56,7 +56,7 @@ export const CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
 // what the hubpool thinks is the correct L2 token for a given L1 token is actually the correct L2 token. It is simply a
 //  sanity check: if for whatever reason this does not line up the bot show fail loudly and stop execution as something
 // is broken and funds are not safe to be sent over the canonical L2 bridges.
-export const l2TokensToL1TokenValidation = {
+export const l2TokensToL1TokenValidation: { [tokenAddress: string]: { [chainId: number]: string } } = {
   "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": {
     10: "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
     137: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -27,7 +27,7 @@ export function spreadEvent(event: Event) {
 
 export interface EventSearchConfig {
   fromBlock: number;
-  toBlock: number | null;
+  toBlock: number;
   maxBlockLookBack?: number;
   concurrency?: number | null;
 }

--- a/src/utils/Help.ts
+++ b/src/utils/Help.ts
@@ -1,4 +1,4 @@
-export function usage(badInput: string = undefined) {
+export function usage(badInput: string | undefined = undefined): boolean {
   let usageStr = badInput ? `\nUnrecognized input: "${badInput}".\n\n` : "";
   const userModes = "monitor|relayer";
   const proModes = "dataworker|finalizer";

--- a/src/utils/LogUtils.ts
+++ b/src/utils/LogUtils.ts
@@ -1,0 +1,1 @@
+export type DefaultLogLevels = "debug" | "info" | "warn" | "error";

--- a/src/utils/TypeGuards.ts
+++ b/src/utils/TypeGuards.ts
@@ -9,3 +9,7 @@ export function isPromiseRejected<T>(
 ): promiseSettledResult is PromiseRejectedResult {
   return promiseSettledResult.status === "rejected";
 }
+
+export function isDefined<T>(input: T | null | undefined): input is T {
+  return input !== null && input !== undefined;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,7 +5,7 @@ import fetch from "node-fetch";
 export { winston, assert, fetch };
 export { delay, Logger } from "@uma/financial-templates-lib";
 
-export { BigNumber, Signer, Contract, ContractFactory, Transaction } from "ethers";
+export { BigNumber, Signer, Contract, ContractFactory, Transaction, BigNumberish } from "ethers";
 export { utils, EventFilter, BaseContract, Event, Wallet } from "ethers";
 export { ethers, providers } from "ethers";
 export type { Block, TransactionResponse, TransactionReceipt } from "@ethersproject/abstract-provider";
@@ -33,6 +33,7 @@ export * from "./TimeUtils";
 export * from "./RedisUtils";
 export * from "./TypeGuards";
 export * from "./Help";
+export * from "./LogUtils";
 
 export { ZERO_ADDRESS, MAX_SAFE_ALLOWANCE, MAX_UINT_VAL, replaceAddressCase } from "@uma/common";
 

--- a/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
+++ b/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
@@ -1,4 +1,4 @@
-import { expect, winston } from "./utils";
+import { expect, createSpyLogger } from "./utils";
 import { toBN } from "./utils";
 import { BaseAdapter } from "../src/clients/bridges";
 import { SpokePoolClient } from "../src/clients";
@@ -12,7 +12,7 @@ class TestAdapter extends BaseAdapter {
       },
       1,
       ["0xmonitored"],
-      new winston.Logger({ silent: true })
+      createSpyLogger().spyLogger
     );
   }
 
@@ -32,7 +32,7 @@ class TestAdapter extends BaseAdapter {
 }
 
 let adapter: TestAdapter;
-describe("AdapterManager: Send tokens cross-chain", async function () {
+describe("AdapterManager: Get outstanding cross chain token transfer amounts", async function () {
   beforeEach(async function () {
     adapter = new TestAdapter();
   });

--- a/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
+++ b/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
@@ -10,9 +10,9 @@ class TestAdapter extends BaseAdapter {
       {
         1: { latestBlockNumber: 123 } as unknown as SpokePoolClient,
       },
-      1
+      1,
+      ["0xmonitored"]
     );
-    this.monitoredAddresses = ["0xmonitored"];
   }
 
   public setDepositEvents(amounts: number[]) {

--- a/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
+++ b/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
@@ -6,7 +6,6 @@ import { OutstandingTransfers } from "../src/interfaces/Bridge";
 
 class TestAdapter extends BaseAdapter {
   constructor() {
-
     super(
       {
         1: { latestBlockNumber: 123 } as unknown as SpokePoolClient,

--- a/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
+++ b/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
@@ -1,4 +1,4 @@
-import { expect } from "./utils";
+import { expect, winston } from "./utils";
 import { toBN } from "./utils";
 import { BaseAdapter } from "../src/clients/bridges";
 import { SpokePoolClient } from "../src/clients";
@@ -6,12 +6,14 @@ import { OutstandingTransfers } from "../src/interfaces/Bridge";
 
 class TestAdapter extends BaseAdapter {
   constructor() {
+
     super(
       {
         1: { latestBlockNumber: 123 } as unknown as SpokePoolClient,
       },
       1,
-      ["0xmonitored"]
+      ["0xmonitored"],
+      new winston.Logger({ silent: true })
     );
   }
 

--- a/test/mocks/MockAdapterManager.ts
+++ b/test/mocks/MockAdapterManager.ts
@@ -1,5 +1,5 @@
 import { AdapterManager } from "../../src/clients/bridges";
-import { BigNumber } from "../../src/utils";
+import { BigNumber, TransactionResponse } from "../../src/utils";
 
 import { createRandomBytes32 } from "../utils";
 import { OutstandingTransfers } from "../../src/interfaces/Bridge";
@@ -14,7 +14,7 @@ export class MockAdapterManager extends AdapterManager {
     if (!this.tokensSentCrossChain[chainId]) this.tokensSentCrossChain[chainId] = {};
     const hash = createRandomBytes32();
     this.tokensSentCrossChain[chainId][l1Token] = { amount, hash };
-    return { hash };
+    return { hash } as TransactionResponse;
   }
 
   override async getOutstandingCrossChainTokenTransferAmount(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "esModuleInterop": true,
     "outDir": "./dist",
     "declaration": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "strict": true
   },
   "include": ["./src", "index.ts"],
   "files": ["./hardhat.config.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,7 @@
     "esModuleInterop": true,
     "outDir": "./dist",
     "declaration": true,
-    "skipLibCheck": true,
-    "strict": true
+    "skipLibCheck": true
   },
   "include": ["./src", "index.ts"],
   "files": ["./hardhat.config.ts"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3281,6 +3281,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
+"@types/minimist@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
+  integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
 "@types/mkdirp@^0.5.2":
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@types/mkdirp/-/mkdirp-0.5.2.tgz#503aacfe5cc2703d5484326b1b27efa67a339c1f"


### PR DESCRIPTION
This is the first PR in what will hopefully be a series of PRs to address type issues that are blocking us from enabling the `strict` setting in our tsconfig.

The idea behind this change is to make our bots safer and more error-proof by expanding the sort of type-checking we're getting from typescript.

I've created this by enabling strict locally and working through the errors manually. Since there are hundreds of errors, I've decided to start working through them folder-by-folder and doing PRs as I go so these can be carefully reviewed.