### PR TITLE
fix(validation-script): Handle case where dispute is atomically bundled with new proposal

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -236,10 +236,8 @@ export class HubPoolClient {
     );
   }
 
-  getMostRecentProposedRootBundle(latestBlockToSearch: number) {
-    return sortEventsDescending(this.proposedRootBundles).find(
-      (proposedRootBundle: ProposedRootBundle) => proposedRootBundle.blockNumber < latestBlockToSearch
-    ) as ProposedRootBundle;
+  getLatestProposedRootBundle() {
+    return sortEventsDescending(this.proposedRootBundles)[0] as ProposedRootBundle;
   }
 
   getFollowingRootBundle(currentRootBundle: ProposedRootBundle) {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -238,7 +238,7 @@ export class HubPoolClient {
 
   getMostRecentProposedRootBundle(latestBlockToSearch: number) {
     return sortEventsDescending(this.proposedRootBundles).find(
-      (proposedRootBundle: ProposedRootBundle) => proposedRootBundle.blockNumber <= latestBlockToSearch
+      (proposedRootBundle: ProposedRootBundle) => proposedRootBundle.blockNumber < latestBlockToSearch
     ) as ProposedRootBundle;
   }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1062,7 +1062,7 @@ export class Dataworker {
     }
 
     const executedLeaves = this.clients.hubPoolClient.getExecutedLeavesForRootBundle(
-      this.clients.hubPoolClient.getMostRecentProposedRootBundle(this.clients.hubPoolClient.latestBlockNumber),
+      this.clients.hubPoolClient.getLatestProposedRootBundle(),
       this.clients.hubPoolClient.latestBlockNumber
     );
 

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -126,6 +126,13 @@ export function sortEventsDescendingInPlace<T extends SortableEvent>(events: T[]
   });
 }
 
+// Returns true if ex is older than ey.
+export function isEventOlder<T extends SortableEvent>(ex: T, ey: T): boolean {
+  if (ex.blockNumber !== ey.blockNumber) return ex.blockNumber < ey.blockNumber;
+  if (ex.transactionIndex !== ey.transactionIndex) return ex.transactionIndex < ey.transactionIndex;
+  return ex.logIndex < ey.logIndex;
+}
+
 export function getTransactionHashes(events: SortableEvent[]) {
   return [...new Set(events.map((e) => e.transactionHash))];
 }

--- a/src/utils/UmaUtils.ts
+++ b/src/utils/UmaUtils.ts
@@ -1,0 +1,28 @@
+import { Contract, ethers, isEventOlder, sortEventsDescending } from ".";
+import * as uma from "@uma/contracts-node";
+import { HubPoolClient } from "../clients";
+import { ProposedRootBundle, SortableEvent } from "../interfaces";
+import { BlockFinder } from "@uma/financial-templates-lib";
+
+export function getDvmContract(mainnetProvider: ethers.providers.Provider): Contract {
+  return new Contract("0x8B1631ab830d11531aE83725fDa4D86012eCCd77", uma.getAbi("Voting"), mainnetProvider);
+}
+export async function getDisputedProposal(
+  dvm: Contract,
+  hubPoolClient: HubPoolClient,
+  disputeRequestTimestamp: number,
+  disputeRequestBlock?: number
+): Promise<ProposedRootBundle> {
+  const filter = dvm.filters.PriceRequestAdded();
+  const blockFinder = new BlockFinder(dvm.provider.getBlock.bind(dvm.provider));
+  const priceRequestBlock =
+    disputeRequestBlock !== undefined
+      ? disputeRequestBlock
+      : (await blockFinder.getBlockForTimestamp(disputeRequestTimestamp)).number;
+  const disputes = await dvm.queryFilter(filter, priceRequestBlock, priceRequestBlock);
+  const dispute = disputes.find((e) => e.args.time.toString() === disputeRequestTimestamp.toString());
+  if (!dispute) throw new Error("Could not find PriceRequestAdded event on DVM matching price request time");
+  return sortEventsDescending(hubPoolClient.getProposedRootBundles()).find((e) =>
+    isEventOlder(e as SortableEvent, dispute as SortableEvent)
+  );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -35,6 +35,7 @@ export * from "./Help";
 export * from "./LogUtils";
 export * from "./TypeUtils";
 export * from "./BigNumberUtils";
+export * from "./UmaUtils";
 
 export { ZERO_ADDRESS, MAX_SAFE_ALLOWANCE, MAX_UINT_VAL, replaceAddressCase } from "@uma/common";
 


### PR DESCRIPTION
This PR makes the validation script more robust when handling atomic disputes (i.e. disputes sent in same block as subsequent proposals) by querying the PriceRequestAdded event emitted by the disputed root bundle event. The script now throws if the
found proposal and filtering out events that don't precede the dispute---by block number, transaction index, or log index.

Additionally, the hub pool client's getMostRecentProposedRootBundle now uses a < comparison instead of a <= to find a root bundle earlier than a block number. This 
function is only used in one place by the Dataworker where it does not change behavior.

Signed-off-by: nicholaspai <npai.nyc@gmail.com>
