### PR TITLE
chore(ProfitClient): Misc. cleanup before update

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -16,7 +16,7 @@ type CoinGeckoPrice = {
 // We use wrapped ERC-20 versions instead of the native tokens such as ETH, MATIC for ease of computing prices.
 // @todo: These don't belong in the ProfitClient; they should be relocated.
 export const MATIC = "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0";
-export const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+export const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
 export const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
 const GAS_TOKEN_BY_CHAIN_ID = {

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -1,4 +1,5 @@
 import { Provider } from "@ethersproject/abstract-provider";
+import * as constants from "../common/Constants";
 import { assert, BigNumber, formatFeePct, winston, toBNWei, toBN, assign } from "../utils";
 import { HubPoolClient } from ".";
 import { Deposit, L1Token, SpokePoolClientsByChain } from "../interfaces";
@@ -13,6 +14,7 @@ type CoinGeckoPrice = {
 };
 
 // We use wrapped ERC-20 versions instead of the native tokens such as ETH, MATIC for ease of computing prices.
+// @todo: These don't belong in the ProfitClient; they should be relocated.
 export const MATIC = "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0";
 export const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
@@ -53,7 +55,7 @@ export class ProfitClient {
     readonly enabledChainIds: number[],
     // Default to throwing errors if fetching token prices fails.
     readonly ignoreTokenPriceFailures: boolean = false,
-    readonly minRelayerFeePct: BigNumber = toBN(0)
+    readonly minRelayerFeePct: BigNumber = toBN(constants.RELAYER_MIN_FEE_PCT)
   ) {
     this.coingecko = new Coingecko();
 

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -16,6 +16,7 @@ type CoinGeckoPrice = {
 // We use wrapped ERC-20 versions instead of the native tokens such as ETH, MATIC for ease of computing prices.
 // @todo: These don't belong in the ProfitClient; they should be relocated.
 export const MATIC = "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0";
+export const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 export const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
 const GAS_TOKEN_BY_CHAIN_ID = {

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -12,10 +12,8 @@ import {
 } from "./utils";
 import { MockHubPoolClient, MockProfitClient } from "./mocks";
 import { Deposit, L1Token } from "../src/interfaces";
-import { SpokePoolClient, WETH, MATIC } from "../src/clients";
+import { SpokePoolClient, MATIC, USDC, WETH } from "../src/clients";
 
-// @todo: This should be centralised (and probably already is...).
-const USDC = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
 const tokens: { [symbol: string]: L1Token } = {
   MATIC: { address: MATIC, decimals: 18, symbol: "MATIC" },
   USDC: { address: USDC, decimals: 6, symbol: "USDC" },


### PR DESCRIPTION
This is a single commit containing a collection of minor changes that were accrued whilst updating the ProfitClient profitability logic. They are separated out here to avoid cluttering the main PR.

 - Use constants for minRelayerFeePct.
 - Reorg. token data in ProfitClient test.