### PR TITLE
improve(ProfitClient): Remove ignoreTokenPriceFailures option

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -72,8 +72,6 @@ export class ProfitClient {
     spokePoolClients: SpokePoolClientsByChain,
     readonly ignoreProfitability: boolean,
     readonly enabledChainIds: number[],
-    // Default to throwing errors if fetching token prices fails.
-    readonly ignoreTokenPriceFailures: boolean = false,
     readonly minRelayerFeePct: BigNumber = toBNWei(constants.RELAYER_MIN_FEE_PCT),
     readonly debugProfitability: boolean = false,
     protected gasMultiplier: BigNumber = toBNWei(1)
@@ -324,9 +322,7 @@ export class ProfitClient {
         mrkdwn += `- Using last known ${l1Token.symbol} price of ${this.getPriceOfToken(l1Token.address)}.\n`;
       });
       this.logger.warn({ at: "ProfitClient", message: "Could not fetch all token prices 💳", mrkdwn });
-      if (!this.ignoreTokenPriceFailures) {
-        throw new Error(errMsg);
-      }
+      if (!this.ignoreProfitability) throw new Error(errMsg);
     }
   }
 

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -51,7 +51,7 @@ export async function constructDataworkerClients(
   // Disable profitability by default as only the relayer needs it.
   // The dataworker only needs price updates from ProfitClient to calculate bundle volume.
   const profitClient = config.proposerEnabled
-    ? new ProfitClient(logger, commonClients.hubPoolClient, {}, false, [], true)
+    ? new ProfitClient(logger, commonClients.hubPoolClient, {}, false, [])
     : undefined;
 
   return {

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -42,7 +42,6 @@ export async function constructRelayerClients(
     spokePoolClients,
     config.ignoreProfitability,
     enabledChainIds,
-    config.ignoreTokenPriceFailures,
     config.minRelayerFeePct,
     config.debugProfitability,
     config.relayerGasMultiplier

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -10,7 +10,6 @@ export class RelayerConfig extends CommonConfig {
   readonly debugProfitability: boolean;
   // Whether token price fetch failures will be ignored when computing relay profitability.
   // If this is false, the relayer will throw an error when fetching prices fails.
-  readonly ignoreTokenPriceFailures: boolean;
   readonly sendingRelaysEnabled: boolean;
   readonly sendingSlowRelaysEnabled: boolean;
   readonly relayerTokens: string[];
@@ -36,7 +35,6 @@ export class RelayerConfig extends CommonConfig {
       RELAYER_DESTINATION_CHAINS,
       DEBUG_PROFITABILITY,
       IGNORE_PROFITABILITY,
-      IGNORE_TOKEN_PRICE_FAILURES,
       RELAYER_GAS_MULTIPLIER,
       RELAYER_INVENTORY_CONFIG,
       RELAYER_TOKENS,
@@ -87,7 +85,6 @@ export class RelayerConfig extends CommonConfig {
     }
     this.debugProfitability = DEBUG_PROFITABILITY === "true";
     this.ignoreProfitability = IGNORE_PROFITABILITY === "true";
-    this.ignoreTokenPriceFailures = IGNORE_TOKEN_PRICE_FAILURES === "true";
     this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -89,7 +89,6 @@ describe("ProfitClient: Consider relay profit", async function () {
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
 
     const ignoreProfitability = false;
-    const ignoreTokenPriceFailures = false;
     const debugProfitability = true;
 
     profitClient = new MockProfitClient(
@@ -98,7 +97,6 @@ describe("ProfitClient: Consider relay profit", async function () {
       spokePoolClients,
       ignoreProfitability,
       [],
-      ignoreTokenPriceFailures,
       minRelayerFeePct,
       debugProfitability
     );

--- a/test/ProfitClient.PriceRetrieval.ts
+++ b/test/ProfitClient.PriceRetrieval.ts
@@ -57,7 +57,7 @@ describe("ProfitClient: Price Retrieval", async function () {
   beforeEach(async function () {
     hubPoolClient = new MockHubPoolClient(null, null);
     mainnetTokens.forEach((token: L1Token) => hubPoolClient.addL1Token(token));
-    profitClient = new ProfitClientWithMockPriceClient(spyLogger, hubPoolClient, {}, true, [], false, toBN(0));
+    profitClient = new ProfitClientWithMockPriceClient(spyLogger, hubPoolClient, {}, true, [], toBN(0));
   });
 
   it("Correctly fetches token prices", async function () {

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -55,7 +55,7 @@ describe.skip("Relayer: Iterative fill", async function () {
     });
 
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
-    profitClient = new ProfitClient(spyLogger, hubPoolClient, {}, true, [], false, toBNWei(1)); // Set relayer discount to 100%.
+    profitClient = new ProfitClient(spyLogger, hubPoolClient, {}, true, [], toBNWei(1)); // Set relayer discount to 100%.
     await updateAllClients();
     relayerInstance = new Relayer(
       relayer.address,

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -186,7 +186,7 @@ export async function setupDataworker(
     [repaymentChainId]: spokePoolClient_3,
     1: spokePoolClient_4,
   };
-  const profitClient = new clients.ProfitClient(spyLogger, hubPoolClient, spokePoolClients, false, [], true);
+  const profitClient = new clients.ProfitClient(spyLogger, hubPoolClient, spokePoolClients, false, []);
   const bundleDataClient = new BundleDataClient(
     spyLogger,
     {


### PR DESCRIPTION
This variable seems pretty redundant now. Price lookup failures are very
rare these days because we have fallback from the Across API to
CoinGecko Free/Pro, and DefiLlama exists as a third option if we choose
to use it. Additionally, the ignoreProfitability option is another good
proxy for whether we want to be strict about price lookup failures.