### PR TITLE
improve(ProfitClient): Add relayer gas multiplier

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -56,7 +56,7 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
   42161: 3000, // At a conservative 10 TPS, 300 seconds = 3000 transactions. And 1 block per txn.
 };
 
-export const DEFAULT_RELAYER_GAS_MULTIPLIER = 1.20;
+export const DEFAULT_RELAYER_GAS_MULTIPLIER = 1.2;
 
 export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
 export const CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -56,6 +56,8 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
   42161: 3000, // At a conservative 10 TPS, 300 seconds = 3000 transactions. And 1 block per txn.
 };
 
+export const DEFAULT_RELAYER_GAS_MULTIPLIER = 1.20;
+
 export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
 export const CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
   1: DEFAULT_MULTICALL_CHUNK_SIZE,

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -42,7 +42,8 @@ export async function constructRelayerClients(
     enabledChainIds,
     config.ignoreTokenPriceFailures,
     config.minRelayerFeePct,
-    config.debugProfitability
+    config.debugProfitability,
+    config.relayerGasMultiplier
   );
 
   const adapterManager = new AdapterManager(logger, spokePoolClients, commonClients.hubPoolClient, [

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -15,6 +15,7 @@ export class RelayerConfig extends CommonConfig {
   readonly sendingSlowRelaysEnabled: boolean;
   readonly relayerTokens: string[];
   readonly relayerDestinationChains: number[];
+  readonly relayerGasMultiplier: number;
   readonly minRelayerFeePct: BigNumber;
   readonly acceptInvalidFills: boolean;
   // Following distances in blocks to guarantee finality on each chain.
@@ -26,6 +27,7 @@ export class RelayerConfig extends CommonConfig {
       DEBUG_PROFITABILITY,
       IGNORE_PROFITABILITY,
       IGNORE_TOKEN_PRICE_FAILURES,
+      RELAYER_GAS_MULTIPLIER,
       RELAYER_INVENTORY_CONFIG,
       RELAYER_TOKENS,
       SEND_RELAYS,
@@ -74,6 +76,10 @@ export class RelayerConfig extends CommonConfig {
     this.debugProfitability = DEBUG_PROFITABILITY === "true";
     this.ignoreProfitability = IGNORE_PROFITABILITY === "true";
     this.ignoreTokenPriceFailures = IGNORE_TOKEN_PRICE_FAILURES === "true";
+    this.relayerGasMultiplier = RELAYER_GAS_MULTIPLIER
+      ? Number(RELAYER_GAS_MULTIPLIER)
+      : Constants.DEFAULT_RELAYER_GAS_MULTIPLIER;
+    assert(this.relayerGasMultiplier >= 0.0, `Invalid relayer gas multiplier: ${this.relayerGasMultiplier}`);
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
     this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -139,9 +139,8 @@ describe("ProfitClient: Consider relay profit", async function () {
       const nativeGasCost = profitClient.getTotalGasCost(chainId);
       expect(nativeGasCost.gt(0)).to.be.true;
 
-      const gasMultipliers = [0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.50, 1.75, 2.0];
+      const gasMultipliers = [0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
       gasMultipliers.forEach((gasMultiplier) => {
-
         const expectedFillCostUsd = nativeGasCost.mul(tokenPrices["USDC"]).mul(toBNWei(gasMultiplier)).div(toBNWei(1));
         const { gasCostUsd } = profitClient.estimateFillCost(chainId);
         expect(expectedFillCostUsd.eq(gasCostUsd), `${expectedFillCostUsd} != ${gasCostUsd}`);


### PR DESCRIPTION
Default to 1.2, to allow some headroom for gas price changes between
when the profitability is calculated and when the txn is submitted.

This won't impact the behaviour of the RL bot, but will make any third-
party bots more conservative.

One thing to note is that this change introduces a single, global multiplier.
The SDK has a per-chain configurable multiplier...so there is some difference
with the SDK, which might be relevant, since it typically computes the fees.