### PR TITLE
fix(ProfitClient): Clamp test token prices

### DIFF
--- a/test/ProfitClient.PriceRetrieval.ts
+++ b/test/ProfitClient.PriceRetrieval.ts
@@ -24,9 +24,7 @@ const mainnetTokens: Array<L1Token> = [
 const minTokenPrice = 0.000001;
 const tokenPrices: { [addr: string]: number } = Object.fromEntries(
   mainnetTokens.map((token) => {
-    let tokenPrice = Math.random();
-    if (tokenPrice < minTokenPrice) tokenPrice = minTokenPrice;
-    return [token.address, tokenPrice];
+    return [token.address, Math.max(Math.random(), minTokenPrice)];
   })
 );
 

--- a/test/ProfitClient.PriceRetrieval.ts
+++ b/test/ProfitClient.PriceRetrieval.ts
@@ -21,8 +21,13 @@ const mainnetTokens: Array<L1Token> = [
   { symbol: "MATIC", address: MATIC, decimals: 18 },
 ];
 
+const minTokenPrice = 0.000001;
 const tokenPrices: { [addr: string]: number } = Object.fromEntries(
-  mainnetTokens.map((token) => [token.address, Math.random()])
+  mainnetTokens.map((token) => {
+    let tokenPrice = Math.random();
+    if (tokenPrice < minTokenPrice) tokenPrice = minTokenPrice;
+    return [token.address, tokenPrice];
+  })
 );
 
 class ProfitClientWithMockPriceClient extends ProfitClient {


### PR DESCRIPTION
Math.random() can occasionally produce a random number that can't be promoted to 18 decimals by BigNumber.

This should address the failure seen here: https://github.com/across-protocol/relayer-v2/actions/runs/3376746366/jobs/5604840582