### PR TITLE
improve: Use lookback based on time for all chains in Finalizer, Relayer and Monitor

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -52,7 +52,6 @@ export async function constructSpokePoolClientsWithLookback(
     )
   );
   );
-  const fromBlocks = Object.fromEntries(spokePools.map((obj, index) => [obj.chainId, _fromBlocks[index]]));
 
   return getSpokePoolClientsForContract(logger, configStoreClient, config, spokePools, fromBlocks);
 }

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -51,7 +51,6 @@ export async function constructSpokePoolClientsWithLookback(
         : spokePools.map(async (obj) => [obj.chainId, await getDeployedBlockNumber("SpokePool", obj.chainId)])
     )
   );
-  );
 
   return getSpokePoolClientsForContract(logger, configStoreClient, config, spokePools, fromBlocks);
 }

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -1,5 +1,12 @@
 import winston from "winston";
-import { getProvider, getDeployedContract, getDeploymentBlockNumber, Wallet, Contract } from "../utils";
+import {
+  getProvider,
+  getDeployedContract,
+  getDeploymentBlockNumber,
+  Wallet,
+  Contract,
+  getDeployedBlockNumber,
+} from "../utils";
 import { HubPoolClient, MultiCallerClient, AcrossConfigStoreClient, SpokePoolClient } from "../clients";
 import { CommonConfig } from "./Config";
 import { createClient } from "redis4";
