### PR TITLE
improve(ProfitClient): Activate profitability logic

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -151,7 +151,7 @@ export class ProfitClient {
     l1Token ??= this.hubPoolClient.getTokenInfoForDeposit(deposit);
     assert(l1Token !== undefined, `No L1 token found for deposit ${JSON.stringify(deposit)}`);
     const tokenPriceUsd = this.getPriceOfToken(l1Token.address);
-    if (tokenPriceUsd.lte(0)) throw new Error(`Unable to determine ${l1Token.symbol}) L1 token price`);
+    if (tokenPriceUsd.lte(0)) throw new Error(`Unable to determine ${l1Token.symbol} L1 token price`);
 
     // Normalise to 18 decimals.
     const scaledFillAmount =

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -17,6 +17,7 @@ type CoinGeckoPrice = {
 // @todo: These don't belong in the ProfitClient; they should be relocated.
 export const MATIC = "0x7D1AfA7B718fb893dB30A3aBc0Cfc608AaCfeBB0";
 export const USDC = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48";
+export const WBTC = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599";
 export const WETH = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
 
 // note: All FillProfit BigNumbers are scaled to 18 decimals unless specified otherwise.
@@ -68,6 +69,7 @@ export class ProfitClient {
   // Queries needed to fetch relay gas costs.
   private relayerFeeQueries: { [chainId: number]: relayFeeCalculator.QueryInterface } = {};
 
+  // @todo: Consolidate this set of args before it grows legs and runs away from us.
   constructor(
     readonly logger: winston.Logger,
     readonly hubPoolClient: HubPoolClient,
@@ -76,7 +78,8 @@ export class ProfitClient {
     readonly enabledChainIds: number[],
     // Default to throwing errors if fetching token prices fails.
     readonly ignoreTokenPriceFailures: boolean = false,
-    readonly minRelayerFeePct: BigNumber = toBN(constants.RELAYER_MIN_FEE_PCT)
+    readonly minRelayerFeePct: BigNumber = toBN(constants.RELAYER_MIN_FEE_PCT),
+    readonly debugProfitability: boolean = false
   ) {
     this.coingecko = new Coingecko();
 
@@ -191,80 +194,35 @@ export class ProfitClient {
     };
   }
 
-  isFillProfitable(deposit: Deposit, fillAmount: BigNumber): boolean {
-    const newRelayerFeePct = toBN(deposit.newRelayerFeePct ?? 0);
-    let relayerFeePct = toBN(deposit.relayerFeePct);
-    // Use the maximum between the original newRelayerFeePct and any updated fee from speedups.
-    if (relayerFeePct.lt(newRelayerFeePct)) {
-      relayerFeePct = newRelayerFeePct;
-    }
+  isFillProfitable(deposit: Deposit, fillAmount: BigNumber, l1Token?: L1Token): boolean {
+    const fill: FillProfit = this.calculateFillProfitability(deposit, fillAmount, l1Token);
 
-    if (relayerFeePct.lt(this.minRelayerFeePct)) {
+    if (!fill.fillProfitable || this.debugProfitability) {
+      const { depositId, originChainId } = deposit;
+      const profitable = fill.fillProfitable ? "profitable" : "unprofitable";
       this.logger.debug({
-        at: "ProfitClient",
-        message: "Relayer fee % < minimum relayer fee %",
+        at: "ProfitClient#isFillProfitable",
+        message: `${l1Token.symbol} deposit ${depositId} on chain ${originChainId} is ${profitable}`,
+        deposit,
+        l1Token,
+        fillAmount,
+        fillAmountUsd: fill.fillAmountUsd,
+        grossRelayerFeePct: `${formatFeePct(fill.grossRelayerFeePct)}%`,
+        nativeGasCost: fill.nativeGasCost,
+        gasPriceUsd: fill.gasPriceUsd,
+        relayerCapitalUsd: `${fill.relayerCapitalUsd}`,
+        grossRelayerFeeUsd: fill.grossRelayerFeeUsd,
+        gasCostUsd: fill.gasCostUsd,
+        netRelayerFeeUsd: `${fill.netRelayerFeeUsd}`,
+        netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)}%`,
         minRelayerFeePct: `${formatFeePct(this.minRelayerFeePct)}%`,
+        fillProfitable: fill.fillProfitable,
       });
-      return false;
     }
 
-    if (relayerFeePct.eq(toBN(0))) {
-      this.logger.debug({ at: "ProfitClient", message: "Deposit set 0 relayerFeePct. Rejecting relay" });
-      return false;
-    }
-
-    // This should happen after the previous checks as we don't want to turn them off when profitability is disabled.
-    // TODO: Revisit whether this makes sense once we have capital fee evaluation.
-    if (this.ignoreProfitability) {
-      this.logger.debug({ at: "ProfitClient", message: "Profitability check is disabled. Accepting relay" });
-      return true;
-    }
-
-    const l1TokenInfo = this.hubPoolClient.getTokenInfoForDeposit(deposit);
-    if (!l1TokenInfo)
-      throw new Error(
-        `ProfitClient::isFillProfitable missing l1TokenInfo for deposit with origin token: ${deposit.originToken}`
-      );
-    const { decimals, address: l1Token } = l1TokenInfo;
-    const tokenPriceInUsd = this.getPriceOfToken(l1Token);
-    const fillRevenueInRelayedToken = relayerFeePct.mul(fillAmount).div(toBN(10).pow(decimals));
-    const fillRevenueInUsd = fillRevenueInRelayedToken.mul(tokenPriceInUsd).div(toBNWei(1));
-
-    // Consider gas cost.
-    const totalGasCostWei = this.getTotalGasCost(deposit.destinationChainId);
-    if (totalGasCostWei.eq(toBN(0))) {
-      const chainId = deposit.destinationChainId;
-      const errorMsg = `Missing total gas cost for ${chainId}. This likely indicates some gas cost request failed`;
-      this.logger.warn({
-        at: "ProfitClient",
-        message: errorMsg,
-        allGasCostsFetched: this.totalGasCosts,
-        chainId,
-      });
-      throw new Error(errorMsg);
-    }
-
-    const gasCostInUsd = totalGasCostWei
-      .mul(this.getPriceOfToken(GAS_TOKEN_BY_CHAIN_ID[deposit.destinationChainId]))
-      .div(toBN(10).pow(GAS_TOKEN_DECIMALS));
-
-    // How much minimumAcceptableRevenue is scaled. If relayer discount is 0 then need minimumAcceptableRevenue at min.
-    const fillProfitInUsd = fillRevenueInUsd.sub(gasCostInUsd);
-    const fillProfitable = fillProfitInUsd.gte(toBN(0));
-    this.logger.debug({
-      at: "ProfitClient",
-      message: "Considered fill profitability",
-      deposit,
-      fillAmount,
-      tokenPriceInUsd,
-      fillRevenueInRelayedToken,
-      fillRevenueInUsd,
-      totalGasCostWei,
-      gasCostInUsd,
-      fillProfitInUsd,
-      fillProfitable,
-    });
-    return fillProfitable;
+    // If profitability is disabled, ensure _at least_ that the relayerFeePct >= minRelayerFeePct.
+    // This is a temporary measure and can hopefully be removed (together with ignoreProfitability) in future.
+    return fill.fillProfitable || (this.ignoreProfitability && fill.grossRelayerFeePct.gte(this.minRelayerFeePct));
   }
 
   captureUnprofitableFill(deposit: Deposit, fillAmount: BigNumber): void {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -100,7 +100,7 @@ export class Relayer {
       }
 
       if (this.clients.tokenClient.hasBalanceForFill(deposit, unfilledAmount)) {
-        if (this.clients.profitClient.isFillProfitable(deposit, unfilledAmount)) {
+        if (this.clients.profitClient.isFillProfitable(deposit, unfilledAmount, l1Token)) {
           this.fillRelay(deposit, unfilledAmount);
         } else {
           this.clients.profitClient.captureUnprofitableFill(deposit, unfilledAmount);

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -41,7 +41,8 @@ export async function constructRelayerClients(
     config.ignoreProfitability,
     enabledChainIds,
     config.ignoreTokenPriceFailures,
-    config.minRelayerFeePct
+    config.minRelayerFeePct,
+    config.debugProfitability
   );
 
   const adapterManager = new AdapterManager(logger, spokePoolClients, commonClients.hubPoolClient, [

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -7,6 +7,7 @@ export class RelayerConfig extends CommonConfig {
   readonly inventoryConfig: InventoryConfig;
   // Whether relay profitability is considered. If false, relayers will attempt to relay all deposits.
   readonly ignoreProfitability: boolean;
+  readonly debugProfitability: boolean;
   // Whether token price fetch failures will be ignored when computing relay profitability.
   // If this is false, the relayer will throw an error when fetching prices fails.
   readonly ignoreTokenPriceFailures: boolean;
@@ -22,6 +23,7 @@ export class RelayerConfig extends CommonConfig {
   constructor(env: ProcessEnv) {
     const {
       RELAYER_DESTINATION_CHAINS,
+      DEBUG_PROFITABILITY,
       IGNORE_PROFITABILITY,
       IGNORE_TOKEN_PRICE_FAILURES,
       RELAYER_INVENTORY_CONFIG,
@@ -69,6 +71,7 @@ export class RelayerConfig extends CommonConfig {
         });
       });
     }
+    this.debugProfitability = DEBUG_PROFITABILITY === "true";
     this.ignoreProfitability = IGNORE_PROFITABILITY === "true";
     this.ignoreTokenPriceFailures = IGNORE_TOKEN_PRICE_FAILURES === "true";
     this.sendingRelaysEnabled = SEND_RELAYS === "true";

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -1,30 +1,22 @@
-import {
-  BigNumber,
-  expect,
-  createSpyLogger,
-  winston,
-  toBNWei,
-  toBN,
-  ethers,
-  deploySpokePoolWithToken,
-  originChainId,
-  destinationChainId,
-} from "./utils";
+import { BigNumber, formatFeePct, toBN, toBNWei } from "../src/utils";
+import { expect, createSpyLogger, winston, ethers, deploySpokePoolWithToken, originChainId, destinationChainId } from "./utils";
 import { MockHubPoolClient, MockProfitClient } from "./mocks";
 import { Deposit, L1Token } from "../src/interfaces";
-import { FillProfit, GAS_TOKEN_BY_CHAIN_ID, SpokePoolClient, MATIC, USDC, WETH } from "../src/clients";
+import { FillProfit, GAS_TOKEN_BY_CHAIN_ID, SpokePoolClient, MATIC, USDC, WBTC, WETH } from "../src/clients";
 
 const chainIds: number[] = [1, 10, 137, 288, 42161];
 
 const tokens: { [symbol: string]: L1Token } = {
   MATIC: { address: MATIC, decimals: 18, symbol: "MATIC" },
   USDC: { address: USDC, decimals: 6, symbol: "USDC" },
+  WBTC: { address: WBTC, decimals: 8, symbol: "WBTC" },
   WETH: { address: WETH, decimals: 18, symbol: "WETH" },
 };
 
 const tokenPrices: { [symbol: string]: BigNumber } = {
   MATIC: toBNWei("0.4"),
   USDC: toBNWei(1),
+  WBTC: toBNWei(21000),
   WETH: toBNWei(3000),
 };
 
@@ -45,9 +37,37 @@ function setDefaultTokenPrices(profitClient: MockProfitClient): void {
   );
 }
 
+const minRelayerFeeBps = 3;
+const minRelayerFeePct = toBNWei(minRelayerFeeBps).div(1e4);
+
+// relayerFeePct clamped at 50 bps by each SpokePool.
+const maxRelayerFeeBps = 50;
+const maxRelayerFeePct = toBNWei(maxRelayerFeeBps).div(1e4);
+
 // Define LOG_IN_TEST for logging to console.
 const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
 let hubPoolClient: MockHubPoolClient, profitClient: MockProfitClient;
+
+function testProfitability(deposit: Deposit, fillAmountUsd: BigNumber, gasCostUsd: BigNumber): FillProfit {
+  const { relayerFeePct } = deposit;
+
+  const grossRelayerFeeUsd = fillAmountUsd.mul(relayerFeePct).div(toBNWei(1));
+  const relayerCapitalUsd = fillAmountUsd.sub(grossRelayerFeeUsd);
+
+  const minRelayerFeeUsd = relayerCapitalUsd.mul(minRelayerFeePct).div(toBNWei(1));
+  const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd);
+  const netRelayerFeePct = netRelayerFeeUsd.mul(toBNWei(1)).div(relayerCapitalUsd);
+
+  const fillProfitable = netRelayerFeeUsd.gte(minRelayerFeeUsd);
+
+  return {
+    grossRelayerFeeUsd,
+    netRelayerFeePct,
+    relayerCapitalUsd,
+    netRelayerFeeUsd,
+    fillProfitable,
+  } as FillProfit;
+}
 
 describe("ProfitClient: Consider relay profit", async function () {
   beforeEach(async function () {
@@ -59,7 +79,21 @@ describe("ProfitClient: Consider relay profit", async function () {
     const spokePoolClient_1 = new SpokePoolClient(spyLogger, spokePool_1.connect(owner), null, originChainId);
     const spokePoolClient_2 = new SpokePoolClient(spyLogger, spokePool_2.connect(owner), null, destinationChainId);
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
-    profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, false, [], false, toBN(0));
+
+    const ignoreProfitability = false;
+    const ignoreTokenPriceFailures = false;
+    const debugProfitability = true;
+
+    profitClient = new MockProfitClient(
+      spyLogger,
+      hubPoolClient,
+      spokePoolClients,
+      ignoreProfitability,
+      [],
+      ignoreTokenPriceFailures,
+      minRelayerFeePct,
+      debugProfitability
+    );
 
     // Load per-chain gas cost (gas consumed * gas price in Wei), in native gas token.
     profitClient.setGasCosts(gasCost);
@@ -90,24 +124,12 @@ describe("ProfitClient: Consider relay profit", async function () {
     });
   });
 
-  it("Considers gas cost when computing protfitability", async function () {
-    // Create a relay that is clearly profitable. Currency of the relay is WETH with a fill amount of 0.1 WETH, price per
-    // WETH set at 3000 and relayer fee % of 0.1% which is a revenue of 0.3.
-    // However, since MATIC costs $0.4, the profit is only 1.2 - 0.3 = $0.9 after gas, which is unprofitable.
-    const relaySize = toBNWei("0.1"); // 1 ETH
-    hubPoolClient.setTokenInfoToReturn(tokens["WETH"]);
-
-    const relay = { relayerFeePct: toBNWei("0.001"), destinationChainId: 137 } as Deposit;
-    profitClient.setGasCosts({ 137: toBNWei(1) });
-    expect(profitClient.isFillProfitable(relay, relaySize)).to.be.false;
-  });
-
   it("Return 0 when gas cost fails to be fetched", async function () {
     profitClient.setGasCosts({ 137: undefined });
     expect(profitClient.getTotalGasCost(137)).to.equal(toBN(0));
   });
 
-  it("Verify gas price lookup failures", function () {
+  it("Verify token price and gas cost lookup failures", function () {
     const l1Token: L1Token = tokens["WETH"];
     const fillAmount = toBNWei(1);
 
@@ -138,52 +160,73 @@ describe("ProfitClient: Consider relay profit", async function () {
     });
   });
 
-  it("Handles non-standard token decimals when considering a relay profitability", async function () {
-    // Create a relay that is clearly profitable. Currency of the relay is USDC with a fill amount of 1000 USDC with a
-    // price per USDC of 1 USD. Set the relayer Fee to 10% should make this clearly relayable.
-    const relaySize = toBN(1000).mul(toBN(10).pow(6)); // 1000e6 for 1000 USDC.
+  /**
+   * Note: This test is a bit of a monster. It iterates over all combinations of:
+   * - Configured destination chains.
+   * - Configured L1 tokens.
+   * - A range of fill amounts.
+   * - A range of relayerFeePct values (sane and insane).
+   *
+   * The utility of this test is also _somewhat_ debatable, since it implements
+   * quite similar logic to the ProfitClient itself. A logic error in both
+   * implementations is certainly possible. However, relay pricing is quite
+   * dynamic, and the development of this test _did_ catch a few unexpected
+   * corner cases. This approach does however require fairly careful analysis of
+   * the test results to make sure that they are sane. Sampling is recommended.
+   */
+  it("Considers gas cost when computing profitability", async function () {
+    const fillAmounts = [".001", "0.1", 1, 10, 100, 1_000, 100_000];
 
-    // Relayer fee is 10% or $100. Gas cost is 0.01 * 3000 = $30. This leaves a profit of $70.
-    hubPoolClient.setTokenInfoToReturn(tokens["USDC"]);
-    const profitableUsdcL1Relay = { relayerFeePct: toBNWei("0.1"), destinationChainId: 1 } as Deposit;
-    profitClient.setGasCosts({ 1: toBNWei("0.01") });
-    expect(profitClient.isFillProfitable(profitableUsdcL1Relay, relaySize)).to.be.true;
+    chainIds.forEach((destinationChainId: number) => {
+      const { gasCostUsd } = profitClient.calculateFillCost(destinationChainId);
 
-    // Relayer fee is still $100. Gas cost is 0.1 * 3000 = $300. This leaves a loss of $200.
-    const unprofitableUsdcL1Relay = { relayerFeePct: toBNWei("0.1"), destinationChainId: 1 } as Deposit;
-    profitClient.setGasCosts({ 1: toBNWei("0.1") });
-    expect(profitClient.isFillProfitable(unprofitableUsdcL1Relay, relaySize)).to.be.false;
+      Object.values(tokens).forEach((l1Token: L1Token) => {
+        const tokenPriceUsd = profitClient.getPriceOfToken(l1Token.address);
+        hubPoolClient.setTokenInfoToReturn(l1Token);
 
-    // Relayer fee is still $100. Gas cost is 0.033 * 3000 = $99. This leaves a small profit of $1.
-    const marginallyProfitableUsdcL1Relay = { relayerFeePct: toBNWei("0.1"), destinationChainId: 1 } as Deposit;
-    profitClient.setGasCosts({ 1: toBNWei("0.033") });
-    expect(profitClient.isFillProfitable(marginallyProfitableUsdcL1Relay, relaySize)).to.be.true;
+        fillAmounts.forEach((_fillAmount: number | string) => {
+          const fillAmount = toBNWei(_fillAmount);
+          const nativeFillAmount = toBNWei(_fillAmount, l1Token.decimals);
+          spyLogger.debug({ message: `Testing fillAmount ${_fillAmount} (${fillAmount}).` });
 
-    // Equally, works on non-mainnet chainIDs.
-    const unprofitableUsdcL2Relay = { relayerFeePct: toBNWei("0.1"), destinationChainId: 10 } as Deposit;
-    profitClient.setGasCosts({ 10: toBNWei("0.1") });
-    expect(profitClient.isFillProfitable(unprofitableUsdcL2Relay, relaySize)).to.be.false;
-    profitClient.setGasCosts({ 10: toBNWei("0.033") });
-    const marginallyUsdcL2ProfitableRelay = { relayerFeePct: toBNWei("0.1"), destinationChainId: 10 } as Deposit;
-    expect(profitClient.isFillProfitable(marginallyUsdcL2ProfitableRelay, relaySize)).to.be.true;
-  });
+          const fillAmountUsd = fillAmount.mul(tokenPriceUsd).div(toBNWei(1));
+          const gasCostPct = gasCostUsd.mul(toBNWei(1)).div(fillAmountUsd);
 
-  it("Considers deposits with relayer fee below min required unprofitable", async function () {
-    const profitableWethL1Relay = { relayerFeePct: toBNWei("0.01"), destinationChainId: 1 } as Deposit;
-    // Ignore gas cost but with a min fee of 0.03%.
-    const profitClientWithMinFee = new MockProfitClient(spyLogger, hubPoolClient, {}, true, [], false, toBNWei("0.03"));
-    expect(profitClientWithMinFee.isFillProfitable(profitableWethL1Relay, toBNWei(1))).to.be.false;
-  });
+          const relayerFeePcts: BigNumber[] = [
+            toBNWei(-1),
+            toBNWei(0),
+            minRelayerFeePct.div(4),
+            minRelayerFeePct.div(2),
+            minRelayerFeePct,
+            minRelayerFeePct.add(gasCostPct),
+            minRelayerFeePct.add(gasCostPct).add(1),
+            minRelayerFeePct.add(gasCostPct).add(toBNWei(1)),
+          ];
 
-  it("Considers deposits with newRelayerFeePct (old)", async function () {
-    const profitableWethL1Relay = {
-      relayerFeePct: toBNWei("0.01"),
-      newRelayerFeePct: toBNWei("0.1"),
-      destinationChainId: 1,
-    } as Deposit;
-    // Ignore gas cost but with a min fee of 0.03%.
-    const profitClientWithMinFee = new MockProfitClient(spyLogger, hubPoolClient, {}, true, [], false, toBNWei("0.03"));
-    expect(profitClientWithMinFee.isFillProfitable(profitableWethL1Relay, toBNWei(1))).to.be.true;
+          relayerFeePcts.forEach((_relayerFeePct: BigNumber) => {
+            const relayerFeePct = _relayerFeePct.gt(maxRelayerFeePct) ? maxRelayerFeePct : _relayerFeePct;
+            const deposit = { relayerFeePct, destinationChainId } as Deposit;
+
+            const fill: FillProfit = testProfitability(deposit, fillAmountUsd, gasCostUsd);
+            spyLogger.debug({
+              message: `Expect ${l1Token.symbol} deposit is ${fill.fillProfitable ? "" : "un"}profitable:`,
+              fillAmount,
+              fillAmountUsd,
+              gasCostUsd,
+              grossRelayerFeePct: `${formatFeePct(relayerFeePct)} %`,
+              gasCostPct: `${formatFeePct(gasCostPct)} %`,
+              relayerCapitalUsd: fill.relayerCapitalUsd,
+              minRelayerFeePct: `${formatFeePct(minRelayerFeePct)} %`,
+              minRelayerFeeUsd: minRelayerFeePct.mul(fillAmountUsd).div(toBNWei(1)),
+              netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)} %`,
+              netRelayerFeeUsd: fill.netRelayerFeeUsd,
+            });
+
+            expect(profitClient.isFillProfitable(deposit, nativeFillAmount, l1Token)).to.equal(fill.fillProfitable);
+          });
+        });
+      });
+    });
   });
 
   it("Considers deposits with newRelayerFeePct", async function () {
@@ -203,18 +246,6 @@ describe("ProfitClient: Consider relay profit", async function () {
     deposit["newRelayerFeePct"] = toBNWei("0.1");
     fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);
     expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct));
-  });
-
-  it("Ignores newRelayerFeePct if it's lower than original relayerFeePct (old)", async function () {
-    const profitableWethL1Relay = {
-      relayerFeePct: toBNWei("0.1"),
-      newRelayerFeePct: toBNWei("0.01"),
-      destinationChainId: 1,
-    } as Deposit;
-    profitClient.setGasCosts({ 1: toBNWei("0.01") });
-    // Ignore gas cost but with a min fee of 0.03%.
-    const profitClientWithMinFee = new MockProfitClient(spyLogger, hubPoolClient, {}, true, [], false, toBNWei("0.03"));
-    expect(profitClientWithMinFee.isFillProfitable(profitableWethL1Relay, toBNWei(1))).to.be.true;
   });
 
   it("Ignores newRelayerFeePct if it's lower than original relayerFeePct", async function () {

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -1,5 +1,13 @@
 import { BigNumber, formatFeePct, toBN, toBNWei } from "../src/utils";
-import { expect, createSpyLogger, winston, ethers, deploySpokePoolWithToken, originChainId, destinationChainId } from "./utils";
+import {
+  expect,
+  createSpyLogger,
+  winston,
+  ethers,
+  deploySpokePoolWithToken,
+  originChainId,
+  destinationChainId,
+} from "./utils";
 import { MockHubPoolClient, MockProfitClient } from "./mocks";
 import { Deposit, L1Token } from "../src/interfaces";
 import { FillProfit, GAS_TOKEN_BY_CHAIN_ID, SpokePoolClient, MATIC, USDC, WBTC, WETH } from "../src/clients";

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -13,8 +13,8 @@ import { deploySpokePoolWithToken, enableRoutesOnHubPool, destinationChainId } f
 import { originChainId, sinon, toBNWei } from "./utils";
 import { amountToLp, defaultTokenConfig } from "./constants";
 import { SpokePoolClient, HubPoolClient, AcrossConfigStoreClient, MultiCallerClient } from "../src/clients";
-import { TokenClient, ProfitClient } from "../src/clients";
-import { MockInventoryClient } from "./mocks";
+import { TokenClient } from "../src/clients";
+import { MockInventoryClient, MockProfitClient } from "./mocks";
 
 import { Relayer } from "../src/relayer/Relayer";
 import { RelayerConfig } from "../src/relayer/RelayerConfig"; // Tested
@@ -28,7 +28,7 @@ let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
 let spokePoolClients: { [chainId: number]: SpokePoolClient };
 let configStoreClient: AcrossConfigStoreClient, hubPoolClient: HubPoolClient, tokenClient: TokenClient;
 let relayerInstance: Relayer;
-let multiCallerClient: MultiCallerClient, profitClient: ProfitClient;
+let multiCallerClient: MultiCallerClient, profitClient: MockProfitClient;
 
 describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
   beforeEach(async function () {
@@ -60,7 +60,9 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     );
     spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
-    profitClient = new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, true, []); // Set relayer discount to 100%.
+    profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, true, []); // Set relayer discount to 100%.
+    profitClient.testInit();
+
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -4,8 +4,8 @@ import { lastSpyLogIncludes, toBNWei, createSpyLogger, deployConfigStore } from 
 import { deployAndConfigureHubPool, winston } from "./utils";
 import { amountToLp, defaultTokenConfig } from "./constants";
 import { SpokePoolClient, HubPoolClient, AcrossConfigStoreClient, MultiCallerClient } from "../src/clients";
-import { TokenClient, ProfitClient } from "../src/clients";
-import { MockInventoryClient } from "./mocks";
+import { TokenClient } from "../src/clients";
+import { MockInventoryClient, MockProfitClient } from "./mocks";
 
 import { Relayer } from "../src/relayer/Relayer";
 import { RelayerConfig } from "../src/relayer/RelayerConfig"; // Tested
@@ -18,7 +18,7 @@ let spy: sinon.SinonSpy, spyLogger: winston.Logger;
 let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
 let configStoreClient: AcrossConfigStoreClient, hubPoolClient: HubPoolClient, tokenClient: TokenClient;
 let relayerInstance: Relayer;
-let multiCallerClient: MultiCallerClient, profitClient: ProfitClient;
+let multiCallerClient: MultiCallerClient, profitClient: MockProfitClient;
 
 describe("Relayer: Token balance shortfall", async function () {
   beforeEach(async function () {
@@ -48,7 +48,9 @@ describe("Relayer: Token balance shortfall", async function () {
     );
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
-    profitClient = new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, true, []); // Set the profit discount to 1 (ignore relay cost.)
+    profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, true, []); // Set the profit discount to 1 (ignore relay cost.)
+    profitClient.testInit();
+
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -20,11 +20,10 @@ import {
   SpokePoolClient,
   HubPoolClient,
   AcrossConfigStoreClient,
-  ProfitClient,
   MultiCallerClient,
   TokenClient,
 } from "../src/clients";
-import { MockInventoryClient } from "./mocks";
+import { MockInventoryClient, MockProfitClient } from "./mocks";
 
 // Tested
 import { Relayer } from "../src/relayer/Relayer";
@@ -40,6 +39,7 @@ const { spy, spyLogger } = createSpyLogger();
 let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
 let configStoreClient: AcrossConfigStoreClient, hubPoolClient: HubPoolClient;
 let multiCallerClient: MultiCallerClient, tokenClient: TokenClient;
+let profitClient: MockProfitClient;
 
 let relayerInstance: Relayer;
 
@@ -71,6 +71,8 @@ describe("Relayer: Unfilled Deposits", async function () {
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     multiCallerClient = new MultiCallerClient(spyLogger);
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
+    profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, true, []);
+    profitClient.testInit();
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,
@@ -78,7 +80,7 @@ describe("Relayer: Unfilled Deposits", async function () {
         spokePoolClients,
         hubPoolClient,
         configStoreClient,
-        profitClient: new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, true, []),
+        profitClient,
         tokenClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),

--- a/test/mocks/MockProfitClient.ts
+++ b/test/mocks/MockProfitClient.ts
@@ -16,6 +16,14 @@ export class MockProfitClient extends ProfitClient {
     GAS_TOKEN_BY_CHAIN_ID[1337] = WETH;
 
     this.setTokenPrices({
+      // A collection of various token addresses that are used during test.
+      // Haven't been able to identify where some of these addresses come from...
+      "0xBBeeB24180F4Fd09C7738eB5d09e1067263534Fd": toBNWei(1),
+      "0x3946560dD834D3cE930aDbbE0260FB05ef3B8b92": toBNWei(1),
+      "0xD2D44DeD37881Fe7A98B7bfF2A6eB024171715c6": toBNWei(1),
+      "0xDDF91FE22B61E408107570675f89362947048580": toBNWei(1),
+      "0xd9fEc8238711935D6c8d79Bef2B9546ef23FC046": toBNWei(1),
+      "0x198e48AfAF7b7eb1e6CcFbb14458A83FFc618967": toBNWei(1),
       "0x9c65f85425c619A6cB6D29fF8d57ef696323d188": toBNWei(1),
       "0x5FeaeBfB4439F3516c74939A9D04e95AFE82C4ae": toBNWei(1),
       "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E": toBNWei(1),

--- a/test/mocks/MockProfitClient.ts
+++ b/test/mocks/MockProfitClient.ts
@@ -1,5 +1,5 @@
-import { BigNumber } from "../utils";
-import { ProfitClient } from "../../src/clients";
+import { BigNumber, toBN, toBNWei } from "../utils";
+import { GAS_TOKEN_BY_CHAIN_ID, ProfitClient, WETH } from "../../src/clients";
 
 export class MockProfitClient extends ProfitClient {
   setTokenPrices(tokenPrices: { [l1Token: string]: BigNumber }): void {
@@ -8,6 +8,25 @@ export class MockProfitClient extends ProfitClient {
 
   setGasCosts(gasCosts: { [chainId: number]: BigNumber }): void {
     this.totalGasCosts = gasCosts;
+  }
+
+  // Some tests run against mocked chains, so hack in the necessary parts
+  testInit(): void {
+    GAS_TOKEN_BY_CHAIN_ID[666] = WETH;
+    GAS_TOKEN_BY_CHAIN_ID[1337] = WETH;
+
+    this.setTokenPrices({
+      "0x9c65f85425c619A6cB6D29fF8d57ef696323d188": toBNWei(1),
+      "0x5FeaeBfB4439F3516c74939A9D04e95AFE82C4ae": toBNWei(1),
+      "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E": toBNWei(1),
+      "0x2B0d36FACD61B71CC05ab8F3D2355ec3631C0dd5": toBNWei(1),
+      "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": toBNWei(1),
+    });
+
+    this.setGasCosts({
+      666: toBN(100_000),
+      1337: toBN(100_000),
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
This commit enables the new profitability logic that has been introduced in recent ProfitClient work.

The env var MIN_RELAYER_FEE_PCT is now more strict, and enforces a minimum fee as a percentage of the amount to be relayers _after_ taking the gas cost into account.

Additionally, more logging/diagnostic information is now available via the DEBUG_PROFITABILITY env var.