### PR TITLE
improve: Store sped-up relayer fee % in cache

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -424,11 +424,12 @@ export class SpokePoolClient {
               blockNumber,
               originBlockNumber,
             };
-            dataToCache.deposits[destinationChainId][index] = {
-              ...speedUpDeposit,
-              blockNumber,
-              originBlockNumber,
-            };
+            if (dataToCache?.deposits && dataToCache?.deposits[destinationChainId])
+              this.deposits[destinationChainId][index] = {
+                ...speedUpDeposit,
+                blockNumber,
+                originBlockNumber,
+              };
           }
         }
     }

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -424,7 +424,7 @@ export class SpokePoolClient {
               blockNumber,
               originBlockNumber,
             };
-            if (dataToCache?.deposits && dataToCache?.deposits[destinationChainId])
+            if (dataToCache?.deposits?.[destinationChainId])
               this.deposits[destinationChainId][index] = {
                 ...speedUpDeposit,
                 blockNumber,

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -404,8 +404,7 @@ export class SpokePoolClient {
       }
     }
 
-    // Disable this loop.
-    // eslint-disable-next-line no-constant-condition
+    // Update deposits with speed up requests from depositor.
     if (eventsToQuery.includes("RequestedSpeedUpDeposit")) {
       const speedUpEvents = queryResults[eventsToQuery.indexOf("RequestedSpeedUpDeposit")];
 
@@ -421,6 +420,11 @@ export class SpokePoolClient {
           const speedUpDeposit = this.appendMaxSpeedUpSignatureToDeposit(depositData);
           if (speedUpDeposit !== depositData) {
             this.deposits[destinationChainId][index] = {
+              ...speedUpDeposit,
+              blockNumber,
+              originBlockNumber,
+            };
+            dataToCache.deposits[destinationChainId][index] = {
               ...speedUpDeposit,
               blockNumber,
               originBlockNumber,
@@ -626,12 +630,18 @@ export class SpokePoolClient {
             .map((deposit) => {
               // Here we convert BigNumber objects to strings before storing into Redis cache
               // which only stores strings.
-              return {
+              const depositToCache = {
                 ...deposit,
                 amount: deposit.amount.toString(),
                 relayerFeePct: deposit.relayerFeePct.toString(),
+                newRelayerFeePct: deposit?.newRelayerFeePct?.toString(),
                 realizedLpFeePct: deposit.realizedLpFeePct.toString(),
               } as DepositWithBlockInCache;
+              // Delete undefined values.
+              Object.keys(depositToCache).forEach(
+                (key) => depositToCache[key] === undefined && delete depositToCache[key]
+              );
+              return depositToCache;
             }),
         ];
       })
@@ -640,7 +650,7 @@ export class SpokePoolClient {
     const fillsToCacheBeforeSnapshot = newCachedData.fills
       .filter((e) => e.blockNumber <= latestBlockToCache)
       .map((fill) => {
-        return {
+        const fillToCache = {
           ...fill,
           amount: fill.amount.toString(),
           totalFilledAmount: fill.totalFilledAmount.toString(),
@@ -649,6 +659,9 @@ export class SpokePoolClient {
           appliedRelayerFeePct: fill.appliedRelayerFeePct.toString(),
           realizedLpFeePct: fill.realizedLpFeePct.toString(),
         } as FillWithBlockInCache;
+        // Delete undefined values.
+        Object.keys(fillToCache).forEach((key) => fillToCache[key] === undefined && delete fillToCache[key]);
+        return fillToCache;
       });
 
     this.log("debug", `Saved cached for chain ${this.chainId}`, {
@@ -678,7 +691,7 @@ export class SpokePoolClient {
     });
   }
 
-  // Neccessary to use this function because RedisDB can only store strings so we need to stringify the BN objects
+  // Necessary to use this function because RedisDB can only store strings so we need to stringify the BN objects
   // before storing them in the cache, and do the opposite to retrieve the data type that we expect when fetching
   // from the cache.
   private convertDepositInCache(deposit: DepositWithBlockInCache): DepositWithBlock {
@@ -686,6 +699,7 @@ export class SpokePoolClient {
       ...deposit,
       amount: toBN(deposit.amount),
       relayerFeePct: toBN(deposit.relayerFeePct),
+      newRelayerFeePct: deposit.newRelayerFeePct ? toBN(deposit.newRelayerFeePct) : undefined,
       realizedLpFeePct: toBN(deposit.realizedLpFeePct),
     };
   }

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -35,7 +35,8 @@ export interface DepositWithBlockInCache extends SortableEvent {
   realizedLpFeePct: string;
   destinationToken: string;
   originBlockNumber: number;
-  speedUpSignature?: string | undefined;
+  speedUpSignature?: string;
+  newRelayerFeePct?: string;
 }
 
 export interface CachedDataBlocks {


### PR DESCRIPTION
When updating deposits following speed ups, the Dataworker cached deposit does not get updated. There is no inherent risk. It does just mean when the Spokepool client updates, and loads deposits from cache, it won't be the most up-to-date version containing the new relayerFeePct.

In practice, deposits are only loaded from the cache if they are older than the most recently validated root bundle, and most deposits are fully filled well before then, but this PR will enhance UX for the edge cases where deposits only get partially filled and are not fully filled for a long time.