### PR TITLE
feat: Use Multicall to batch Finalizer transactions

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -14,8 +14,7 @@ export class AcrossApiClient {
 
   public updatedLimits = false;
 
-  // Note: Max vercel execution duration is 1 minute
-  constructor(readonly logger: winston.Logger, readonly tokensQuery: string[] = [], readonly timeout: number = 60000) {
+  constructor(readonly logger: winston.Logger, readonly tokensQuery: string[] = [], readonly timeout: number = 5000) {
     if (Object.keys(tokensQuery).length === 0) this.tokensQuery = Object.keys(l2TokensToL1TokenValidation);
   }
 

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -14,7 +14,8 @@ export class AcrossApiClient {
 
   public updatedLimits = false;
 
-  constructor(readonly logger: winston.Logger, readonly tokensQuery: string[] = [], readonly timeout: number = 5000) {
+  // Note: Max vercel execution duration is 1 minute
+  constructor(readonly logger: winston.Logger, readonly tokensQuery: string[] = [], readonly timeout: number = 60000) {
     if (Object.keys(tokensQuery).length === 0) this.tokensQuery = Object.keys(l2TokensToL1TokenValidation);
   }
 

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -134,7 +134,7 @@ export async function finalize(
       logger.warn({
         at: "Finalizer",
         message: "Error creating aggregateTx",
-        error,
+        reason: error.stack || error.message || error.toString(),
         notificationPath: "across-error",
       });
     }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -74,7 +74,6 @@ export async function finalize(
     const client = spokePoolClients[chainId];
     const tokensBridged = client.getTokensBridged();
 
-
     if (chainId === 42161) {
       // Skip events that are likely not past the seven day challenge period.
       const olderTokensBridgedEvents = tokensBridged.filter(

--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -34,7 +34,7 @@ export async function finalizeArbitrum(
     logger.warn({
       at: "ArbitrumFinalizer",
       message: "Error creating executeTransactionTx",
-      error,
+      reason: error.stack || error.message || error.toString(),
       notificationPath: "across-error",
     });
   }
@@ -105,7 +105,7 @@ export async function getMessageOutboxStatusAndProof(
         logIndex,
         l2ToL1Messages: l2ToL1Messages.length,
         txnHash: event.transactionHash,
-        error,
+        reason: error.stack || error.message || error.toString(),
         notificationPath: "across-error",
       });
       throw error;

--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -4,12 +4,14 @@ import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { L1Token, TokensBridged } from "../../interfaces";
 import { convertFromWei, ethers, getNodeUrlList, groupObjectCountsByProp, Wallet, winston } from "../../utils";
 
+const CHAIN_ID = 10;
+
 export function getOptimismClient(hubSigner: Wallet): optimismSDK.CrossChainMessenger {
   return new optimismSDK.CrossChainMessenger({
     l1ChainId: 1,
-    l2ChainId: 10,
+    l2ChainId: CHAIN_ID,
     l1SignerOrProvider: hubSigner.connect(new ethers.providers.JsonRpcProvider(getNodeUrlList(1)[0])),
-    l2SignerOrProvider: hubSigner.connect(new ethers.providers.JsonRpcProvider(getNodeUrlList(10)[0])),
+    l2SignerOrProvider: hubSigner.connect(new ethers.providers.JsonRpcProvider(getNodeUrlList(CHAIN_ID)[0])),
   });
 }
 
@@ -90,7 +92,10 @@ export async function getOptimismFinalizableMessages(
 }
 
 export function getL1TokenInfoForOptimismToken(hubPoolClient: HubPoolClient, l2Token: string): L1Token {
-  return hubPoolClient.getL1TokenInfoForL2Token(SpokePoolClient.getExecutedRefundLeafL2Token(10, l2Token), 10);
+  return hubPoolClient.getL1TokenInfoForL2Token(
+    SpokePoolClient.getExecutedRefundLeafL2Token(CHAIN_ID, l2Token),
+    CHAIN_ID
+  );
 }
 
 export async function finalizeOptimismMessage(
@@ -118,7 +123,7 @@ export async function multicallOptimismFinalizations(
     const l1TokenInfo = getL1TokenInfoForOptimismToken(hubPoolClient, message.event.l2TokenAddress);
     const amountFromWei = convertFromWei(message.event.amountToReturn.toString(), l1TokenInfo.decimals);
     return {
-      l2ChainId: 10,
+      l2ChainId: CHAIN_ID,
       l1TokenSymbol: l1TokenInfo.symbol,
       amount: amountFromWei,
     };

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -150,7 +150,7 @@ export async function multicallPolygonFinalizations(
   hubPoolClient: HubPoolClient,
   logger: winston.Logger
 ): Promise<void> {
-  const finalizableMessages = await getFinalizableTransactions(logger, tokensBridged, posClient)
+  const finalizableMessages = await getFinalizableTransactions(logger, tokensBridged, posClient);
   if (finalizableMessages.length === 0) return;
   try {
     const callData = await Promise.all(finalizableMessages.map((event) => finalizePolygon(posClient, event)));
@@ -204,7 +204,7 @@ export async function multicallPolygonRetrievals(
       logger.info({
         at: "PolygonFinalizer",
         message: `Retrieved ${balanceFromWei} of ${retrieval.l1TokenInfo.symbol} from PolygonTokenBridger 🪃`,
-        transactionHash: etherscanLink(txn.transactionhash, 1),
+        transactionHash: etherscanLink(txn.transactionHash, 1),
       });
     }
   } catch (error) {


### PR DESCRIPTION
Currently only batches Polygon and Optimism finalizations because Arbitrum's calldata is a bit harder to extract. I will work on this as a follow up to this PR once we are happy with the structure.

Example txn I sent with this:
- https://etherscan.io/tx/0x26ad50ff8bd6a81e36251838c222067da39bb0f0156deb152d31de0c2f8cf29d (this one I had a bug in the code that didn't correctly include the `PolygonTokenBridger.retrieve()` txns but the second txn includes this bug fix and correctly calls `retrieve()`)
- https://etherscan.io/tx/0xc852ab8dedcdc8909e84377e1266cdf9c9f413199daa97330a8e9e74d746b425