### PR TITLE
fix: Use typecasting to fix optimism finalizer

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -74,7 +74,7 @@ export async function finalize(
       const olderTokensBridgedEvents = tokensBridged.filter(
         (e) => e.blockNumber < client.latestBlockNumber - optimisticRollupFinalizationWindow
       );
-      const crossChainMessenger = getOptimismClient();
+      const crossChainMessenger = getOptimismClient(hubSigner);
       const finalizableMessages = await getOptimismFinalizableMessages(
         logger,
         olderTokensBridgedEvents,

--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -1,14 +1,27 @@
 import * as optimismSDK from "@eth-optimism/sdk";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { L1Token, TokensBridged } from "../../interfaces";
-import { convertFromWei, delay, etherscanLink, getNodeUrlList, groupObjectCountsByProp, winston } from "../../utils";
+import {
+  convertFromWei,
+  delay,
+  ethers,
+  etherscanLink,
+  getNodeUrlList,
+  groupObjectCountsByProp,
+  Wallet,
+  winston,
+} from "../../utils";
 
-export function getOptimismClient(): optimismSDK.CrossChainMessenger {
+export function getOptimismClient(hubSigner: Wallet): optimismSDK.CrossChainMessenger {
   return new optimismSDK.CrossChainMessenger({
     l1ChainId: 1,
     l2ChainId: 10,
-    l1SignerOrProvider: optimismSDK.toSignerOrProvider(getNodeUrlList(1)[0]),
-    l2SignerOrProvider: optimismSDK.toSignerOrProvider(getNodeUrlList(10)[0]),
+    l1SignerOrProvider: hubSigner.connect(
+      new ethers.providers.JsonRpcProvider(getNodeUrlList(1)[0])
+    ) as unknown as optimismSDK.SignerLike,
+    l2SignerOrProvider: hubSigner.connect(
+      new ethers.providers.JsonRpcProvider(getNodeUrlList(10)[0])
+    ) as unknown as optimismSDK.SignerLike,
   });
 }
 

--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -16,6 +16,11 @@ export function getOptimismClient(hubSigner: Wallet): optimismSDK.CrossChainMess
   return new optimismSDK.CrossChainMessenger({
     l1ChainId: 1,
     l2ChainId: 10,
+    // @dev: The optimismSDK's version of Signer and Provider is a bit different than the one imported by
+    // this repo, specifically it claims:
+    // - Type 'Wallet' is not assignable to type 'Signer'.
+    // - The types returned by 'provider.getFeeData()' are incompatible between these types.
+    // - So we cast to unknown to ignore this incompatibility which doesn't seem important.
     l1SignerOrProvider: hubSigner.connect(
       new ethers.providers.JsonRpcProvider(getNodeUrlList(1)[0])
     ) as unknown as optimismSDK.SignerLike,


### PR DESCRIPTION
New optimism sdk 1.6.x has a different Signer type than that exported by ethers.Signer that we use as dependency. I was able to run this code locally and it works in run time so the main issue seemed to be compile time. For example I finalized this optimism L2 message using this code: https://etherscan.io/tx/0x22e80cd98823c47f6949e08429f97cf6e0e95ee0ae793d7a931acb4ef435a333
