### PR TITLE
feat: Enable route-specific rate model in ConfigStoreClient

### DIFF
--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -75,10 +75,12 @@ export class AcrossConfigStoreClient {
     // Test SNX deposit was before the rate model update for SNX.
     if (quoteBlock === 14856066) quoteBlock = 14856211;
 
-    // Use route-rate model if available, otherwise use default rate model for l1Token.
-    const route = `${deposit.originChainId}-${deposit.destinationChainId}`;
-    const routeRateModel = this.getRouteRateModelForBlockNumber(l1Token, route, quoteBlock);
-    const rateModel = routeRateModel ?? this.getRateModelForBlockNumber(l1Token, quoteBlock);
+    const rateModel = this.getRateModelForBlockNumber(
+      l1Token,
+      deposit.originChainId,
+      deposit.destinationChainId,
+      quoteBlock
+    );
 
     // There is one deposit on optimism that is right at the margin of when liquidity was first added.
     if (quoteBlock > 14718100 && quoteBlock < 14718107) quoteBlock = 14718107;
@@ -89,8 +91,16 @@ export class AcrossConfigStoreClient {
     return { realizedLpFeePct, quoteBlock };
   }
 
-  getRateModelForBlockNumber(l1Token: string, blockNumber: number | undefined = undefined): across.constants.RateModel {
-    return this.rateModelDictionary.getRateModelForBlockNumber(l1Token, blockNumber);
+  getRateModelForBlockNumber(
+    l1Token: string,
+    originChainId: number | string,
+    destinationChainId: number | string,
+    blockNumber: number | undefined = undefined
+  ): across.constants.RateModel {
+    // Use route-rate model if available, otherwise use default rate model for l1Token.
+    const route = `${originChainId}-${destinationChainId}`;
+    const routeRateModel = this.getRouteRateModelForBlockNumber(l1Token, route, blockNumber);
+    return routeRateModel ?? this.rateModelDictionary.getRateModelForBlockNumber(l1Token, blockNumber);
   }
 
   getRouteRateModelForBlockNumber(

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -111,8 +111,8 @@ export class AcrossConfigStoreClient {
     const config = (sortEventsDescending(this.cumulativeRouteRateModelUpdates) as RouteRateModelUpdate[]).find(
       (config) => config.blockNumber <= blockNumber && config.l1Token === l1Token
     );
-    if (config[route] === undefined) return undefined;
-    return across.rateModel.parseAndReturnRateModelFromString(config[route]);
+    if (config?.routeRateModels[route] === undefined) return undefined;
+    return across.rateModel.parseAndReturnRateModelFromString(config.routeRateModels[route]);
   }
 
   getTokenTransferThresholdForBlock(l1Token: string, blockNumber: number = Number.MAX_SAFE_INTEGER): BigNumber {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -456,6 +456,7 @@ export class SpokePoolClient {
     const deposit = {
       amount: depositEvent.args.amount,
       originChainId: Number(depositEvent.args.originChainId),
+      destinationChainId: Number(depositEvent.args.destinationChainId),
       originToken: depositEvent.args.originToken,
       quoteTimestamp: depositEvent.args.quoteTimestamp,
     };

--- a/src/interfaces/ConfigStore.ts
+++ b/src/interfaces/ConfigStore.ts
@@ -1,18 +1,11 @@
 import { BigNumber } from "../utils";
 import { SortableEvent } from "./Common";
 import { across } from "@uma/sdk";
-
-export interface RateModel {
-  UBar: string;
-  R0: string;
-  R1: string;
-  R2: string;
-}
 export interface ParsedTokenConfig {
   transferThreshold: string;
-  rateModel: RateModel;
+  rateModel: across.rateModel.RateModelDictionary;
   routeRateModels?: {
-    [path: string]: RateModel;
+    [path: string]: across.rateModel.RateModelDictionary;
   };
   spokeTargetBalances?: {
     [chainId: number]: {

--- a/src/interfaces/ConfigStore.ts
+++ b/src/interfaces/ConfigStore.ts
@@ -1,16 +1,18 @@
 import { BigNumber } from "../utils";
 import { SortableEvent } from "./Common";
+import { across } from "@uma/sdk";
 
+export interface RateModel {
+  UBar: string;
+  R0: string;
+  R1: string;
+  R2: string;
+}
 export interface ParsedTokenConfig {
   transferThreshold: string;
-  rateModel: {
-    UBar: string;
-    R0: string;
-    R1: string;
-    R2: string;
-  };
-  lpFeeScaling?: {
-    [chainId: number]: string;
+  rateModel: RateModel;
+  routeRateModels?: {
+    [path: string]: RateModel;
   };
   spokeTargetBalances?: {
     [chainId: number]: {
@@ -25,11 +27,6 @@ export interface L1TokenTransferThreshold extends SortableEvent {
   l1Token: string;
 }
 
-export interface LpFeeScaling extends SortableEvent {
-  scalingPct: { [chainId: number]: number };
-  l1Token: string;
-}
-
 export interface SpokePoolTargetBalance {
   target: BigNumber;
   threshold: BigNumber;
@@ -38,6 +35,13 @@ export interface SpokePoolTargetBalance {
 export interface SpokeTargetBalanceUpdate extends SortableEvent {
   spokeTargetBalances?: {
     [chainId: number]: SpokePoolTargetBalance;
+  };
+  l1Token: string;
+}
+
+export interface RouteRateModelUpdate extends SortableEvent {
+  routeRateModels: {
+    [path: string]: string;
   };
   l1Token: string;
 }

--- a/src/interfaces/ConfigStore.ts
+++ b/src/interfaces/ConfigStore.ts
@@ -9,6 +9,9 @@ export interface ParsedTokenConfig {
     R1: string;
     R2: string;
   };
+  lpFeeScaling?: {
+    [chainId: number]: string;
+  };
   spokeTargetBalances?: {
     [chainId: number]: {
       target: string;
@@ -19,6 +22,11 @@ export interface ParsedTokenConfig {
 
 export interface L1TokenTransferThreshold extends SortableEvent {
   transferThreshold: BigNumber;
+  l1Token: string;
+}
+
+export interface LpFeeScaling extends SortableEvent {
+  scalingPct: { [chainId: number]: number };
   l1Token: string;
 }
 


### PR DESCRIPTION
Supports the ability for Across to charge different LP fees based on route.

Follow up PR will add feature to `sdk-v2` and the API in `frontend-v2`.

There is no risk to merging this now since `AcrossConfigStore` does not currently contain any `routeRateModels`

