### PR TITLE
chore(FormattingUtils): Use sdk-v2 implementations

### DIFF
--- a/src/utils/FormattingUtils.ts
+++ b/src/utils/FormattingUtils.ts
@@ -1,14 +1,19 @@
 import { ethers, BigNumber } from "ethers";
+import { utils } from "@across-protocol/sdk-v2";
 import { createFormatFunction } from "../utils";
+
+export type BigNumberish = utils.BigNumberish;
+export type BN = utils.BN;
 
 export const toWei = (num: string | number | BigNumber) => ethers.utils.parseEther(num.toString());
 
-export const toBNWei = (num: string | number | BigNumber) => BigNumber.from(toWei(num));
+export const toBNWei = utils.toBNWei;
 
 export const toGWei = (num: string | number | BigNumber) => ethers.utils.parseUnits(num.toString(), 9);
 
-export const fromWei = (num: string | number | BigNumber) => ethers.utils.formatUnits(num.toString());
+export const fromWei = utils.fromWei;
 
+// @todo: Backport support for decimal points to @across-protocol/sdk-v2
 export const toBN = (num: string | number | BigNumber) => {
   // If the string version of the num contains a `.` then it is a number which needs to be parsed to a string int.
   if (num.toString().includes(".")) return BigNumber.from(parseInt(num.toString()));


### PR DESCRIPTION
Remove the opportunity for errors to creep in over time due to duplicate implementations. The sdk-v2 implementation of toBN() allows optional decimal scaling, which is nice to have.

Without going on too much of a yak-shaving odyssey, we should also probably migrate some of the extra implementations from here over into the SDK.

For reference, the SDK implementations are available here: https://github.com/across-protocol/sdk-v2/blob/f77190132d3fb8cb88fb34f3141d397942816bdb/src/utils.ts

Ref: ACX-325