### PR TITLE
improve(ProviderUtils): Override ethers 429 backoff

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -309,6 +309,7 @@ export function getProvider(chainId: number, logger?: winston.Logger) {
   // Default to a max concurrency of 1000 requests per node.
   const nodeMaxConcurrency = Number(process.env[`NODE_MAX_CONCURRENCY_${chainId}`] || NODE_MAX_CONCURRENCY || "1000");
 
+<<<<<<< HEAD
   // Custom delay + logging for RPC rate-limiting.
   const rpcRateLimited =
     ({ nodeMaxConcurrency, logger }) =>
@@ -332,12 +333,14 @@ export function getProvider(chainId: number, logger?: winston.Logger) {
       return attempt < retries;
     };
 
+  // See ethers ConnectionInfo for field descriptions.
+  // https://docs.ethers.org/v5/api/utils/web/#ConnectionInfo
   const constructorArgumentLists = getNodeUrlList(chainId).map((nodeUrl): [ethers.utils.ConnectionInfo, number] => [
     {
       url: nodeUrl,
       timeout,
       allowGzip: true,
-      throttleSlotInterval: 1,
+      throttleSlotInterval: 1, // Effectively disables ethers' internal backoff algorithm.
       throttleCallback: rpcRateLimited({ nodeMaxConcurrency, logger }),
     },
     chainId,

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -309,7 +309,6 @@ export function getProvider(chainId: number, logger?: winston.Logger) {
   // Default to a max concurrency of 1000 requests per node.
   const nodeMaxConcurrency = Number(process.env[`NODE_MAX_CONCURRENCY_${chainId}`] || NODE_MAX_CONCURRENCY || "1000");
 
-<<<<<<< HEAD
   // Custom delay + logging for RPC rate-limiting.
   const rpcRateLimited =
     ({ nodeMaxConcurrency, logger }) =>

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -313,6 +313,8 @@ export function getProvider(chainId: number, logger?: winston.Logger) {
   const rpcRateLimited =
     ({ nodeMaxConcurrency, logger }) =>
     async (attempt: number, url: string): Promise<boolean> => {
+      // Implement a slightly aggressive expontential backoff to account for fierce paralellism.
+      // @todo: Start w/ maxConcurrency low and increase until 429 responses start arriving.
       const baseDelay = 1000 * Math.pow(2, attempt); // ms; attempt = [0, 1, 2, ...]
       const delayMs = baseDelay + baseDelay * Math.random();
 

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -309,18 +309,13 @@ export function getProvider(chainId: number, logger?: winston.Logger) {
   // Default to a max concurrency of 1000 requests per node.
   const nodeMaxConcurrency = Number(process.env[`NODE_MAX_CONCURRENCY_${chainId}`] || NODE_MAX_CONCURRENCY || "1000");
 
-  const sleep = async (duration: number): Promise<number> => {
-    const startMs = Date.now();
-    await new Promise((resolve) => setTimeout(resolve, duration));
-    return Date.now() - startMs;
-  };
-
   // Custom delay + logging for RPC rate-limiting.
   const rpcRateLimited =
     ({ nodeMaxConcurrency, logger }) =>
     async (attempt: number, url: string): Promise<boolean> => {
       const baseDelay = 1000 * Math.pow(2, attempt); // ms; attempt = [0, 1, 2, ...]
-      const delayMs = await sleep(baseDelay + baseDelay * Math.random());
+      const delayMs = baseDelay + baseDelay * Math.random();
+      await delay(delayMs);
 
       if (logger) {
         // Make an effort to filter out any api keys.

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -315,7 +315,6 @@ export function getProvider(chainId: number, logger?: winston.Logger) {
     async (attempt: number, url: string): Promise<boolean> => {
       const baseDelay = 1000 * Math.pow(2, attempt); // ms; attempt = [0, 1, 2, ...]
       const delayMs = baseDelay + baseDelay * Math.random();
-      await delay(delayMs);
 
       if (logger) {
         // Make an effort to filter out any api keys.
@@ -328,6 +327,7 @@ export function getProvider(chainId: number, logger?: winston.Logger) {
           workers: nodeMaxConcurrency,
         });
       }
+      await delay(delayMs);
 
       return attempt < retries;
     };

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -283,9 +283,9 @@ export function getProvider(chainId: number, logger?: winston.Logger) {
   };
 
   // Custom delay + logging for RPC rate-limiting.
-  const rpcRateLimited = ({ nodeMaxConcurrency, logger }) =>
+  const rpcRateLimited =
+    ({ nodeMaxConcurrency, logger }) =>
     async (attempt: number, url: string): Promise<boolean> => {
-
       const baseDelay = 1000 * Math.pow(2, attempt); // ms; attempt = [0, 1, 2, ...]
       const delayMs = await sleep(baseDelay + baseDelay * Math.random());
 
@@ -297,7 +297,7 @@ export function getProvider(chainId: number, logger?: winston.Logger) {
           message: `Got 429 on attempt ${attempt}.`,
           rpc: regex ? regex[1] : url,
           retryAfter: `${delayMs} ms`,
-          workers: nodeMaxConcurrency
+          workers: nodeMaxConcurrency,
         });
       }
 


### PR DESCRIPTION
The default ethers implementation is very aggressive and will regularly retry immediately after a 429 response. This might be OK for serialised requests, but is not very compatible with the heavily-parallel request load of this bot.

This change sets a new minimum delay of (1000 * failure) ms, where failure is [1, 2, 3, ...]. An additional random delay between 0 and (1000 * failure) ms is subsequently added to the minimum delay. This is an aggressive backoff that also delivers some randomisation in order to avoid further rate-limiting as a result of retries being submitted in batches.

There are some limitations with this approach:
 - Each RPC provider has different recommendations for handling 429 responses.
 - If the 429 response includes a retry-after header, this new custom delay will be imposed in _addition_ to the retry-after delay. This is an unfortunate necessity that results from the [internal implementation of ethers](https://github.com/ethers-io/ethers.js/blob/44cbc7fa4e199c1d6113ceec3c5162f53def5bb8/packages/web/src.ts/index.ts#L275).
 - The algorithm has limited responsivity to en-masse rate-limiting. Ultimately, the operator must manually tune NODE_MAX_CONCURRENCY if they are seeing regular rate-limiting with > 1 retry.

It should be noted that the reason for not simply tuning the ethers throttleSlotInterval is that the resulting delay can still resolve to 0 ms as [a result of the use of parseInt()](https://github.com/ethers-io/ethers.js/blob/44cbc7fa4e199c1d6113ceec3c5162f53def5bb8/packages/web/src.ts/index.ts#L278).

A nice long-term solution would be to make the RateLimitProvider maxConcurrency automagically self-regulate downwards in response to 429 rate-limiting. This would allow for an more optimistic default NODE_MAX_CONCURRENCY.

This change configuration has been tested against a free-tier Alchemy plan with NODE_MAX_CONCURRENCY=5. I was regularly rate-limited with this approach, but was only rarely rate-limited more than once per request. This is OK per Alchemy's recommendations: they specify that it's OK for up to 30% of requests to be rate-limited.