### PR TITLE
fix: Various relayer fixes

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -14,7 +14,8 @@ export class AcrossApiClient {
 
   public updatedLimits = false;
 
-  constructor(readonly logger: winston.Logger, readonly tokensQuery: string[] = [], readonly timeout: number = 5000) {
+  // Note: Max vercel execution duration is 1 minute
+  constructor(readonly logger: winston.Logger, readonly tokensQuery: string[] = [], readonly timeout: number = 60000) {
     if (Object.keys(tokensQuery).length === 0) this.tokensQuery = Object.keys(l2TokensToL1TokenValidation);
   }
 

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -2,7 +2,6 @@ import { DEFAULT_MULTICALL_CHUNK_SIZE, CHAIN_MULTICALL_CHUNK_SIZE } from "../com
 import {
   winston,
   getNetworkName,
-  assign,
   Contract,
   runTransaction,
   getTarget,
@@ -296,7 +295,7 @@ export class MultiCallerClient {
           }
         });
       });
-      this.logger.info({ at: "MultiCallerClient", message: "Multicall batch sent! 🧙‍♂️", mrkdwn });
+      this.logger.info({ at: "MultiCallerClient", message: "Multicall batch sent! 🧙", mrkdwn });
       this.clearTransactionQueue();
       return transactionHashes;
     } catch (error) {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -157,7 +157,7 @@ export class Relayer {
       ) {
         this.logger.warn({
           at: "Relayer",
-          message: "😱 Skipping deposit with greater unfilled amount that API suggested limit",
+          message: "😱 Skipping deposit with greater unfilled amount than API suggested limit",
           limit: this.clients.acrossApiClient.getLimit(l1Token.address),
           unfilledAmount: unfilledAmount.toString(),
           l1Token: l1Token.address,


### PR DESCRIPTION
- Typo in Relayer in AcrossAPIClient log
- Increase default timeout in AcrossAPIClient to 60s, the full length of the vercel API timeout
- Typo in MultiCallerClient