### PR TITLE
fix(relayer): Ignore deposits with quote time in future

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -66,7 +66,7 @@ export const MIN_DEPOSIT_CONFIRMATIONS: { [threshold: number | string]: { [chain
     42161: 0,
   },
 };
-export const QUOTE_TIME_BUFFER = 12 * 60 * 2; // 2 blocks on Mainnet.
+export const QUOTE_TIME_BUFFER = 12 * 60 * 5; // 5 blocks on Mainnet.
 
 // Optimism, ethereum can do infinity lookbacks. boba and Arbitrum limited to 100000 on infura.
 export const CHAIN_MAX_BLOCK_LOOKBACK = {

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -66,6 +66,7 @@ export const MIN_DEPOSIT_CONFIRMATIONS: { [threshold: number | string]: { [chain
     42161: 0,
   },
 };
+export const QUOTE_TIME_BUFFER = 12 * 60 * 2; // 2 blocks on Mainnet.
 
 // Optimism, ethereum can do infinity lookbacks. boba and Arbitrum limited to 100000 on infura.
 export const CHAIN_MAX_BLOCK_LOOKBACK = {

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -66,7 +66,7 @@ export const MIN_DEPOSIT_CONFIRMATIONS: { [threshold: number | string]: { [chain
     42161: 0,
   },
 };
-export const QUOTE_TIME_BUFFER = 12 * 60 * 5; // 5 blocks on Mainnet.
+export const QUOTE_TIME_BUFFER = 12 * 5; // 5 blocks on Mainnet.
 
 // Optimism, ethereum can do infinity lookbacks. boba and Arbitrum limited to 100000 on infura.
 export const CHAIN_MAX_BLOCK_LOOKBACK = {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -86,10 +86,9 @@ export class Relayer {
 
     // Require that all fillable deposits meet the minimum specified number of confirmations.
     const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.maxUnfilledDepositLookBack)
-      .filter((x) => x.deposit.quoteTimestamp <= latestHubPoolTime)
       .filter((x) => {
         return (
-          x.deposit.quoteTimestamp <= latestHubPoolTime &&
+          x.deposit.quoteTimestamp + this.config.quoteTimeBuffer <= latestHubPoolTime &&
           x.deposit.originBlockNumber <=
             this.clients.spokePoolClients[x.deposit.originChainId].latestBlockNumber -
               mdcPerChain[x.deposit.originChainId]

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -47,13 +47,13 @@ export class Relayer {
       this.clients.spokePoolClients,
       this.maxUnfilledDepositLookBack
     )
-    .filter((x) => x.deposit.quoteTimestamp <= latestHubPoolTime)
-    .reduce((agg, curr) => {
-      const unfilledAmountUsd = this.clients.profitClient.getFillAmountInUsd(curr.deposit, curr.unfilledAmount);
-      if (!agg[curr.deposit.originChainId]) agg[curr.deposit.originChainId] = toBN(0);
-      agg[curr.deposit.originChainId] = agg[curr.deposit.originChainId].add(unfilledAmountUsd);
-      return agg;
-    }, {});
+      .filter((x) => x.deposit.quoteTimestamp <= latestHubPoolTime)
+      .reduce((agg, curr) => {
+        const unfilledAmountUsd = this.clients.profitClient.getFillAmountInUsd(curr.deposit, curr.unfilledAmount);
+        if (!agg[curr.deposit.originChainId]) agg[curr.deposit.originChainId] = toBN(0);
+        agg[curr.deposit.originChainId] = agg[curr.deposit.originChainId].add(unfilledAmountUsd);
+        return agg;
+      }, {});
 
     // Sort thresholds in ascending order.
     const minimumDepositConfirmationThresholds = Object.keys(this.config.minDepositConfirmations)

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -36,26 +36,16 @@ export class Relayer {
     // TODO: Note this does not consider the price of the token which will be added once the profitability module is
     // added to this bot.
 
-    // Remove deposits whose deposit quote timestamp is > HubPool's current time, because there is a risk that
-    // the ConfigStoreClient's computed realized lp fee % is incorrect for quote times in the future. The client
-    // would use the current utilization as an input to compute this fee %, but if the utilization is different for the
-    // actual block that is mined at the deposit quote time, then the fee % would be different. This should not
-    // impact the bridge users' UX in the normal path because deposit UI's have no reason to set quote times in the
-    // future.
-    const latestHubPoolTime = this.clients.hubPoolClient.currentTime;
-
     // Sum the total unfilled deposit amount per origin chain and set a MDC for that chain.
     const unfilledDepositAmountsPerChain: { [chainId: number]: BigNumber } = getUnfilledDeposits(
       this.clients.spokePoolClients,
       this.maxUnfilledDepositLookBack
-    )
-      .filter((x) => x.deposit.quoteTimestamp <= latestHubPoolTime)
-      .reduce((agg, curr) => {
-        const unfilledAmountUsd = this.clients.profitClient.getFillAmountInUsd(curr.deposit, curr.unfilledAmount);
-        if (!agg[curr.deposit.originChainId]) agg[curr.deposit.originChainId] = toBN(0);
-        agg[curr.deposit.originChainId] = agg[curr.deposit.originChainId].add(unfilledAmountUsd);
-        return agg;
-      }, {});
+    ).reduce((agg, curr) => {
+      const unfilledAmountUsd = this.clients.profitClient.getFillAmountInUsd(curr.deposit, curr.unfilledAmount);
+      if (!agg[curr.deposit.originChainId]) agg[curr.deposit.originChainId] = toBN(0);
+      agg[curr.deposit.originChainId] = agg[curr.deposit.originChainId].add(unfilledAmountUsd);
+      return agg;
+    }, {});
 
     // Sort thresholds in ascending order.
     const minimumDepositConfirmationThresholds = Object.keys(this.config.minDepositConfirmations)
@@ -86,13 +76,23 @@ export class Relayer {
       minDepositConfirmations: this.config.minDepositConfirmations,
     });
 
+    // Remove deposits whose deposit quote timestamp is > HubPool's current time, because there is a risk that
+    // the ConfigStoreClient's computed realized lp fee % is incorrect for quote times in the future. The client
+    // would use the current utilization as an input to compute this fee %, but if the utilization is different for the
+    // actual block that is mined at the deposit quote time, then the fee % would be different. This should not
+    // impact the bridge users' UX in the normal path because deposit UI's have no reason to set quote times in the
+    // future.
+    const latestHubPoolTime = this.clients.hubPoolClient.currentTime;
+
     // Require that all fillable deposits meet the minimum specified number of confirmations.
     const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.maxUnfilledDepositLookBack)
+      .filter((x) => x.deposit.quoteTimestamp <= latestHubPoolTime)
       .filter((x) => {
         return (
+          x.deposit.quoteTimestamp <= latestHubPoolTime &&
           x.deposit.originBlockNumber <=
-          this.clients.spokePoolClients[x.deposit.originChainId].latestBlockNumber -
-            mdcPerChain[x.deposit.originChainId]
+            this.clients.spokePoolClients[x.deposit.originChainId].latestBlockNumber -
+              mdcPerChain[x.deposit.originChainId]
         );
       })
       .sort((a, b) =>

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -39,7 +39,9 @@ export class Relayer {
     // Remove deposits whose deposit quote timestamp is > HubPool's current time, because there is a risk that
     // the ConfigStoreClient's computed realized lp fee % is incorrect for quote times in the future. The client
     // would use the current utilization as an input to compute this fee %, but if the utilization is different for the
-    // actual block that is mined at the deposit quote time, then the fee % would be different.
+    // actual block that is mined at the deposit quote time, then the fee % would be different. This should not
+    // impact the bridge users' UX in the normal path because deposit UI's have no reason to set quote times in the
+    // future.
     const latestHubPoolTime = this.clients.hubPoolClient.currentTime;
 
     // Sum the total unfilled deposit amount per origin chain and set a MDC for that chain.

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -21,6 +21,11 @@ export class RelayerConfig extends CommonConfig {
   readonly minDepositConfirmations: {
     [threshold: number]: { [chainId: number]: number };
   };
+  // Quote timestamp buffer to protect relayer from edge case where a quote time is > HEAD's latest block.
+  // This exposes relayer to risk that HubPool utilization changes between now and the eventual block mined at that
+  // timestamp, since the ConfigStoreClient.computeRealizedLpFee returns the current lpFee % for quote times >
+  // HEAD
+  readonly quoteTimeBuffer: number;
 
   constructor(env: ProcessEnv) {
     const {
@@ -35,6 +40,7 @@ export class RelayerConfig extends CommonConfig {
       MIN_RELAYER_FEE_PCT,
       ACCEPT_INVALID_FILLS,
       MIN_DEPOSIT_CONFIRMATIONS,
+      QUOTE_TIME_BUFFER,
     } = env;
     super(env);
 
@@ -93,5 +99,6 @@ export class RelayerConfig extends CommonConfig {
       });
     // Force default thresholds in MDC config.
     this.minDepositConfirmations["default"] = Constants.DEFAULT_MIN_DEPOSIT_CONFIRMATIONS;
+    this.quoteTimeBuffer = QUOTE_TIME_BUFFER ? Number(QUOTE_TIME_BUFFER) : Constants.QUOTE_TIME_BUFFER;
   }
 }

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -72,6 +72,7 @@ describe.skip("Relayer: Iterative fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig
     );

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -66,6 +66,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig
     );

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -66,6 +66,7 @@ describe("Relayer: Token balance shortfall", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig
     );

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -88,6 +88,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
         acceptInvalidFills: false,
       } as unknown as RelayerConfig


### PR DESCRIPTION
Adds a deposit quote timestamp buffer to protect relayer from edge case where a quote time is > HEAD's latest block. Currently, the relayer is exposed to the risk that HubPool utilization changes between `now` and the eventual block mined at that timestamp, since the ConfigStoreClient.computeRealizedLpFee returns the current lpFee % for quote times >HEAD