### PR TITLE
improve(finalizer): Specify direction on Optimism

### DIFF
--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -45,10 +45,9 @@ export async function getCrossChainMessages(
       tokensBridged.map(
         async (l2Event, i) =>
           (
-            await crossChainMessenger.getMessagesByTransaction(
-              l2Event.transactionHash,
-              { direction: optimismSDK.MessageDirection.L2_TO_L1 }
-            )
+            await crossChainMessenger.getMessagesByTransaction(l2Event.transactionHash, {
+              direction: optimismSDK.MessageDirection.L2_TO_L1,
+            })
           )[logIndexesForMessage[i]]
       )
     )

--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -39,12 +39,16 @@ export async function getCrossChainMessages(
     logIndexesForMessage.push(logIndex);
     uniqueTokenhashes[event.transactionHash] += 1;
   }
+
   return (
     await Promise.all(
       tokensBridged.map(
         async (l2Event, i) =>
           (
-            await crossChainMessenger.getMessagesByTransaction(l2Event.transactionHash)
+            await crossChainMessenger.getMessagesByTransaction(
+              l2Event.transactionHash,
+              { direction: optimismSDK.MessageDirection.L2_TO_L1 }
+            )
           )[logIndexesForMessage[i]]
       )
     )


### PR DESCRIPTION
If direction is not defined, then the SDK will (per current implementation) perform an L1 -> L2 lookup before an L2 -> L1 lookup. By specifying the direction we can avoid the redundant lookup.

Description is here: https://sdk.optimism.io/classes/crosschainmessenger#getMessagesByTransaction

Relevant code in the SDK is here: https://github.com/ethereum-optimism/optimism/blob/8f531f201c9d400acd7a4bc4a54db9a094b0778f/packages/sdk/src/cross-chain-messenger.ts#L283