### PR TITLE
improve(HubPoolClient): Warn on unexepcted token decimals

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -426,13 +426,7 @@ export class HubPoolClient {
     for (const info of tokenInfo) {
       if (!this.l1Tokens.find((token) => token.symbol === info.symbol)) {
         if (info.decimals > 0 && info.decimals <= 18) this.l1Tokens.push(info);
-        else {
-          this.logger.warn({
-            at: "HubPoolClient#update",
-            message: "Unsupported HubPool token.",
-            token: info,
-          });
-        }
+        else throw new Error(`Unsupported HubPool token: ${JSON.stringify(info)}`);
       }
     }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -424,7 +424,16 @@ export class HubPoolClient {
       Promise.all(uniqueL1Tokens.map(async (l1Token: string) => await this.hubPool.pooledTokens(l1Token))),
     ]);
     for (const info of tokenInfo) {
-      if (!this.l1Tokens.find((token) => token.symbol === info.symbol)) this.l1Tokens.push(info);
+      if (!this.l1Tokens.find((token) => token.symbol === info.symbol)) {
+        if (info.decimals > 0 && info.decimals <= 18) this.l1Tokens.push(info);
+        else {
+          this.logger.warn({
+            at: "HubPoolClient#update",
+            message: "Unsupported HubPool token.",
+            token: info,
+          });
+        }
+      }
     }
 
     uniqueL1Tokens.forEach((token: string, i) => {


### PR DESCRIPTION
Should _never_ happen in practice, but if it did then it would break a lot of assumptions in the bot. This therefore saves consumers of these L1Tokens from having to explicitly check.