### PR TITLE
fix(balance-allocator): Count WETH and ETH for OVM spoke chains

### DIFF
--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -40,7 +40,6 @@ export class BalanceAllocator {
           )
         );
 
-        // Replace `tokens` property with one of the interchangeable tokens.
         const returnedRequest = {
           ...request,
           balances,

--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -1,4 +1,5 @@
 import { BigNumber, ERC20, ethers, ZERO_ADDRESS } from "../utils";
+import lodash from "lodash";
 
 // This type is used to map used and current balances of different users.
 interface BalanceMap {
@@ -17,37 +18,45 @@ export class BalanceAllocator {
   constructor(readonly providers: { [chainId: number]: ethers.providers.Provider }) {}
 
   // Note: The caller is suggesting that `tokens` for a request are interchangeable.
+  // The tokens whose balances are depleted first should be placed at the front of the array.
   async requestBalanceAllocations(
     requests: { chainId: number; tokens: string[]; holder: string; amount: BigNumber }[]
   ): Promise<boolean> {
+
+    // Validate that all input tokens are unique.
+    const tokens = requests.map(({ tokens }) => tokens.map(token => token.toLowerCase())).flat();
+    if (!lodash.uniq(tokens)) throw new Error("BalanceAllocator::requestBalanceAllocations input tokens not unique!");
+
     // Do all async work up-front to avoid atomicity problems with updating used.
     const requestsWithbalances = await Promise.all(
       requests.map(async (request) => {
-        const balances = await Promise.all(
-          request.tokens.map((token) => this.getBalance(request.chainId, token, request.holder))
-        );
+        const balances = Object.fromEntries(await Promise.all(
+          request.tokens.map(async (token): Promise<[string, BigNumber]> => [token, await this.getBalance(request.chainId, token, request.holder)])
+        ));
 
         // Replace `tokens` property with one of the interchangeable tokens.
         const returnedRequest = {
           ...request,
-          token: request.tokens[0],
-          balance: balances.reduce((acc, curr) => acc.add(curr), BigNumber.from(0)),
+          balances,
         };
-        delete returnedRequest.tokens;
         return returnedRequest;
       })
     );
 
     // Determine if the entire group will be successful.
-    const success = requestsWithbalances.every(({ chainId, token, holder, amount, balance }) => {
-      const used = this.getUsed(chainId, token, holder);
-      return balance.gte(used.add(amount));
+    const success = requestsWithbalances.every(({ chainId, tokens, holder, amount, balances }) => {
+      const availableBalance = tokens.reduce((acc, token) => acc.add(balances[token].sub(this.getUsed(chainId, token, holder))), BigNumber.from(0));
+      return availableBalance.gte(amount);
     });
 
     // If the entire group is successful commit to using these tokens.
     if (success)
-      requestsWithbalances.forEach(({ chainId, token, holder, amount }) =>
-        this.addUsed(chainId, token, holder, amount)
+      requestsWithbalances.forEach(({ chainId, tokens, holder, balances, amount }) =>
+        tokens.forEach(token => {
+          const used = amount.gt(balances[token]) ? balances[token] : amount;
+          this.addUsed(chainId, token, holder, used);
+          amount = amount.sub(used);
+        })
       );
 
     // Return success.

--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -23,6 +23,7 @@ export class BalanceAllocator {
     // Do all async work up-front to avoid atomicity problems with updating used.
     const requestsWithbalances = await Promise.all(
       requests.map(async (request) => {
+        const balances = await Promise.all(
           request.tokens.map((token) => this.getBalance(request.chainId, token, request.holder))
         );
 

--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -55,11 +55,11 @@ export class BalanceAllocator {
       let balance: BigNumber;
       // If chain is an OVM and the token is a weth address, then sum both weth and eth addresses
       // since the Ovm_SpokePool will automatically deposit ETH into WETH before executing a leaf.
-      if (ovmChainIds.includes(chainId) && ovmEthAddresses.includes(token)) 
+      if (ovmChainIds.includes(chainId) && ovmEthAddresses.includes(token))
         balance = (await ERC20.connect(ovmEthAddresses[0], this.providers[chainId]).balanceOf(holder)).add(
           await ERC20.connect(ovmEthAddresses[1], this.providers[chainId]).balanceOf(holder)
         );
-      else 
+      else
         balance =
           token === ZERO_ADDRESS
             ? await this.providers[chainId].getBalance(holder)

--- a/src/clients/bridges/OptimismAdapter.ts
+++ b/src/clients/bridges/OptimismAdapter.ts
@@ -27,6 +27,8 @@ const ovmL2StandardBridgeAddress = "0x4200000000000000000000000000000000000010";
 
 const wethOptimismAddress = "0x4200000000000000000000000000000000000006";
 const wethBobaAddress = "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000";
+export const ovmWethTokens = [wethOptimismAddress, wethBobaAddress];
+export const isOvmChain = (chainId: number) => [10, 288].includes(chainId);
 
 const atomicDepositorAddress = "0x26eaf37ee5daf49174637bdcd2f7759a25206c34";
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -34,6 +34,7 @@ import {
 import { BalanceAllocator } from "../clients";
 import _ from "lodash";
 import { IGNORED_SPOKE_BUNDLES } from "../common";
+import { isOvmChain, ovmWethTokens } from "../clients/bridges";
 
 // Internal error reasons for labeling a pending root bundle as "invalid" that we don't want to submit a dispute
 // for. These errors are due to issues with the dataworker configuration, instead of with the pending root
@@ -897,7 +898,7 @@ export class Dataworker {
                 const amountRequired = getRefund(leaf.amount.sub(amountFilled), leaf.realizedLpFeePct);
                 const success = await balanceAllocator.requestBalanceAllocation(
                   leaf.destinationChainId,
-                  leaf.destinationToken,
+                  isOvmChain(leaf.destinationChainId) ? ovmWethTokens : [leaf.destinationToken],
                   client.spokePool.address,
                   amountRequired
                 );
@@ -1052,7 +1053,7 @@ export class Dataworker {
         unexecutedLeaves.map(async (leaf) => {
           const requests = leaf.netSendAmounts.map((amount, i) => ({
             amount: amount.gte(0) ? amount : BigNumber.from(0),
-            token: leaf.l1Tokens[i],
+            tokens: [leaf.l1Tokens[i]],
             holder: this.clients.hubPoolClient.hubPool.address,
             chainId: hubPoolChainId,
           }));
@@ -1063,7 +1064,7 @@ export class Dataworker {
             );
             if (hubPoolBalance.lt(this._getRequiredEthForArbitrumPoolRebalanceLeaf(leaf)))
               requests.push({
-                token: ZERO_ADDRESS,
+                tokens: [ZERO_ADDRESS],
                 amount: this._getRequiredEthForArbitrumPoolRebalanceLeaf(leaf),
                 holder: await this.clients.spokePoolSigners[hubPoolChainId].getAddress(),
                 chainId: hubPoolChainId,
@@ -1320,6 +1321,7 @@ export class Dataworker {
 
           const leavesForChain = leaves.filter((leaf) => leaf.chainId === Number(chainId));
           const unexecutedLeaves = leavesForChain.filter((leaf) => {
+            return true;
             const executedLeaf = executedLeavesForChain.find(
               (event) => event.rootBundleId === rootBundleRelay.rootBundleId && event.leafId === leaf.leafId
             );
@@ -1337,7 +1339,7 @@ export class Dataworker {
                 const totalSent = refundSum.add(leaf.amountToReturn.gte(0) ? leaf.amountToReturn : BigNumber.from(0));
                 const success = await balanceAllocator.requestBalanceAllocation(
                   leaf.chainId,
-                  leaf.l2TokenAddress,
+                  isOvmChain(leaf.chainId) ? ovmWethTokens : [leaf.l2TokenAddress],
                   client.spokePool.address,
                   totalSent
                 );

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1321,7 +1321,6 @@ export class Dataworker {
 
           const leavesForChain = leaves.filter((leaf) => leaf.chainId === Number(chainId));
           const unexecutedLeaves = leavesForChain.filter((leaf) => {
-            return true;
             const executedLeaf = executedLeavesForChain.find(
               (event) => event.rootBundleId === rootBundleRelay.rootBundleId && event.leafId === leaf.leafId
             );


### PR DESCRIPTION
Ovm_SpokePool will deposit ETH into WETH before executing any leaves, so both the ETH and WETH balances should be counted together when deciding whether a leaf can be executed. Without this logic, the dataworker mistakenly skips executing leaves that it does have balance for but the balance is split between eth and weth
