### PR TITLE
improve(ProfitClient): Add new profitability logic

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -108,8 +108,7 @@ export class ProfitClient {
     gasCostUsd: BigNumber;
   } {
     const nativeGasCost: BigNumber = this.getTotalGasCost(chainId); // gas cost in native token
-    const gasToken: string = GAS_TOKEN_BY_CHAIN_ID[chainId];
-    const gasPriceUsd: BigNumber = this.getPriceOfToken(gasToken);
+    const gasPriceUsd: BigNumber = this.getPriceOfToken(GAS_TOKEN_BY_CHAIN_ID[chainId]);
     const gasCostUsd: BigNumber = nativeGasCost.mul(gasPriceUsd).div(toBN(10).pow(GAS_TOKEN_DECIMALS));
 
     return {

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -32,8 +32,8 @@ const tokenPrices: { [symbol: string]: BigNumber } = {
 // gas prices to test with, since there's a spread in the chainId numbers.
 const gasCost: { [chainId: number]: BigNumber } = Object.fromEntries(
   chainIds.map((chainId: number) => {
-    const nativeGasPrice: BigNumber = toBN(chainId).mul(1e9); // Gwei
-    const gasConsumed: BigNumber = toBN(100_000); // Assume 100k gas for a single fill
+    const nativeGasPrice = toBN(chainId).mul(1e9); // Gwei
+    const gasConsumed = toBN(100_000); // Assume 100k gas for a single fill
     return [chainId, gasConsumed.mul(nativeGasPrice)];
   })
 );
@@ -68,7 +68,7 @@ describe("ProfitClient: Consider relay profit", async function () {
     chainIds.forEach((chainId: number) => {
       spyLogger.debug({ message: `Verifying USD fill cost calculation for chain ${chainId}.` });
 
-      const nativeGasCost: BigNumber = profitClient.getTotalGasCost(chainId);
+      const nativeGasCost = profitClient.getTotalGasCost(chainId);
       expect(nativeGasCost.eq(0)).to.be.false;
       expect(nativeGasCost.eq(gasCost[chainId]));
 
@@ -76,7 +76,7 @@ describe("ProfitClient: Consider relay profit", async function () {
       const gasToken: L1Token = Object.values(tokens).find((token: L1Token) => gasTokenAddr === token.address);
       expect(gasToken).to.not.be.undefined;
 
-      const gasPriceUsd: BigNumber = tokenPrices[gasToken.symbol];
+      const gasPriceUsd = tokenPrices[gasToken.symbol];
       expect(gasPriceUsd.eq(tokenPrices[gasToken.symbol]));
 
       const estimate: { [key: string]: BigNumber } = profitClient.calculateFillCost(chainId);
@@ -155,7 +155,7 @@ describe("ProfitClient: Consider relay profit", async function () {
     const l1Token: L1Token = tokens["WETH"];
     hubPoolClient.setTokenInfoToReturn(l1Token);
 
-    const fillAmount: BigNumber = toBNWei(1);
+    const fillAmount = toBNWei(1);
     const deposit = {
       relayerFeePct: toBNWei("0.001"),
       destinationChainId: 1,
@@ -191,7 +191,7 @@ describe("ProfitClient: Consider relay profit", async function () {
       newRelayerFeePct: toBNWei("0.01"),
       destinationChainId: 1,
     } as Deposit;
-    const fillAmount: BigNumber = toBNWei(1);
+    const fillAmount = toBNWei(1);
 
     let fill: FillProfit;
     fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -12,7 +12,9 @@ import {
 } from "./utils";
 import { MockHubPoolClient, MockProfitClient } from "./mocks";
 import { Deposit, L1Token } from "../src/interfaces";
-import { SpokePoolClient, MATIC, USDC, WETH } from "../src/clients";
+import { FillProfit, GAS_TOKEN_BY_CHAIN_ID, SpokePoolClient, MATIC, USDC, WETH } from "../src/clients";
+
+const chainIds: number[] = [1, 10, 137, 288, 42161];
 
 const tokens: { [symbol: string]: L1Token } = {
   MATIC: { address: MATIC, decimals: 18, symbol: "MATIC" },
@@ -25,6 +27,16 @@ const tokenPrices: { [symbol: string]: BigNumber } = {
   USDC: toBNWei(1),
   WETH: toBNWei(3000),
 };
+
+// Quirk: Use the chainId as the gas price in Gwei. This gives a range of
+// gas prices to test with, since there's a spread in the chainId numbers.
+const gasCost: { [chainId: number]: BigNumber } = Object.fromEntries(
+  chainIds.map((chainId: number) => {
+    const nativeGasPrice: BigNumber = toBN(chainId).mul(1e9); // Gwei
+    const gasConsumed: BigNumber = toBN(100_000); // Assume 100k gas for a single fill
+    return [chainId, gasConsumed.mul(nativeGasPrice)];
+  })
+);
 
 // Set env LOG_IN_TEST to log to console.
 const { spyLogger } = createSpyLogger();
@@ -42,10 +54,36 @@ describe("ProfitClient: Consider relay profit", async function () {
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, false, [], false, toBN(0));
 
+    // Load per-chain gas cost (gas consumed * gas price in Wei), in native gas token.
+    profitClient.setGasCosts(gasCost);
+
     // Load ERC20 token prices in USD.
     profitClient.setTokenPrices(
       Object.fromEntries(Object.entries(tokenPrices).map(([symbol, price]) => [tokens[symbol].address, price]))
     );
+  });
+
+  // Verify gas cost calculation first, so we can leverage it in all subsequent tests.
+  it("Verify gas cost estimation", function () {
+    chainIds.forEach((chainId: number) => {
+      spyLogger.debug({ message: `Verifying USD fill cost calculation for chain ${chainId}.` });
+
+      const nativeGasCost: BigNumber = profitClient.getTotalGasCost(chainId);
+      expect(nativeGasCost.eq(0)).to.be.false;
+      expect(nativeGasCost.eq(gasCost[chainId]));
+
+      const gasTokenAddr: string = GAS_TOKEN_BY_CHAIN_ID[chainId];
+      const gasToken: L1Token = Object.values(tokens).find((token: L1Token) => gasTokenAddr === token.address);
+      expect(gasToken).to.not.be.undefined;
+
+      const gasPriceUsd: BigNumber = tokenPrices[gasToken.symbol];
+      expect(gasPriceUsd.eq(tokenPrices[gasToken.symbol]));
+
+      const estimate: { [key: string]: BigNumber } = profitClient.calculateFillCost(chainId);
+      expect(estimate.nativeGasCost.eq(gasCost[chainId]));
+      expect(estimate.gasPriceUsd.eq(tokenPrices[gasToken.symbol]));
+      expect(estimate.gasCostUsd.eq(gasPriceUsd.mul(nativeGasCost)));
+    });
   });
 
   it("Considers gas cost when computing protfitability", async function () {
@@ -102,7 +140,7 @@ describe("ProfitClient: Consider relay profit", async function () {
     expect(profitClientWithMinFee.isFillProfitable(profitableWethL1Relay, toBNWei(1))).to.be.false;
   });
 
-  it("Considers deposits with newRelayerFeePct", async function () {
+  it("Considers deposits with newRelayerFeePct (old)", async function () {
     const profitableWethL1Relay = {
       relayerFeePct: toBNWei("0.01"),
       newRelayerFeePct: toBNWei("0.1"),
@@ -113,7 +151,26 @@ describe("ProfitClient: Consider relay profit", async function () {
     expect(profitClientWithMinFee.isFillProfitable(profitableWethL1Relay, toBNWei(1))).to.be.true;
   });
 
-  it("Ignores newRelayerFeePct if it's lower than original relayerFeePct", async function () {
+  it("Considers deposits with newRelayerFeePct", async function () {
+    const l1Token: L1Token = tokens["WETH"];
+    hubPoolClient.setTokenInfoToReturn(l1Token);
+
+    const fillAmount: BigNumber = toBNWei(1);
+    const deposit = {
+      relayerFeePct: toBNWei("0.001"),
+      destinationChainId: 1,
+    } as Deposit;
+
+    let fill: FillProfit;
+    fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);
+    expect(fill.grossRelayerFeePct.eq(deposit.relayerFeePct));
+
+    deposit["newRelayerFeePct"] = toBNWei("0.1");
+    fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);
+    expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct));
+  });
+
+  it("Ignores newRelayerFeePct if it's lower than original relayerFeePct (old)", async function () {
     const profitableWethL1Relay = {
       relayerFeePct: toBNWei("0.1"),
       newRelayerFeePct: toBNWei("0.01"),
@@ -123,6 +180,27 @@ describe("ProfitClient: Consider relay profit", async function () {
     // Ignore gas cost but with a min fee of 0.03%.
     const profitClientWithMinFee = new MockProfitClient(spyLogger, hubPoolClient, {}, true, [], false, toBNWei("0.03"));
     expect(profitClientWithMinFee.isFillProfitable(profitableWethL1Relay, toBNWei(1))).to.be.true;
+  });
+
+  it("Ignores newRelayerFeePct if it's lower than original relayerFeePct", async function () {
+    const l1Token: L1Token = tokens["WETH"];
+    hubPoolClient.setTokenInfoToReturn(l1Token);
+
+    const deposit = {
+      relayerFeePct: toBNWei("0.1"),
+      newRelayerFeePct: toBNWei("0.01"),
+      destinationChainId: 1,
+    } as Deposit;
+    const fillAmount: BigNumber = toBNWei(1);
+
+    let fill: FillProfit;
+    fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);
+    expect(fill.grossRelayerFeePct.eq(deposit.relayerFeePct));
+
+    deposit.relayerFeePct = toBNWei(".001");
+    expect(deposit.relayerFeePct.lt(deposit.newRelayerFeePct)); // Sanity check
+    fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);
+    expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct));
   });
 
   it("Captures unprofitable fills", async function () {


### PR DESCRIPTION
    This commit introduces new profitability logic to the ProfitClient.
    The change currently has no functional impact, but prepares the
    ProfitClient to support user-configurable profit margins, rather than
    gross fee margins, as is currently the case.
    
    It also increases the reporting of profitability information by logging,
    but also by exposing the various outputs of the new profitability logic.
    
    A follow-up commit will activate this new logic in the production code.