@@ -41,7 +48,7 @@ export async function constructSpokePoolClientsWithLookback(
       ? spokePools.map((obj: { chainId: number; contract: Contract }) =>
           utils.findBlockAtOrOlder(obj.contract.provider, initialLookBackOverride)
         )
-      : spokePools.map((obj: { contract: Contract }) => obj.contract.provider.getBlockNumber())
+      : spokePools.map((obj: { chainId: number }) => getDeployedBlockNumber("SpokePool", obj.chainId))
   );
   const fromBlocks = Object.fromEntries(
     spokePools.map((obj: { chainId: number }, i: number) => {

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -55,7 +55,7 @@ export async function constructSpokePoolClientsWithLookback(
   return getSpokePoolClientsForContract(logger, configStoreClient, config, spokePools, fromBlocks);
 }
 
-function getSpokePoolClientsForContract(
+export function getSpokePoolClientsForContract(
   logger: winston.Logger,
   configStoreClient: AcrossConfigStoreClient,
   config: CommonConfig,

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -43,17 +43,15 @@ export async function constructSpokePoolClientsWithLookback(
 
   // If initial lookback override is non-zero, then look up the l2 block number at that time, otherwise
   // use latest L2 block.
-  const _fromBlocks = await Promise.all(
-    initialLookBackOverride > 0
-      ? spokePools.map((obj: { chainId: number; contract: Contract }) =>
-          utils.findBlockAtOrOlder(obj.contract.provider, initialLookBackOverride)
-        )
-      : spokePools.map((obj: { chainId: number }) => getDeployedBlockNumber("SpokePool", obj.chainId))
-  );
   const fromBlocks = Object.fromEntries(
-    spokePools.map((obj: { chainId: number }, i: number) => {
-      return [obj.chainId, _fromBlocks[i]];
-    })
+    await Promise.all(
+      initialLookBackOverride > 0
+        ? spokePools.map((obj) => [
+            obj.chainId,
+            utils.findBlockAtOrOlder(obj.contract.provider, initialLookBackOverride),
+          ])
+        : spokePools.map((obj) => [obj.chainId, getDeployedBlockNumber("SpokePool", obj.chainId)])
+    )
   );
 
   return getSpokePoolClientsForContract(logger, configStoreClient, config, spokePools, fromBlocks);

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -43,16 +43,12 @@ export async function constructSpokePoolClientsWithLookback(
 
   // If initial lookback override is non-zero, then look up the l2 block number at that time, otherwise
   // use latest L2 block.
-  const fromBlocks = Object.fromEntries(
-    await Promise.all(
-      initialLookBackOverride > 0
-        ? spokePools.map((obj) => [
-            obj.chainId,
-            utils.findBlockAtOrOlder(obj.contract.provider, initialLookBackOverride),
-          ])
-        : spokePools.map((obj) => [obj.chainId, getDeployedBlockNumber("SpokePool", obj.chainId)])
-    )
+  const _fromBlocks = await Promise.all(
+    initialLookBackOverride > 0
+      ? spokePools.map((obj) => utils.findBlockAtOrOlder(obj.contract.provider, initialLookBackOverride))
+      : spokePools.map((obj) => getDeployedBlockNumber("SpokePool", obj.chainId))
   );
+  const fromBlocks = Object.fromEntries(spokePools.map((obj, index) => [obj.chainId, _fromBlocks[index]]));
 
   return getSpokePoolClientsForContract(logger, configStoreClient, config, spokePools, fromBlocks);
 }

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -41,12 +41,16 @@ export async function constructSpokePoolClientsWithLookback(
     return { chainId, contract: getDeployedContract("SpokePool", chainId, spokePoolSigners[chainId]) };
   });
 
-  // If initial lookback override is non-zero, then look up the l2 block number at that time, otherwise
-  // use latest L2 block.
-  const _fromBlocks = await Promise.all(
-    initialLookBackOverride > 0
-      ? spokePools.map((obj) => utils.findBlockAtOrOlder(obj.contract.provider, initialLookBackOverride))
-      : spokePools.map((obj) => getDeployedBlockNumber("SpokePool", obj.chainId))
+  const fromBlocks = Object.fromEntries(
+    await Promise.all(
+      initialLookBackOverride > 0
+        ? spokePools.map(async (obj) => [
+            obj.chainId,
+            await utils.findBlockAtOrOlder(obj.contract.provider, initialLookBackOverride),
+          ])
+        : spokePools.map(async (obj) => [obj.chainId, await getDeployedBlockNumber("SpokePool", obj.chainId)])
+    )
+  );
   );
   const fromBlocks = Object.fromEntries(spokePools.map((obj, index) => [obj.chainId, _fromBlocks[index]]));
 

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -4,7 +4,7 @@ import { HubPoolClient, MultiCallerClient, AcrossConfigStoreClient, SpokePoolCli
 import { CommonConfig } from "./Config";
 import { createClient } from "redis4";
 import { SpokePoolClientsByChain } from "../interfaces";
-import { utils } from "@across-protocol/sdk-v2"
+import { utils } from "@across-protocol/sdk-v2";
 
 export interface Clients {
   hubPoolClient: HubPoolClient;
@@ -37,12 +37,17 @@ export async function constructSpokePoolClientsWithLookback(
   // If initial lookback override is non-zero, then look up the l2 block number at that time, otherwise
   // use latest L2 block.
   const _fromBlocks = await Promise.all(
-    initialLookBackOverride > 0 ?
-        spokePools.map((obj: { chainId: number; contract: Contract }) => utils.findBlockAtOrOlder(obj.contract.provider, initialLookBackOverride))
-      :
-        spokePools.map((obj: { contract: Contract }) => obj.contract.provider.getBlockNumber())
+    initialLookBackOverride > 0
+      ? spokePools.map((obj: { chainId: number; contract: Contract }) =>
+          utils.findBlockAtOrOlder(obj.contract.provider, initialLookBackOverride)
+        )
+      : spokePools.map((obj: { contract: Contract }) => obj.contract.provider.getBlockNumber())
   );
-  const fromBlocks = Object.fromEntries(spokePools.map((obj: { chainId: number }, i: number) => { return [obj.chainId, _fromBlocks[i]] }))
+  const fromBlocks = Object.fromEntries(
+    spokePools.map((obj: { chainId: number }, i: number) => {
+      return [obj.chainId, _fromBlocks[i]];
+    })
+  );
 
   return getSpokePoolClientsForContract(logger, configStoreClient, config, spokePools, fromBlocks);
 }

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -15,8 +15,8 @@ export class CommonConfig {
   readonly sendingTransactionsEnabled: boolean;
   readonly redisUrl: string | undefined;
   readonly bundleRefundLookback: number;
-  readonly maxRelayerLookBack: { [chainId: number]: number };
-  readonly maxRelayerUnfilledDepositLookBack: { [chainId: number]: number };
+  readonly maxRelayerLookBack: number;
+  readonly maxRelayerUnfilledDepositLookBack: number;
   readonly version: string;
 
   constructor(env: ProcessEnv) {
@@ -37,19 +37,15 @@ export class CommonConfig {
 
     // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
     this.maxRelayerLookBack = MAX_RELAYER_DEPOSIT_LOOK_BACK
-      ? JSON.parse(MAX_RELAYER_DEPOSIT_LOOK_BACK)
+      ? Number(MAX_RELAYER_DEPOSIT_LOOK_BACK)
       : Constants.MAX_RELAYER_DEPOSIT_LOOK_BACK;
 
     // `maxRelayerUnfilledDepositLookBack` informs relayer to ignore any unfilled deposits older than this amount of
     // of blocks from latest. This allows us to ignore any false positive unfilled deposits that occur because of how
     // `maxRelayerLookBack` is set. This can happen because block lookback per chain is not exactly equal to the same
     // amount of time looking back on the chains, so you might produce some deposits that look like they weren't filled.
-    this.maxRelayerUnfilledDepositLookBack = { ...this.maxRelayerLookBack };
-    Object.keys(this.maxRelayerUnfilledDepositLookBack).forEach((_chainId) => {
-      const chainId = Number(_chainId);
-      this.maxRelayerUnfilledDepositLookBack[chainId] = Number(this.maxRelayerLookBack[chainId]) / 4; // TODO: Allow caller
-      // to modify what we divide `maxRelayerLookBack` values by.
-    });
+    this.maxRelayerUnfilledDepositLookBack = this.maxRelayerLookBack / 4; // TODO: Allow caller
+    // to modify what we divide `maxRelayerLookBack` values by.
     this.hubPoolChainId = HUB_CHAIN_ID ? Number(HUB_CHAIN_ID) : 1;
     this.spokePoolChains = CONFIGURED_NETWORKS ? JSON.parse(CONFIGURED_NETWORKS) : Constants.CHAIN_ID_LIST_INDICES;
     this.pollingDelay = POLLING_DELAY ? Number(POLLING_DELAY) : 60;

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -36,27 +36,24 @@ export class CommonConfig {
     this.version = ACROSS_BOT_VERSION ?? "unknown";
 
     // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
-    this.maxRelayerLookBack = MAX_RELAYER_DEPOSIT_LOOK_BACK
-      ? Number(MAX_RELAYER_DEPOSIT_LOOK_BACK)
-      : Constants.MAX_RELAYER_DEPOSIT_LOOK_BACK;
-
+    this.maxRelayerLookBack = Number(MAX_RELAYER_DEPOSIT_LOOK_BACK ?? Constants.MAX_RELAYER_DEPOSIT_LOOK_BACK);
     // `maxRelayerUnfilledDepositLookBack` informs relayer to ignore any unfilled deposits older than this amount of
     // of blocks from latest. This allows us to ignore any false positive unfilled deposits that occur because of how
     // `maxRelayerLookBack` is set. This can happen because block lookback per chain is not exactly equal to the same
     // amount of time looking back on the chains, so you might produce some deposits that look like they weren't filled.
     this.maxRelayerUnfilledDepositLookBack = this.maxRelayerLookBack / 4; // TODO: Allow caller
     // to modify what we divide `maxRelayerLookBack` values by.
-    this.hubPoolChainId = HUB_CHAIN_ID ? Number(HUB_CHAIN_ID) : 1;
+    this.hubPoolChainId = Number(HUB_CHAIN_ID ?? 1);
     this.spokePoolChains = CONFIGURED_NETWORKS ? JSON.parse(CONFIGURED_NETWORKS) : Constants.CHAIN_ID_LIST_INDICES;
-    this.pollingDelay = POLLING_DELAY ? Number(POLLING_DELAY) : 60;
+    this.pollingDelay = Number(POLLING_DELAY ?? 60);
     this.maxBlockLookBack = MAX_BLOCK_LOOK_BACK ? JSON.parse(MAX_BLOCK_LOOK_BACK) : {};
     if (Object.keys(this.maxBlockLookBack).length > 0)
       for (const chainId of this.spokePoolChains)
         assert(Object.keys(this.maxBlockLookBack).includes(chainId.toString()), "MAX_BLOCK_LOOK_BACK missing networks");
     else this.maxBlockLookBack = Constants.CHAIN_MAX_BLOCK_LOOKBACK;
-    this.maxTxWait = MAX_TX_WAIT_DURATION ? Number(MAX_TX_WAIT_DURATION) : 180; // 3 minutes
+    this.maxTxWait = Number(MAX_TX_WAIT_DURATION ?? 180); // 3 minutes
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
     this.redisUrl = REDIS_URL;
-    this.bundleRefundLookback = BUNDLE_REFUND_LOOKBACK ? Number(BUNDLE_REFUND_LOOKBACK) : 2;
+    this.bundleRefundLookback = Number(BUNDLE_REFUND_LOOKBACK ?? 2);
   }
 }

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -16,7 +16,6 @@ export class CommonConfig {
   readonly redisUrl: string | undefined;
   readonly bundleRefundLookback: number;
   readonly maxRelayerLookBack: number;
-  readonly maxRelayerUnfilledDepositLookBack: number;
   readonly version: string;
 
   constructor(env: ProcessEnv) {
@@ -37,12 +36,6 @@ export class CommonConfig {
 
     // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
     this.maxRelayerLookBack = Number(MAX_RELAYER_DEPOSIT_LOOK_BACK ?? Constants.MAX_RELAYER_DEPOSIT_LOOK_BACK);
-    // `maxRelayerUnfilledDepositLookBack` informs relayer to ignore any unfilled deposits older than this amount of
-    // of blocks from latest. This allows us to ignore any false positive unfilled deposits that occur because of how
-    // `maxRelayerLookBack` is set. This can happen because block lookback per chain is not exactly equal to the same
-    // amount of time looking back on the chains, so you might produce some deposits that look like they weren't filled.
-    this.maxRelayerUnfilledDepositLookBack = this.maxRelayerLookBack / 4; // TODO: Allow caller
-    // to modify what we divide `maxRelayerLookBack` values by.
     this.hubPoolChainId = Number(HUB_CHAIN_ID ?? 1);
     this.spokePoolChains = CONFIGURED_NETWORKS ? JSON.parse(CONFIGURED_NETWORKS) : Constants.CHAIN_ID_LIST_INDICES;
     this.pollingDelay = Number(POLLING_DELAY ?? 60);

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -66,13 +66,17 @@ export const MIN_DEPOSIT_CONFIRMATIONS: { [threshold: number | string]: { [chain
 };
 export const QUOTE_TIME_BUFFER = 12 * 5; // 5 blocks on Mainnet.
 
-// Optimism, ethereum can do infinity lookbacks. boba and Arbitrum limited to 100000 on infura.
+// Quicknode is the bottleneck here and imposes a 10k block limit on an event search.
+// Alchemy-Polygon imposes a 3500 block limit.
+// Note: a 0 value here leads to an infinite lookback, which would be useful and reduce RPC requests
+// if the RPC provider allows it. This is why the user should override these lookbacks if they are not using
+// Quicknode for example.
 export const CHAIN_MAX_BLOCK_LOOKBACK = {
-  1: 0, // Note: 0 gets defaulted to infinity lookback
-  10: 0,
+  1: 10000,
+  10: 10000, // Quick
   137: 3490,
   288: 4990,
-  42161: 99990,
+  42161: 10000,
 };
 
 export const BUNDLE_END_BLOCK_BUFFERS = {

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -4,14 +4,8 @@ export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];
 
 export const RELAYER_MIN_FEE_PCT = 0.0003;
 
-// Target ~2 days per chain. Avg. block times: { 1: 12s, 10/42161: ~0.25s, 137: 2.5s, 288: 30s }
-export const MAX_RELAYER_DEPOSIT_LOOK_BACK: { [chainId: number]: number } = {
-  1: 14400,
-  10: 691200,
-  137: 69120,
-  288: 5760,
-  42161: 691200,
-};
+// Target ~2 days per chain.
+export const MAX_RELAYER_DEPOSIT_LOOK_BACK = 2 * 24 * 60 * 60;
 
 // Target ~4 days per chain. Should cover all events needed to construct pending bundle.
 export const DATAWORKER_FAST_LOOKBACK: { [chainId: number]: number } = {
@@ -24,13 +18,7 @@ export const DATAWORKER_FAST_LOOKBACK: { [chainId: number]: number } = {
 
 // Target ~14 days per chain. Should cover all events that could be finalized, so 2x the optimistic
 // rollup challenge period seems safe.
-export const FINALIZER_TOKENBRIDGE_LOOKBACK: { [chainId: number]: number } = {
-  1: 100800,
-  10: 4838400,
-  137: 483840,
-  288: 40320,
-  42161: 4838400,
-};
+export const FINALIZER_TOKENBRIDGE_LOOKBACK = 14 * 24 * 60 * 60;
 
 // Reorgs are anticipated on Ethereum and Polygon. We use different following distances when processing deposit
 // events based on the USD amount of the deposit. This protects the relayer from the worst case situation where it fills

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -4,8 +4,8 @@ export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];
 
 export const RELAYER_MIN_FEE_PCT = 0.0003;
 
-// Target ~2 days per chain.
-export const MAX_RELAYER_DEPOSIT_LOOK_BACK = 2 * 24 * 60 * 60;
+// Target ~4 hours
+export const MAX_RELAYER_DEPOSIT_LOOK_BACK = 4 * 60 * 60;
 
 // Target ~4 days per chain. Should cover all events needed to construct pending bundle.
 export const DATAWORKER_FAST_LOOKBACK: { [chainId: number]: number } = {

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -5,6 +5,7 @@ import {
   Clients,
   CommonConfig,
   constructClients,
+  getSpokePoolClientsForContract,
   getSpokePoolSigners,
   updateClients,
   updateSpokePoolClients,
@@ -195,14 +196,4 @@ export function getSpokePoolClientEventSearchConfigsForFastDataworker(
     fromBlocks,
     toBlocks,
   };
-}
-function getSpokePoolClientsForContract(
-  logger: winston.Logger,
-  configStoreClient: AcrossConfigStoreClient,
-  config: CommonConfig,
-  spokePools: { chainId: number; contract: ethers.Contract }[],
-  fromBlocks: { [chainId: number]: number },
-  toBlockOverride: { [chainId: number]: number }
-): SpokePoolClientsByChain | PromiseLike<SpokePoolClientsByChain> {
-  throw new Error("Function not implemented.");
 }

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -133,15 +133,14 @@ export async function constructSpokePoolClientsForFastDataworker(
     startBlocks,
     endBlocks
   );
-  await updateSpokePoolClients(spokePoolClients, 
-    [
-      "FundsDeposited",
-      "RequestedSpeedUpDeposit",
-      "FilledRelay",
-      "EnabledDepositRoute",
-      "RelayedRootBundle",
-      "ExecutedRelayerRefundRoot",
-    ]);
+  await updateSpokePoolClients(spokePoolClients, [
+    "FundsDeposited",
+    "RequestedSpeedUpDeposit",
+    "FilledRelay",
+    "EnabledDepositRoute",
+    "RelayedRootBundle",
+    "ExecutedRelayerRefundRoot",
+  ]);
   return spokePoolClients;
 }
 
@@ -197,7 +196,13 @@ export function getSpokePoolClientEventSearchConfigsForFastDataworker(
     toBlocks,
   };
 }
-function getSpokePoolClientsForContract(logger: winston.Logger, configStoreClient: AcrossConfigStoreClient, config: CommonConfig, spokePools: { chainId: number; contract: ethers.Contract; }[], fromBlocks: { [chainId: number]: number; }, toBlockOverride: { [chainId: number]: number; }): SpokePoolClientsByChain | PromiseLike<SpokePoolClientsByChain> {
+function getSpokePoolClientsForContract(
+  logger: winston.Logger,
+  configStoreClient: AcrossConfigStoreClient,
+  config: CommonConfig,
+  spokePools: { chainId: number; contract: ethers.Contract }[],
+  fromBlocks: { [chainId: number]: number },
+  toBlockOverride: { [chainId: number]: number }
+): SpokePoolClientsByChain | PromiseLike<SpokePoolClientsByChain> {
   throw new Error("Function not implemented.");
 }
-

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -183,7 +183,7 @@ export class FinalizerConfig extends DataworkerConfig {
     // By default, filters out any TokensBridged events younger than 1 days old and older than 2 days old.
     this.polygonFinalizationWindow = Number(FINALIZER_POLYGON_FINALIZATION_WINDOW ?? oneDayOfBlocks);
     // `maxFinalizerLookback` is how far we fetch events from, modifying the search config's 'fromBlock'
-    this.maxFinalizerLookback = Number(FINALIZER_MAX_TOKENBRIDGE_LOOKBACK ?? FINALIZER_MAX_TOKENBRIDGE_LOOKBACK);
+    this.maxFinalizerLookback = Number(FINALIZER_MAX_TOKENBRIDGE_LOOKBACK ?? FINALIZER_TOKENBRIDGE_LOOKBACK);
   }
 }
 

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -179,17 +179,11 @@ export class FinalizerConfig extends DataworkerConfig {
     super(env);
 
     // By default, filters out any TokensBridged events younger than 5 days old and older than 10 days old.
-    this.optimisticRollupFinalizationWindow = FINALIZER_OROLLUP_FINALIZATION_WINDOW
-      ? Number(FINALIZER_OROLLUP_FINALIZATION_WINDOW)
-      : fiveDaysOfBlocks;
+    this.optimisticRollupFinalizationWindow = Number(FINALIZER_OROLLUP_FINALIZATION_WINDOW ?? fiveDaysOfBlocks);
     // By default, filters out any TokensBridged events younger than 1 days old and older than 2 days old.
-    this.polygonFinalizationWindow = FINALIZER_POLYGON_FINALIZATION_WINDOW
-      ? Number(FINALIZER_POLYGON_FINALIZATION_WINDOW)
-      : oneDayOfBlocks;
+    this.polygonFinalizationWindow = Number(FINALIZER_POLYGON_FINALIZATION_WINDOW ?? oneDayOfBlocks);
     // `maxFinalizerLookback` is how far we fetch events from, modifying the search config's 'fromBlock'
-    this.maxFinalizerLookback = FINALIZER_MAX_TOKENBRIDGE_LOOKBACK
-      ? Number(FINALIZER_MAX_TOKENBRIDGE_LOOKBACK)
-      : FINALIZER_TOKENBRIDGE_LOOKBACK;
+    this.maxFinalizerLookback = Number(FINALIZER_MAX_TOKENBRIDGE_LOOKBACK ?? FINALIZER_MAX_TOKENBRIDGE_LOOKBACK);
   }
 }
 

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -188,7 +188,7 @@ export class FinalizerConfig extends DataworkerConfig {
       : oneDayOfBlocks;
     // `maxFinalizerLookback` is how far we fetch events from, modifying the search config's 'fromBlock'
     this.maxFinalizerLookback = FINALIZER_MAX_TOKENBRIDGE_LOOKBACK
-      ? JSON.parse(FINALIZER_MAX_TOKENBRIDGE_LOOKBACK)
+      ? Number(FINALIZER_MAX_TOKENBRIDGE_LOOKBACK)
       : FINALIZER_TOKENBRIDGE_LOOKBACK;
   }
 }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -170,10 +170,7 @@ export class Monitor {
   }
 
   async reportUnfilledDeposits() {
-    const unfilledDeposits = getUnfilledDeposits(
-      this.clients.spokePoolClients,
-      this.monitorConfig.maxRelayerUnfilledDepositLookBack
-    );
+    const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.monitorConfig.maxRelayerLookBack);
 
     // Group unfilled amounts by chain id and token id.
     const unfilledAmountByChainAndToken: { [chainId: number]: { [tokenAddress: string]: BigNumber } } = {};

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -82,7 +82,10 @@ export class Relayer {
     const latestHubPoolTime = this.clients.hubPoolClient.currentTime;
 
     // Require that all fillable deposits meet the minimum specified number of confirmations.
-    const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.config.maxRelayerUnfilledDepositLookBack)
+    const unfilledDeposits = getUnfilledDeposits(
+      this.clients.spokePoolClients,
+      this.config.maxRelayerUnfilledDepositLookBack
+    )
       .filter((x) => {
         return (
           x.deposit.quoteTimestamp + this.config.quoteTimeBuffer <= latestHubPoolTime &&

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -20,16 +20,13 @@ export class Relayer {
   // Track by originChainId since depositId is issued on the origin chain.
   // Key is in the form of "chainId-depositId".
   private fullyFilledDeposits: { [key: string]: boolean } = {};
-  private readonly maxUnfilledDepositLookBack: { [chainId: number]: number } = {};
 
   constructor(
     readonly relayerAddress: string,
     readonly logger: winston.Logger,
     readonly clients: RelayerClients,
     readonly config: RelayerConfig
-  ) {
-    this.maxUnfilledDepositLookBack = config.maxRelayerUnfilledDepositLookBack ?? {};
-  }
+  ) {}
 
   async checkForUnfilledDepositsAndFill(sendSlowRelays = true): Promise<void> {
     // Fetch all unfilled deposits, order by total earnable fee.
@@ -39,7 +36,7 @@ export class Relayer {
     // Sum the total unfilled deposit amount per origin chain and set a MDC for that chain.
     const unfilledDepositAmountsPerChain: { [chainId: number]: BigNumber } = getUnfilledDeposits(
       this.clients.spokePoolClients,
-      this.maxUnfilledDepositLookBack
+      this.config.maxRelayerUnfilledDepositLookBack
     ).reduce((agg, curr) => {
       const unfilledAmountUsd = this.clients.profitClient.getFillAmountInUsd(curr.deposit, curr.unfilledAmount);
       if (!agg[curr.deposit.originChainId]) agg[curr.deposit.originChainId] = toBN(0);
@@ -85,7 +82,7 @@ export class Relayer {
     const latestHubPoolTime = this.clients.hubPoolClient.currentTime;
 
     // Require that all fillable deposits meet the minimum specified number of confirmations.
-    const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.maxUnfilledDepositLookBack)
+    const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.config.maxRelayerUnfilledDepositLookBack)
       .filter((x) => {
         return (
           x.deposit.quoteTimestamp + this.config.quoteTimeBuffer <= latestHubPoolTime &&

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -36,7 +36,7 @@ export class Relayer {
     // Sum the total unfilled deposit amount per origin chain and set a MDC for that chain.
     const unfilledDepositAmountsPerChain: { [chainId: number]: BigNumber } = getUnfilledDeposits(
       this.clients.spokePoolClients,
-      this.config.maxRelayerUnfilledDepositLookBack
+      this.config.maxRelayerLookBack
     ).reduce((agg, curr) => {
       const unfilledAmountUsd = this.clients.profitClient.getFillAmountInUsd(curr.deposit, curr.unfilledAmount);
       if (!agg[curr.deposit.originChainId]) agg[curr.deposit.originChainId] = toBN(0);
@@ -82,10 +82,7 @@ export class Relayer {
     const latestHubPoolTime = this.clients.hubPoolClient.currentTime;
 
     // Require that all fillable deposits meet the minimum specified number of confirmations.
-    const unfilledDeposits = getUnfilledDeposits(
-      this.clients.spokePoolClients,
-      this.config.maxRelayerUnfilledDepositLookBack
-    )
+    const unfilledDeposits = getUnfilledDeposits(this.clients.spokePoolClients, this.config.maxRelayerLookBack)
       .filter((x) => {
         return (
           x.deposit.quoteTimestamp + this.config.quoteTimeBuffer <= latestHubPoolTime &&

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,6 +1,6 @@
 import { HubPoolClient } from "../clients";
 import { DepositWithBlock, Fill, FillsToRefund, FillWithBlock, SpokePoolClientsByChain } from "../interfaces";
-import { BigNumber, assign, getRealizedLpFeeForFills, getRefundForFills, sortEventsDescending, toBN } from "./";
+import { BigNumber, assign, getRealizedLpFeeForFills, getRefundForFills, sortEventsDescending, toBN, MAX_UINT_VAL } from "./";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 import _ from "lodash";
 
@@ -151,7 +151,7 @@ export function getFillsInRange(
 // Returns all unfilled deposits over all spokePoolClients. Return values include the amount of the unfilled deposit.
 export function getUnfilledDeposits(
   spokePoolClients: SpokePoolClientsByChain,
-  maxUnfilledDepositLookBack: { [chainId: number]: number } = {}
+  maxUnfilledDepositLookBack: number
 ): { deposit: DepositWithBlock; unfilledAmount: BigNumber; fillCount: number; invalidFills: Fill[] }[] {
   const unfilledDeposits: {
     deposit: DepositWithBlock;
@@ -174,9 +174,8 @@ export function getUnfilledDeposits(
       const unfilledDepositsForDestinationChain = depositsForDestinationChain
         .filter((deposit) => {
           // If deposit is older than unfilled deposit lookback, ignore it
-          const lookback = maxUnfilledDepositLookBack[deposit.originChainId];
           const latestBlockForOriginChain = originClient.latestBlockNumber;
-          return lookback === undefined || deposit.originBlockNumber >= latestBlockForOriginChain - lookback;
+          return deposit.originBlockNumber >= latestBlockForOriginChain - maxUnfilledDepositLookBack;
         })
         .map((deposit) => {
           // eslint-disable-next-line no-console

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,6 +1,14 @@
 import { HubPoolClient } from "../clients";
 import { DepositWithBlock, Fill, FillsToRefund, FillWithBlock, SpokePoolClientsByChain } from "../interfaces";
-import { BigNumber, assign, getRealizedLpFeeForFills, getRefundForFills, sortEventsDescending, toBN, MAX_UINT_VAL } from "./";
+import {
+  BigNumber,
+  assign,
+  getRealizedLpFeeForFills,
+  getRefundForFills,
+  sortEventsDescending,
+  toBN,
+  MAX_UINT_VAL,
+} from "./";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 import _ from "lodash";
 

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,14 +1,6 @@
 import { HubPoolClient } from "../clients";
 import { DepositWithBlock, Fill, FillsToRefund, FillWithBlock, SpokePoolClientsByChain } from "../interfaces";
-import {
-  BigNumber,
-  assign,
-  getRealizedLpFeeForFills,
-  getRefundForFills,
-  sortEventsDescending,
-  toBN,
-  MAX_UINT_VAL,
-} from "./";
+import { BigNumber, assign, getRealizedLpFeeForFills, getRefundForFills, sortEventsDescending, toBN } from "./";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 import _ from "lodash";
 

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -85,6 +85,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        maxRelayerUnfilledDepositLookBack: 24*60*60,
         minDepositConfirmations: defaultMinDepositConfirmations,
         quoteTimeBuffer: 0,
       } as unknown as RelayerConfig
@@ -289,6 +290,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [originChainId],
+        maxRelayerUnfilledDepositLookBack: 24*60*60,
         minDepositConfirmations: defaultMinDepositConfirmations,
         quoteTimeBuffer: 0,
       } as unknown as RelayerConfig

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -85,7 +85,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        maxRelayerUnfilledDepositLookBack: 24*60*60,
+        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
         minDepositConfirmations: defaultMinDepositConfirmations,
         quoteTimeBuffer: 0,
       } as unknown as RelayerConfig
@@ -290,7 +290,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [originChainId],
-        maxRelayerUnfilledDepositLookBack: 24*60*60,
+        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
         minDepositConfirmations: defaultMinDepositConfirmations,
         quoteTimeBuffer: 0,
       } as unknown as RelayerConfig

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -85,7 +85,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
+        maxRelayerLookBack: 24 * 60 * 60,
         minDepositConfirmations: defaultMinDepositConfirmations,
         quoteTimeBuffer: 0,
       } as unknown as RelayerConfig
@@ -290,7 +290,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [originChainId],
-        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
+        maxRelayerLookBack: 24 * 60 * 60,
         minDepositConfirmations: defaultMinDepositConfirmations,
         quoteTimeBuffer: 0,
       } as unknown as RelayerConfig

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -72,6 +72,7 @@ describe.skip("Relayer: Iterative fill", async function () {
       },
       {
         relayerTokens: [],
+        maxRelayerUnfilledDepositLookBack: 24*60*60,
         relayerDestinationChains: [],
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -72,7 +72,7 @@ describe.skip("Relayer: Iterative fill", async function () {
       },
       {
         relayerTokens: [],
-        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
+        maxRelayerLookBack: 24 * 60 * 60,
         relayerDestinationChains: [],
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,

--- a/test/Relayer.IterativeFill.ts
+++ b/test/Relayer.IterativeFill.ts
@@ -72,7 +72,7 @@ describe.skip("Relayer: Iterative fill", async function () {
       },
       {
         relayerTokens: [],
-        maxRelayerUnfilledDepositLookBack: 24*60*60,
+        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
         relayerDestinationChains: [],
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -73,6 +73,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        maxRelayerUnfilledDepositLookBack: 24*60*60,
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -73,7 +73,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
+        maxRelayerLookBack: 24 * 60 * 60,
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -73,7 +73,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        maxRelayerUnfilledDepositLookBack: 24*60*60,
+        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -73,6 +73,7 @@ describe("Relayer: Token balance shortfall", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        maxRelayerUnfilledDepositLookBack: 24*60*60,
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -73,7 +73,7 @@ describe("Relayer: Token balance shortfall", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        maxRelayerUnfilledDepositLookBack: 24*60*60,
+        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -73,7 +73,7 @@ describe("Relayer: Token balance shortfall", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
+        maxRelayerLookBack: 24 * 60 * 60,
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
       } as unknown as RelayerConfig

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -96,7 +96,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
+        maxRelayerLookBack: 24 * 60 * 60,
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
         acceptInvalidFills: false,

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -15,7 +15,13 @@ import {
   toBNWei,
 } from "./utils";
 import { simpleDeposit, fillRelay, ethers, Contract, SignerWithAddress, setupTokensForWallet } from "./utils";
-import { amountToLp, originChainId, amountToRelay, defaultMinDepositConfirmations } from "./constants";
+import {
+  amountToLp,
+  originChainId,
+  amountToRelay,
+  defaultMinDepositConfirmations,
+  DEFAULT_UNFILLED_DEPOSIT_LOOKBACK,
+} from "./constants";
 import {
   SpokePoolClient,
   HubPoolClient,
@@ -125,7 +131,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
     const deposit2Complete = await buildDepositStruct(deposit2, hubPoolClient, configStoreClient, l1Token);
 
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, DEFAULT_UNFILLED_DEPOSIT_LOOKBACK))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: deposit1.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
@@ -146,7 +152,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
     await updateAllClients();
     // Validate the relayer correctly computes the unfilled amount.
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, DEFAULT_UNFILLED_DEPOSIT_LOOKBACK))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         {
@@ -164,7 +170,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
     // Deposit 1 should now be partially filled by all three fills. This should be correctly reflected.
     const unfilledAmount = deposit1.amount.sub(fill1.fillAmount.add(fill2.fillAmount).add(fill3.fillAmount));
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, DEFAULT_UNFILLED_DEPOSIT_LOOKBACK))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: unfilledAmount, deposit: deposit1Complete, fillCount: 3, invalidFills: [] },
@@ -175,7 +181,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const fill4 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete, unfilledAmount);
     expect(fill4.totalFilledAmount).to.equal(deposit1.amount); // should be 100% filled at this point.
     await updateAllClients();
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, DEFAULT_UNFILLED_DEPOSIT_LOOKBACK))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: deposit2Complete.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
@@ -191,7 +197,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, { ...deposit1Complete, depositId: 1337 });
     await updateAllClients();
     // The deposit should show up as unfilled, since the fill was incorrectly applied to the wrong deposit.
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, DEFAULT_UNFILLED_DEPOSIT_LOOKBACK))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: deposit1Complete.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
@@ -209,7 +215,10 @@ describe("Relayer: Unfilled Deposits", async function () {
     await spokePool_1.speedUpDeposit(depositor.address, newRelayFeePct, deposit1.depositId, speedUpSignature);
     await updateAllClients();
 
-    const unfilledDeposits = getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60);
+    const unfilledDeposits = getUnfilledDeposits(
+      relayerInstance.clients.spokePoolClients,
+      DEFAULT_UNFILLED_DEPOSIT_LOOKBACK
+    );
     // expect only one unfilled deposit
     expect(unfilledDeposits.length).to.eq(1);
     // expect unfilled deposit to have new relay fee
@@ -223,7 +232,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
     const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
     await updateAllClients();
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, DEFAULT_UNFILLED_DEPOSIT_LOOKBACK))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         {
@@ -240,7 +249,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await spokePool_1.speedUpDeposit(depositor.address, newRelayerFeePct, deposit1.depositId, speedUpSignature);
     await updateAllClients();
     const depositWithSpeedUp = { ...deposit1Complete, newRelayerFeePct, speedUpSignature };
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, DEFAULT_UNFILLED_DEPOSIT_LOOKBACK))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         {
@@ -268,7 +277,10 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
 
     // getUnfilledDeposit still returns the deposit as unfilled but with the invalid fill.
-    const unfilledDeposit = getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60)[0];
+    const unfilledDeposit = getUnfilledDeposits(
+      relayerInstance.clients.spokePoolClients,
+      DEFAULT_UNFILLED_DEPOSIT_LOOKBACK
+    )[0];
     expect(unfilledDeposit.unfilledAmount).to.equal(deposit.amount);
     expect(unfilledDeposit.deposit.depositId).to.equal(deposit.depositId);
     expect(unfilledDeposit.invalidFills.length).to.equal(1);

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -90,6 +90,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
+        maxRelayerUnfilledDepositLookBack: 24*60*60,
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
         acceptInvalidFills: false,
@@ -124,7 +125,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
     const deposit2Complete = await buildDepositStruct(deposit2, hubPoolClient, configStoreClient, l1Token);
 
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: deposit1.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
@@ -145,7 +146,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
     await updateAllClients();
     // Validate the relayer correctly computes the unfilled amount.
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         {
@@ -163,7 +164,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
     // Deposit 1 should now be partially filled by all three fills. This should be correctly reflected.
     const unfilledAmount = deposit1.amount.sub(fill1.fillAmount.add(fill2.fillAmount).add(fill3.fillAmount));
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: unfilledAmount, deposit: deposit1Complete, fillCount: 3, invalidFills: [] },
@@ -174,7 +175,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const fill4 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete, unfilledAmount);
     expect(fill4.totalFilledAmount).to.equal(deposit1.amount); // should be 100% filled at this point.
     await updateAllClients();
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: deposit2Complete.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
@@ -190,7 +191,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, { ...deposit1Complete, depositId: 1337 });
     await updateAllClients();
     // The deposit should show up as unfilled, since the fill was incorrectly applied to the wrong deposit.
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: deposit1Complete.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
@@ -208,7 +209,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await spokePool_1.speedUpDeposit(depositor.address, newRelayFeePct, deposit1.depositId, speedUpSignature);
     await updateAllClients();
 
-    const unfilledDeposits = getUnfilledDeposits(relayerInstance.clients.spokePoolClients);
+    const unfilledDeposits = getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60);
     // expect only one unfilled deposit
     expect(unfilledDeposits.length).to.eq(1);
     // expect unfilled deposit to have new relay fee
@@ -222,7 +223,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
     const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
     await updateAllClients();
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         {
@@ -239,7 +240,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await spokePool_1.speedUpDeposit(depositor.address, newRelayerFeePct, deposit1.depositId, speedUpSignature);
     await updateAllClients();
     const depositWithSpeedUp = { ...deposit1Complete, newRelayerFeePct, speedUpSignature };
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         {
@@ -267,7 +268,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
 
     // getUnfilledDeposit still returns the deposit as unfilled but with the invalid fill.
-    const unfilledDeposit = getUnfilledDeposits(relayerInstance.clients.spokePoolClients)[0];
+    const unfilledDeposit = getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60)[0];
     expect(unfilledDeposit.unfilledAmount).to.equal(deposit.amount);
     expect(unfilledDeposit.deposit.depositId).to.equal(deposit.depositId);
     expect(unfilledDeposit.invalidFills.length).to.equal(1);

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -90,7 +90,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       {
         relayerTokens: [],
         relayerDestinationChains: [],
-        maxRelayerUnfilledDepositLookBack: 24*60*60,
+        maxRelayerUnfilledDepositLookBack: 24 * 60 * 60,
         quoteTimeBuffer: 0,
         minDepositConfirmations: defaultMinDepositConfirmations,
         acceptInvalidFills: false,
@@ -125,7 +125,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
     const deposit2Complete = await buildDepositStruct(deposit2, hubPoolClient, configStoreClient, l1Token);
 
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: deposit1.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
@@ -146,7 +146,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
     await updateAllClients();
     // Validate the relayer correctly computes the unfilled amount.
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         {
@@ -164,7 +164,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
     // Deposit 1 should now be partially filled by all three fills. This should be correctly reflected.
     const unfilledAmount = deposit1.amount.sub(fill1.fillAmount.add(fill2.fillAmount).add(fill3.fillAmount));
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: unfilledAmount, deposit: deposit1Complete, fillCount: 3, invalidFills: [] },
@@ -175,7 +175,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const fill4 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete, unfilledAmount);
     expect(fill4.totalFilledAmount).to.equal(deposit1.amount); // should be 100% filled at this point.
     await updateAllClients();
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: deposit2Complete.amount, deposit: deposit2Complete, fillCount: 0, invalidFills: [] },
@@ -191,7 +191,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, { ...deposit1Complete, depositId: 1337 });
     await updateAllClients();
     // The deposit should show up as unfilled, since the fill was incorrectly applied to the wrong deposit.
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         { unfilledAmount: deposit1Complete.amount, deposit: deposit1Complete, fillCount: 0, invalidFills: [] },
@@ -209,7 +209,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await spokePool_1.speedUpDeposit(depositor.address, newRelayFeePct, deposit1.depositId, speedUpSignature);
     await updateAllClients();
 
-    const unfilledDeposits = getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60);
+    const unfilledDeposits = getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60);
     // expect only one unfilled deposit
     expect(unfilledDeposits.length).to.eq(1);
     // expect unfilled deposit to have new relay fee
@@ -223,7 +223,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     const deposit1Complete = await buildDepositStruct(deposit1, hubPoolClient, configStoreClient, l1Token);
     const fill1 = await fillWithRealizedLpFeePct(spokePool_2, relayer, depositor, deposit1Complete);
     await updateAllClients();
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         {
@@ -240,7 +240,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await spokePool_1.speedUpDeposit(depositor.address, newRelayerFeePct, deposit1.depositId, speedUpSignature);
     await updateAllClients();
     const depositWithSpeedUp = { ...deposit1Complete, newRelayerFeePct, speedUpSignature };
-    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60))
+    expect(getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60))
       .excludingEvery(["blockNumber", "originBlockNumber"])
       .to.deep.equal([
         {
@@ -268,7 +268,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
 
     // getUnfilledDeposit still returns the deposit as unfilled but with the invalid fill.
-    const unfilledDeposit = getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1*24*60*60)[0];
+    const unfilledDeposit = getUnfilledDeposits(relayerInstance.clients.spokePoolClients, 1 * 24 * 60 * 60)[0];
     expect(unfilledDeposit.unfilledAmount).to.equal(deposit.amount);
     expect(unfilledDeposit.deposit.depositId).to.equal(deposit.depositId);
     expect(unfilledDeposit.invalidFills.length).to.equal(1);

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -4,6 +4,9 @@ export const randomOriginToken = randomAddress();
 export const randomDestinationToken = randomAddress();
 export const randomDestinationToken2 = randomAddress();
 
+// This lookback of 24 hours should be enough to cover all Deposit events in the test cases.
+export const DEFAULT_UNFILLED_DEPOSIT_LOOKBACK = 1 * 24 * 60 * 60;
+
 // Max number of refunds in relayer refund leaf for a { repaymentChainId, L2TokenAddress }.
 export const MAX_REFUNDS_PER_RELAYER_REFUND_LEAF = 3;
 


### PR DESCRIPTION
These functions currently require caller to pass in lookback per chain in terms of blocks. Can now specify in seconds which willl be same for all chains.

Dataworker currently sets lookback based on bundle end blocks, so that implicitly standardizes time across chains.