### PR TITLE
improve: Log package version on startup

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,12 +5,14 @@ import { runRelayer } from "./src/relayer";
 import { runDataworker } from "./src/dataworker";
 import { runMonitor } from "./src/monitor";
 import { runFinalizer } from "./src/finalizer";
+import { version } from "./package.json";
 
 let logger: winston.Logger;
 
 export async function run(args: { [k: string]: boolean | string }): Promise<void> {
   logger = Logger;
 
+  logger.debug({ at: "index#run", message: "Startup.", version });
   const config = new CommonConfig(process.env);
 
   const cmds = {

--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,6 @@ let logger: winston.Logger;
 export async function run(args: { [k: string]: boolean | string }): Promise<void> {
   logger = Logger;
 
-  logger.debug({ at: "index#run", message: "Startup.", version });
   const config = new CommonConfig(process.env);
 
   const cmds = {
@@ -48,6 +47,8 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
 }
 
 if (require.main === module) {
+  // Inject version into process.env so CommonConfig and all subclasses inherit it.
+  process.env.VERSION = version;
   config();
 
   const opts = {

--- a/index.ts
+++ b/index.ts
@@ -48,7 +48,7 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
 
 if (require.main === module) {
   // Inject version into process.env so CommonConfig and all subclasses inherit it.
-  process.env.VERSION = version;
+  process.env.ACROSS_BOT_VERSION = version;
   config();
 
   const opts = {

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -17,6 +17,7 @@ export class CommonConfig {
   readonly bundleRefundLookback: number;
   readonly maxRelayerLookBack: { [chainId: number]: number };
   readonly maxRelayerUnfilledDepositLookBack: { [chainId: number]: number };
+  readonly version: string;
 
   constructor(env: ProcessEnv) {
     const {
@@ -30,7 +31,10 @@ export class CommonConfig {
       SEND_TRANSACTIONS,
       REDIS_URL,
       BUNDLE_REFUND_LOOKBACK,
+      VERSION
     } = env;
+
+    this.version = VERSION ?? "unknown";
 
     // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
     this.maxRelayerLookBack = MAX_RELAYER_DEPOSIT_LOOK_BACK

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -31,7 +31,7 @@ export class CommonConfig {
       SEND_TRANSACTIONS,
       REDIS_URL,
       BUNDLE_REFUND_LOOKBACK,
-      ACROSS_BOT_VERSION
+      ACROSS_BOT_VERSION,
     } = env;
 
     this.version = ACROSS_BOT_VERSION ?? "unknown";

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -31,10 +31,10 @@ export class CommonConfig {
       SEND_TRANSACTIONS,
       REDIS_URL,
       BUNDLE_REFUND_LOOKBACK,
-      VERSION
+      ACROSS_BOT_VERSION
     } = env;
 
-    this.version = VERSION ?? "unknown";
+    this.version = ACROSS_BOT_VERSION ?? "unknown";
 
     // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
     this.maxRelayerLookBack = MAX_RELAYER_DEPOSIT_LOOK_BACK

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "esModuleInterop": true,
     "outDir": "./dist",
     "declaration": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "resolveJsonModule": true
   },
   "include": ["./src", "index.ts"],
   "files": ["./hardhat.config.ts"],


### PR DESCRIPTION
Could alternatively be bundled into the global config within src/common/Config.ts, so it would be automagically logged by the respective "{Dataworker,Relayer} started" log messages.