### PR TITLE
improve: Add es-lint rules to prevent chai "expect" statements without assertions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
     mocha: true,
     node: true,
   },
-  plugins: ["node", "prettier", "@typescript-eslint", "mocha"],
+  plugins: ["node", "prettier", "@typescript-eslint", "mocha", "chai-expect"],
   extends: [
     "plugin:prettier/recommended",
     "eslint:recommended",
@@ -32,6 +32,7 @@ module.exports = {
     "node/no-unsupported-features/es-syntax": ["error", { ignores: ["modules"] }],
     // Disable warnings for { a, b, ...rest } variables, since this is typically used to remove variables.
     "@typescript-eslint/no-unused-vars": ["warn", { ignoreRestSiblings: true }],
+    "chai-expect/missing-assertion": 2,
   },
   settings: {
     node: {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "eslint": "^7.29.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-chai-expect": "^3.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-mocha": "^10.0.5",
     "eslint-plugin-node": "^11.1.0",

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -50,7 +50,6 @@ const QUERY_HANDLERS: {
   42161: relayFeeCalculator.ArbitrumQueries,
 };
 
-type TokenPrice = priceClient.TokenPrice;
 const { PriceClient } = priceClient;
 const { acrossApi, coingecko } = priceClient.adapters;
 

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -299,7 +299,7 @@ describe("Dataworker: Build merkle roots", async function () {
       expect(
         allSigners.length >= MAX_REFUNDS_PER_RELAYER_REFUND_LEAF + 1,
         "ethers.getSigners doesn't have enough signers"
-      );
+      ).to.be.true;
       for (let i = 0; i < MAX_REFUNDS_PER_RELAYER_REFUND_LEAF + 1; i++) {
         await setupTokensForWallet(spokePool_2, allSigners[i], [erc20_2]);
         await buildFillForRepaymentChain(spokePool_2, allSigners[i], deposit4, 0.01 + i * 0.01, 98);
@@ -405,7 +405,7 @@ describe("Dataworker: Build merkle roots", async function () {
       expect(
         allSigners.length >= MAX_REFUNDS_PER_RELAYER_REFUND_LEAF + 1,
         "ethers.getSigners doesn't have enough signers"
-      );
+      ).to.be.true;
       const sortedAllSigners = [...allSigners].sort((x, y) => compareAddresses(x.address, y.address));
       const fills = [];
       for (let i = 0; i < MAX_REFUNDS_PER_RELAYER_REFUND_LEAF + 1; i++) {

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -618,7 +618,7 @@ describe("Dataworker: Load data used in all functions", async function () {
 
     // Speed up relays are included. Re-use the same fill information
     const fill4 = await buildModifiedFill(spokePool_2, depositor, relayer, fill1, 2, 0.1);
-    expect(fill4.totalFilledAmount.gt(fill4.fillAmount), "speed up fill didn't match original deposit");
+    expect(fill4.totalFilledAmount.gt(fill4.fillAmount), "speed up fill didn't match original deposit").to.be.true;
     await updateAllClients();
     const data6 = dataworkerInstance.clients.bundleDataClient.loadData(getDefaultBlockRange(4), spokePoolClients);
     expect(data6.fillsToRefund).to.deep.equal({

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -128,7 +128,7 @@ describe("ProfitClient: Consider relay profit", async function () {
       const estimate: { [key: string]: BigNumber } = profitClient.calculateFillCost(chainId);
       expect(estimate.nativeGasCost.eq(gasCost[chainId])).to.be.true;
       expect(estimate.gasPriceUsd.eq(tokenPrices[gasToken.symbol])).to.be.true;
-      expect(estimate.gasCostUsd.eq(gasPriceUsd.mul(nativeGasCost))).to.be.true;
+      expect(estimate.gasCostUsd.eq(gasPriceUsd.mul(nativeGasCost).div(toBN(10).pow(gasToken.decimals)))).to.be.true;
     });
   });
 

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -116,19 +116,19 @@ describe("ProfitClient: Consider relay profit", async function () {
 
       const nativeGasCost = profitClient.getTotalGasCost(chainId);
       expect(nativeGasCost.eq(0)).to.be.false;
-      expect(nativeGasCost.eq(gasCost[chainId]));
+      expect(nativeGasCost.eq(gasCost[chainId])).to.be.true;
 
       const gasTokenAddr: string = GAS_TOKEN_BY_CHAIN_ID[chainId];
       const gasToken: L1Token = Object.values(tokens).find((token: L1Token) => gasTokenAddr === token.address);
       expect(gasToken).to.not.be.undefined;
 
       const gasPriceUsd = tokenPrices[gasToken.symbol];
-      expect(gasPriceUsd.eq(tokenPrices[gasToken.symbol]));
+      expect(gasPriceUsd.eq(tokenPrices[gasToken.symbol])).to.be.true;
 
       const estimate: { [key: string]: BigNumber } = profitClient.calculateFillCost(chainId);
-      expect(estimate.nativeGasCost.eq(gasCost[chainId]));
-      expect(estimate.gasPriceUsd.eq(tokenPrices[gasToken.symbol]));
-      expect(estimate.gasCostUsd.eq(gasPriceUsd.mul(nativeGasCost)));
+      expect(estimate.nativeGasCost.eq(gasCost[chainId])).to.be.true;
+      expect(estimate.gasPriceUsd.eq(tokenPrices[gasToken.symbol])).to.be.true;
+      expect(estimate.gasCostUsd.eq(gasPriceUsd.mul(nativeGasCost))).to.be.true;
     });
   });
 
@@ -249,11 +249,11 @@ describe("ProfitClient: Consider relay profit", async function () {
 
     let fill: FillProfit;
     fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);
-    expect(fill.grossRelayerFeePct.eq(deposit.relayerFeePct));
+    expect(fill.grossRelayerFeePct.eq(deposit.relayerFeePct)).to.be.true;
 
     deposit["newRelayerFeePct"] = toBNWei("0.1");
     fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);
-    expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct));
+    expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct)).to.be.true;
   });
 
   it("Ignores newRelayerFeePct if it's lower than original relayerFeePct", async function () {
@@ -269,12 +269,12 @@ describe("ProfitClient: Consider relay profit", async function () {
 
     let fill: FillProfit;
     fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);
-    expect(fill.grossRelayerFeePct.eq(deposit.relayerFeePct));
+    expect(fill.grossRelayerFeePct.eq(deposit.relayerFeePct)).to.be.true;
 
     deposit.relayerFeePct = toBNWei(".001");
-    expect(deposit.relayerFeePct.lt(deposit.newRelayerFeePct)); // Sanity check
+    expect(deposit.relayerFeePct.lt(deposit.newRelayerFeePct)).to.be.true; // Sanity check
     fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token);
-    expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct));
+    expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct)).to.be.true;
   });
 
   it("Captures unprofitable fills", async function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7568,6 +7568,11 @@ eslint-module-utils@^2.7.3:
     debug "^3.2.7"
     find-up "^2.1.0"
 
+eslint-plugin-chai-expect@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-3.0.0.tgz#812d7384756177b2d424040cb3c20e78606db1b2"
+  integrity sha512-NS0YBcToJl+BRKBSMCwRs/oHJIX67fG5Gvb4tGked+9Wnd1/PzKijd82B2QVKcSSOwRe+pp4RAJ2AULeck4eQw==
+
 eslint-plugin-es@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"


### PR DESCRIPTION
Prevents the case where an `expect(...)` without an assertion (e.g. `to.be.true`) suppresses an error or contains something `false` in the inner expression. This is because `expect(...)` returns true if the inside statement is truthy which includes Errors and `false`