### PR TITLE
improve(multicaller): Env-configurable chunk sizes

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -11,6 +11,7 @@ import {
   TransactionResponse,
   TransactionSimulationResult,
 } from "../utils";
+
 import lodash from "lodash";
 
 export interface AugmentedTransaction {

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_MULTICALL_CHUNK_SIZE, CHAIN_MULTICALL_CHUNK_SIZE } from "../common";
 import {
   winston,
   getNetworkName,
@@ -63,7 +62,7 @@ const canIgnoreRevertReasons = (obj: {
 export class MultiCallerClient {
   private transactions: AugmentedTransaction[] = [];
   // eslint-disable-next-line no-useless-constructor
-  constructor(readonly logger: winston.Logger) {}
+  constructor(readonly logger: winston.Logger, readonly multiCallChunkSize: { [chainId: number]: number }) {}
 
   // Adds all information associated with a transaction to the transaction queue. This is the intention of the
   // caller to send a transaction. The transaction might not be executable, which should be filtered later.
@@ -160,7 +159,7 @@ export class MultiCallerClient {
       const chunkedTransactions: { [chainId: number]: AugmentedTransaction[][] } = Object.fromEntries(
         Object.entries(groupedTransactions).map(([_chainId, transactions]) => {
           const chainId = Number(_chainId);
-          const chunkSize: number = CHAIN_MULTICALL_CHUNK_SIZE[chainId] || DEFAULT_MULTICALL_CHUNK_SIZE;
+          const chunkSize: number = this.multiCallChunkSize[chainId];
           if (transactions.length > chunkSize) {
             const dropped: Array<{ address: string; method: string; args: any[] }> = transactions
               .slice(chunkSize)

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_MULTICALL_CHUNK_SIZE } from "../common";
 import {
   winston,
   getNetworkName,
@@ -9,7 +10,6 @@ import {
   etherscanLink,
   TransactionResponse,
 } from "../utils";
-import { DEFAULT_MULTICALL_CHUNK_SIZE } from "../common";
 import lodash from "lodash";
 
 export interface AugmentedTransaction {

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -62,10 +62,7 @@ const canIgnoreRevertReasons = (obj: {
 export class MultiCallerClient {
   private transactions: AugmentedTransaction[] = [];
   // eslint-disable-next-line no-useless-constructor
-  constructor(
-    readonly logger: winston.Logger,
-    readonly multiCallChunkSize: { [chainId: number]: number } = {}
-  ) {}
+  constructor(readonly logger: winston.Logger, readonly multiCallChunkSize: { [chainId: number]: number } = {}) {}
 
   // Adds all information associated with a transaction to the transaction queue. This is the intention of the
   // caller to send a transaction. The transaction might not be executable, which should be filtered later.

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -179,7 +179,7 @@ export async function constructClients(
     redisClient
   );
 
-  const multiCallerClient = new MultiCallerClient(logger);
+  const multiCallerClient = new MultiCallerClient(logger, config.multiCallChunkSize);
 
   return { hubPoolClient, configStoreClient, multiCallerClient, hubSigner };
 }

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -61,7 +61,7 @@ export class CommonConfig {
             ?? DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE[chainId]
             ?? DEFAULT_MULTICALL_CHUNK_SIZE
         );
-        assert(chunkSize > 0, `Chain ${chainId} multicall chunk size must be greater than 0.`);
+        assert(chunkSize > 0, `Chain ${chainId} multicall chunk size (${chunkSize}) must be greater than 0.`);
         return [chainId, chunkSize];
       })
     );

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -61,7 +61,7 @@ export class CommonConfig {
             ?? DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE[chainId]
             ?? DEFAULT_MULTICALL_CHUNK_SIZE
         );
-        assert(chunkSize > 0, `Chain ${chainId} multicall chunk size (${chunkSize}) must be greater than 0.`);
+        assert(chunkSize > 0, `Chain ${chainId} multicall chunk size (${chunkSize}) must be greater than 0`);
         return [chainId, chunkSize];
       })
     );

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -23,7 +23,6 @@ export class CommonConfig {
   constructor(env: ProcessEnv) {
     const {
       MAX_RELAYER_DEPOSIT_LOOK_BACK,
-      CHAIN_MULTICALL_CHUNK_SIZE,
       CONFIGURED_NETWORKS,
       HUB_CHAIN_ID,
       POLLING_DELAY,

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -62,6 +62,7 @@ export class CommonConfig {
             ?? DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE[chainId]
             ?? DEFAULT_MULTICALL_CHUNK_SIZE
         );
+        assert(chunkSize > 0, `Chain ${chainId} multicall chunk size must be greater than 0.`);
         return [chainId, chunkSize];
       })
     );

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_MULTICALL_CHUNK_SIZE, DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE } from "../common";
 import { assert } from "../utils";
 import * as Constants from "./Constants";
 
@@ -17,11 +18,13 @@ export class CommonConfig {
   readonly bundleRefundLookback: number;
   readonly maxRelayerLookBack: { [chainId: number]: number };
   readonly maxRelayerUnfilledDepositLookBack: { [chainId: number]: number };
+  readonly multiCallChunkSize: { [chainId: number]: number };
   readonly version: string;
 
   constructor(env: ProcessEnv) {
     const {
       MAX_RELAYER_DEPOSIT_LOOK_BACK,
+      CHAIN_MULTICALL_CHUNK_SIZE,
       CONFIGURED_NETWORKS,
       HUB_CHAIN_ID,
       POLLING_DELAY,
@@ -62,5 +65,12 @@ export class CommonConfig {
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
     this.redisUrl = REDIS_URL;
     this.bundleRefundLookback = BUNDLE_REFUND_LOOKBACK ? Number(BUNDLE_REFUND_LOOKBACK) : 2;
+
+    this.multiCallChunkSize = CHAIN_MULTICALL_CHUNK_SIZE
+      ? JSON.parse(CHAIN_MULTICALL_CHUNK_SIZE)
+      : DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE;
+    Object(this.spokePoolChains).forEach((chainId) => {
+      this.multiCallChunkSize[chainId] = this.multiCallChunkSize[chainId] ?? DEFAULT_MULTICALL_CHUNK_SIZE;
+    });
   }
 }

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -58,7 +58,7 @@ export class CommonConfig {
         const chainId = Number(_chainId);
         // prettier-ignore
         const chunkSize = Number(
-          process.env[`CHAIN_${chainId}_MULTICALL_CHUNK_SIZE`]
+          process.env[`MULTICALL_CHUNK_SIZE_CHAIN_${chainId}`]
             ?? DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE[chainId]
             ?? DEFAULT_MULTICALL_CHUNK_SIZE
         );

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -98,7 +98,7 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
 export const DEFAULT_RELAYER_GAS_MULTIPLIER = 1.2;
 
 export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
-export const CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
+export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
   1: DEFAULT_MULTICALL_CHUNK_SIZE,
   10: 75,
   137: DEFAULT_MULTICALL_CHUNK_SIZE,

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -101,11 +101,7 @@ export const DEFAULT_RELAYER_GAS_MULTIPLIER = 1.2;
 
 export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
 export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
-  1: DEFAULT_MULTICALL_CHUNK_SIZE,
   10: 75,
-  137: DEFAULT_MULTICALL_CHUNK_SIZE,
-  288: DEFAULT_MULTICALL_CHUNK_SIZE,
-  42161: DEFAULT_MULTICALL_CHUNK_SIZE,
 };
 
 // The most critical failure mode that can happen in the inventory management module is a miss-mapping between L1 token


### PR DESCRIPTION
Identified as a requirement when we detected that Optimism RPCs were
not accepting the default chunk size of 100 txns. At that point it would
have been really convenient to override via the environment rather than
forcing a new bot revision...but this wasn't supported by the bots.

Fixes ACX-437.