### PR TITLE
improve: Construct AcrossAPIClient with only L1 tokens enabeld in HubPool

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -2,6 +2,7 @@ import { winston, BigNumber, MAX_UINT_VAL } from "../utils";
 import { l2TokensToL1TokenValidation } from "../common";
 import axios, { AxiosError } from "axios";
 import get from "lodash.get";
+import { HubPoolClient } from "./HubPoolClient";
 
 export interface DepositLimits {
   maxDeposit: BigNumber;
@@ -15,7 +16,12 @@ export class AcrossApiClient {
   public updatedLimits = false;
 
   // Note: Max vercel execution duration is 1 minute
-  constructor(readonly logger: winston.Logger, readonly tokensQuery: string[] = [], readonly timeout: number = 60000) {
+  constructor(
+    readonly logger: winston.Logger,
+    readonly hubPoolClient: HubPoolClient,
+    readonly tokensQuery: string[] = [],
+    readonly timeout: number = 60000
+  ) {
     if (Object.keys(tokensQuery).length === 0) this.tokensQuery = Object.keys(l2TokensToL1TokenValidation);
   }
 
@@ -25,11 +31,15 @@ export class AcrossApiClient {
       return;
     }
 
+    // Note: Skip tokens not currently enabled in HubPool as we won't be able to relay them.
+    if (!this.hubPoolClient.isUpdated) throw new Error("HubPoolClient must be updated before AcrossAPIClient");
+    const enabledTokens = this.hubPoolClient.getL1Tokens().map((token) => token.address);
+    const tokensQuery = this.tokensQuery.filter((token) => enabledTokens.includes(token));
     this.logger.debug({
       at: "AcrossAPIClient",
       message: "Querying /limits",
       timeout: this.timeout,
-      tokensQuery: this.tokensQuery,
+      tokensQuery,
       endpoint: this.endpoint,
     });
     this.updatedLimits = false;
@@ -39,15 +49,15 @@ export class AcrossApiClient {
     // liquidity is shared for all tokens and affects maxDeposit. We don't care about maxDepositInstant
     // when deciding whether a relay will be refunded.
     const data = await Promise.all(
-      this.tokensQuery.map((l1Token) => {
+      tokensQuery.map((l1Token) => {
         const validDestinationChainForL1Token = l2TokensToL1TokenValidation[l1Token]
           ? Number(Object.keys(l2TokensToL1TokenValidation[l1Token])[0])
           : 10;
         return this.callLimits(l1Token, validDestinationChainForL1Token);
       })
     );
-    for (let i = 0; i < this.tokensQuery.length; i++) {
-      const l1Token = this.tokensQuery[i];
+    for (let i = 0; i < tokensQuery.length; i++) {
+      const l1Token = tokensQuery[i];
       this.limits[l1Token] = data[i].maxDeposit;
     }
     this.logger.debug({

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -93,7 +93,7 @@ export async function updateRelayerClients(clients: RelayerClients, config: Rela
 
   // We can update the inventory client at the same time as checking for eth wrapping as these do not depend on each other.
   await Promise.all([
-    clients.acrossApiClient.update(config.ignoreLimits), // Note: AcrossAPIClient requires HubPoolClient to be updated.
+    clients.acrossApiClient.update(config.ignoreLimits),
     clients.inventoryClient.update(),
     clients.inventoryClient.wrapL2EthIfAboveThreshold(),
     clients.inventoryClient.setL1TokenApprovals(),

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -30,7 +30,7 @@ export async function constructRelayerClients(
     config.maxRelayerLookBack
   );
 
-  const acrossApiClient = new AcrossApiClient(logger, config.relayerTokens);
+  const acrossApiClient = new AcrossApiClient(logger, commonClients.hubPoolClient, config.relayerTokens);
   const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);
 
   // If `relayerDestinationChains` is a non-empty array, then copy its value, otherwise default to all chains.
@@ -93,7 +93,7 @@ export async function updateRelayerClients(clients: RelayerClients, config: Rela
 
   // We can update the inventory client at the same time as checking for eth wrapping as these do not depend on each other.
   await Promise.all([
-    clients.acrossApiClient.update(config.ignoreLimits),
+    clients.acrossApiClient.update(config.ignoreLimits), // Note: AcrossAPIClient requires HubPoolClient to be updated.
     clients.inventoryClient.update(),
     clients.inventoryClient.wrapL2EthIfAboveThreshold(),
     clients.inventoryClient.setL1TokenApprovals(),

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -30,11 +30,7 @@ export async function constructRelayerClients(
     config.maxRelayerLookBack
   );
 
-  const enabledL1Tokens = commonClients.hubPoolClient.getL1Tokens().map((token) => token.address);
-  const acrossApiClient = new AcrossApiClient(
-    logger,
-    config.relayerTokens.filter((token) => enabledL1Tokens.includes(token))
-  );
+  const acrossApiClient = new AcrossApiClient(logger, config.relayerTokens);
   const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);
 
   // If `relayerDestinationChains` is a non-empty array, then copy its value, otherwise default to all chains.

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -30,7 +30,11 @@ export async function constructRelayerClients(
     config.maxRelayerLookBack
   );
 
-  const acrossApiClient = new AcrossApiClient(logger, config.relayerTokens);
+  const enabledL1Tokens = commonClients.hubPoolClient.getL1Tokens().map((token) => token.address);
+  const acrossApiClient = new AcrossApiClient(
+    logger,
+    config.relayerTokens.filter((token) => enabledL1Tokens.includes(token))
+  );
   const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);
 
   // If `relayerDestinationChains` is a non-empty array, then copy its value, otherwise default to all chains.

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -1,4 +1,4 @@
-import { BigNumber, toBNWei, assert, toBN, replaceAddressCase } from "../utils";
+import { BigNumber, toBNWei, assert, toBN, replaceAddressCase, ethers } from "../utils";
 import { CommonConfig, ProcessEnv } from "../common";
 import * as Constants from "../common/Constants";
 import { InventoryConfig } from "../interfaces";
@@ -51,7 +51,9 @@ export class RelayerConfig extends CommonConfig {
     // Empty means all chains.
     this.relayerDestinationChains = RELAYER_DESTINATION_CHAINS ? JSON.parse(RELAYER_DESTINATION_CHAINS) : [];
     // Empty means all tokens.
-    this.relayerTokens = RELAYER_TOKENS ? JSON.parse(RELAYER_TOKENS) : [];
+    this.relayerTokens = RELAYER_TOKENS
+      ? JSON.parse(RELAYER_TOKENS).map((token) => ethers.utils.getAddress(token))
+      : [];
     this.inventoryConfig = RELAYER_INVENTORY_CONFIG ? JSON.parse(RELAYER_INVENTORY_CONFIG) : {};
     this.minRelayerFeePct = toBNWei(MIN_RELAYER_FEE_PCT || Constants.RELAYER_MIN_FEE_PCT);
 

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -80,7 +80,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
       },
       {
         relayerTokens: [],
@@ -159,7 +159,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
       },
       {
         relayerTokens: [],
@@ -195,7 +195,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
       },
       {
         relayerTokens: [],
@@ -284,7 +284,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -68,7 +68,7 @@ describe.skip("Relayer: Iterative fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger),
+        acrossApiClient: new AcrossApiClient, configStoreClient.hubPoolClient),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -68,7 +68,7 @@ describe.skip("Relayer: Iterative fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient, configStoreClient.hubPoolClient),
+        acrossApiClient: new AcrossApiClient(spyLogger, configStoreClient.hubPoolClient),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -68,7 +68,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -68,7 +68,7 @@ describe("Relayer: Token balance shortfall", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -85,7 +85,7 @@ describe("Relayer: Unfilled Deposits", async function () {
         tokenClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
       },
       {
         relayerTokens: [],


### PR DESCRIPTION
AcrossAPI fails to return data for l1 tokens not enabled in hub pool, so relayer should construct the APIClient only with enabled L1 tokens
﻿Signed-off-by: nicholaspai <npai.nyc@gmail.com>
