### PR TITLE
chore(ProfitClient): Lint

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -88,11 +88,11 @@ export class ProfitClient {
     }
   }
 
-  getAllPrices() {
+  getAllPrices(): { [address: string]: BigNumber } {
     return this.tokenPrices;
   }
 
-  getPriceOfToken(token: string) {
+  getPriceOfToken(token: string): BigNumber {
     // Warn on this initially, and move to an assert() once any latent issues are resolved.
     // assert(this.tokenPrices[token] !== undefined, `Token ${token} not in price list.`);
     if (this.tokenPrices[token] === undefined) {
@@ -130,11 +130,11 @@ export class ProfitClient {
     };
   }
 
-  getUnprofitableFills() {
+  getUnprofitableFills(): { [chainId: number]: { deposit: Deposit; fillAmount: BigNumber }[] } {
     return this.unprofitableFills;
   }
 
-  clearUnprofitableFills() {
+  clearUnprofitableFills(): void {
     this.unprofitableFills = {};
   }
 
@@ -191,7 +191,7 @@ export class ProfitClient {
     };
   }
 
-  isFillProfitable(deposit: Deposit, fillAmount: BigNumber) {
+  isFillProfitable(deposit: Deposit, fillAmount: BigNumber): boolean {
     const newRelayerFeePct = toBN(deposit.newRelayerFeePct ?? 0);
     let relayerFeePct = toBN(deposit.relayerFeePct);
     // Use the maximum between the original newRelayerFeePct and any updated fee from speedups.
@@ -267,7 +267,7 @@ export class ProfitClient {
     return fillProfitable;
   }
 
-  captureUnprofitableFill(deposit: Deposit, fillAmount: BigNumber) {
+  captureUnprofitableFill(deposit: Deposit, fillAmount: BigNumber): void {
     this.logger.debug({ at: "ProfitClient", message: "Handling unprofitable fill", deposit, fillAmount });
     assign(this.unprofitableFills, [deposit.originChainId], [{ deposit, fillAmount }]);
   }
@@ -276,7 +276,7 @@ export class ProfitClient {
     return Object.keys(this.unprofitableFills).length != 0;
   }
 
-  async update() {
+  async update(): Promise<void> {
     const updates = [this.updateTokenPrices()];
 
     // Skip gas cost lookup if profitability is disabled. We still

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -45,8 +45,8 @@ function setDefaultTokenPrices(profitClient: MockProfitClient): void {
   );
 }
 
-// Set env LOG_IN_TEST to log to console.
-const { spyLogger } = createSpyLogger();
+// Define LOG_IN_TEST for logging to console.
+const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
 let hubPoolClient: MockHubPoolClient, profitClient: MockProfitClient;
 
 describe("ProfitClient: Consider relay profit", async function () {

--- a/test/ProfitClient.PriceRetrieval.ts
+++ b/test/ProfitClient.PriceRetrieval.ts
@@ -4,8 +4,6 @@ import { expect, createSpyLogger, winston, BigNumber, toBN } from "./utils";
 import { MockHubPoolClient } from "./mocks";
 import { ProfitClient, MATIC, WETH } from "../src/clients"; // Tested
 
-let hubPoolClient: MockHubPoolClient, spy: sinon.SinonSpy, spyLogger: winston.Logger;
-
 const mainnetTokens: Array<L1Token> = [
   // Checksummed addresses
   { symbol: "USDC", address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", decimals: 6 },
@@ -23,18 +21,21 @@ const mainnetTokens: Array<L1Token> = [
 ];
 
 class ProfitClientWithMockCoingecko extends ProfitClient {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   protected async coingeckoPrices(tokens: string[], platformId?: string) {
     return mainnetTokens.map((token) => {
       return { address: token.address, price: 1 };
     });
   }
 }
+
+// Define LOG_IN_TEST for logging to console.
+const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
+let hubPoolClient: MockHubPoolClient;
 let profitClient: ProfitClientWithMockCoingecko; // tested
 
 describe("ProfitClient: Price Retrieval", async function () {
   beforeEach(async function () {
-    ({ spy, spyLogger } = createSpyLogger());
-
     hubPoolClient = new MockHubPoolClient(null, null);
     mainnetTokens.forEach((token: L1Token) => hubPoolClient.addL1Token(token));
     profitClient = new ProfitClientWithMockCoingecko(spyLogger, hubPoolClient, {}, true, [], false, toBN(0));

--- a/test/mocks/MockProfitClient.ts
+++ b/test/mocks/MockProfitClient.ts
@@ -2,14 +2,14 @@ import { BigNumber } from "../utils";
 import { ProfitClient } from "../../src/clients";
 
 export class MockProfitClient extends ProfitClient {
-  setTokenPrices(tokenPrices: { [l1Token: string]: BigNumber }) {
+  setTokenPrices(tokenPrices: { [l1Token: string]: BigNumber }): void {
     this.tokenPrices = tokenPrices;
   }
 
-  setGasCosts(gasCosts: { [chainId: number]: BigNumber }) {
+  setGasCosts(gasCosts: { [chainId: number]: BigNumber }): void {
     this.totalGasCosts = gasCosts;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  async update() {}
+  async update(): Promise<void> {}
 }


### PR DESCRIPTION
Addresses 14 warnings raised by the linter:

```
across-protocol/relayer-v2/src/clients/ProfitClient.ts
   91:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
   95:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  133:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  137:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  194:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  270:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  279:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types

across-protocol/relayer-v2/test/ProfitClient.ConsiderProfitability.ts
  5:3  warning  'winston' is defined but never used  @typescript-eslint/no-unused-vars

across-protocol/relayer-v2/test/ProfitClient.PriceRetrieval.ts
  26:35  warning  'tokens' is defined but never used        @typescript-eslint/no-unused-vars
  26:53  warning  'platformId' is defined but never used    @typescript-eslint/no-unused-vars
  36:8   warning  'spy' is assigned a value but never used  @typescript-eslint/no-unused-vars

across-protocol/relayer-v2/test/mocks/MockProfitClient.ts
   5:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
   9:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  14:3  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
```