### PR TITLE
improve: Dataworker should throw explicitly when it can't construct a slow fill excess

### DIFF
--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -118,6 +118,15 @@ export function getFillDataForSlowFillFromPreviousRootBundle(
     (_fill: FillWithBlock) => filledSameDeposit(_fill, fill) && isFirstFillForDeposit(_fill as Fill)
   );
 
+  // If there is no first fill for the same deposit, then throw an error.
+  if (firstFillForSameDeposit === undefined) {
+    // TODO: Use something similar to SpokePoolClient.queryHistoricalDepositForFill to look up all fills
+    // for the same deposit. I would add in PR#382 but its too complex so I'll leave for another PR.
+    throw new Error(
+      `FillUtils#getFillDataForSlowFillFromPreviousRootBundle: Cannot find first fill for for deposit ${fill.depositId} on chain ${fill.destinationChainId}, set a larger DATAWORKER_FAST_LOOKBACK_COUNT`
+    );
+  }
+
   // Find ending block number for chain from ProposeRootBundle event that should have included a slow fill
   // refund for this first fill. This will be undefined if there is no block range containing the first fill.
   const rootBundleEndBlockContainingFirstFill = hubPoolClient.getRootBundleEvalBlockNumberContainingBlock(

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -4,6 +4,8 @@ import {
   buildFillForRepaymentChain,
   enableRoutesOnHubPool,
   signForSpeedUp,
+  createSpyLogger,
+  assertPromiseError,
 } from "./utils";
 import { SignerWithAddress, expect, ethers, Contract, toBN, toBNWei, setupTokensForWallet } from "./utils";
 import { buildDeposit, buildFill, buildSlowFill, BigNumber, deployNewTokenMapping } from "./utils";
@@ -18,8 +20,8 @@ import {
   buildPoolRebalanceLeaves,
 } from "./constants";
 import { MAX_REFUNDS_PER_RELAYER_REFUND_LEAF, MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF } from "./constants";
-import { refundProposalLiveness, CHAIN_ID_TEST_LIST, DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD } from "./constants";
-import { setupDataworker, setupFastDataworker } from "./fixtures/Dataworker.Fixture";
+import { refundProposalLiveness, CHAIN_ID_TEST_LIST } from "./constants";
+import { setupFastDataworker } from "./fixtures/Dataworker.Fixture";
 import { Deposit, Fill, RunningBalances } from "../src/interfaces";
 import { getRealizedLpFeeForFills, getRefundForFills, getRefund, EMPTY_MERKLE_ROOT } from "../src/utils";
 import { compareAddresses } from "../src/utils";
@@ -526,6 +528,7 @@ describe("Dataworker: Build merkle roots", async function () {
 
       // Partial fill deposit1
       const fill1 = await buildFillForRepaymentChain(spokePool_2, relayer, deposit1, 0.5, destinationChainId);
+      const fill1Block = await spokePool_2.provider.getBlockNumber();
       const unfilledAmount1 = deposit1.amount.sub(fill1.totalFilledAmount);
 
       // Partial fill deposit2
@@ -661,6 +664,27 @@ describe("Dataworker: Build merkle roots", async function () {
         )
       );
       await updateAllClients();
+
+      // Test that we can still look up the excess if the first fill for the same deposit as the one slow filed
+      //  is older than the spoke pool client's lookback window.
+      const shortRangeSpokePoolClient = new SpokePoolClient(
+        createSpyLogger().spyLogger,
+        spokePool_2,
+        configStoreClient,
+        destinationChainId,
+        { fromBlock: fill1Block + 1 }, // Set fromBlock to now, after first fill for same deposit as the slowFill1
+        spokePoolClients[destinationChainId].spokePoolDeploymentBlock
+      );
+      await shortRangeSpokePoolClient.update();
+      expect(shortRangeSpokePoolClient.getFills().length).to.equal(2); // We should only be able to see 2 fills
+      // for this deposit, even though there are 3.
+      assertPromiseError(
+        dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(3), {
+          ...spokePoolClients,
+          [destinationChainId]: shortRangeSpokePoolClient,
+        }),
+        "Cannot find first fill for for deposit"
+      );
 
       // The excess amount in the contract is now equal to the partial fill amount sent before the slow fill.
       // Again, now that the slowFill1 was sent, the unfilledAmount1 can be subtracted from running balances since its

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -678,18 +678,19 @@ describe("Dataworker: Build merkle roots", async function () {
       await shortRangeSpokePoolClient.update();
       expect(shortRangeSpokePoolClient.getFills().length).to.equal(2); // We should only be able to see 2 fills
       // for this deposit, even though there are 3.
-      assertPromiseError(
+      expect(spokePoolClients[destinationChainId].getFills().length).to.equal(3);
+      expect(() =>
         dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(3), {
           ...spokePoolClients,
           [destinationChainId]: shortRangeSpokePoolClient,
-        }),
-        "Cannot find first fill for for deposit"
-      );
+        })
+      ).to.throw(/Cannot find first fill for for deposit/);
 
       // The excess amount in the contract is now equal to the partial fill amount sent before the slow fill.
       // Again, now that the slowFill1 was sent, the unfilledAmount1 can be subtracted from running balances since its
       // no longer associated with an unfilled deposit.
       const excess = fill5.fillAmount;
+
       updateAndCheckExpectedPoolRebalanceCounters(
         expectedRunningBalances,
         expectedRealizedLpFees,
@@ -697,7 +698,7 @@ describe("Dataworker: Build merkle roots", async function () {
         getRealizedLpFeeForFills([slowFill1, fill5]),
         [fill5.destinationChainId],
         [l1Token_1.address],
-        dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(3), spokePoolClients)
+        dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(4), spokePoolClients)
       );
 
       // Before executing the last slow relay leaf, completely fill the deposit. This will leave the full slow fill
@@ -713,7 +714,7 @@ describe("Dataworker: Build merkle roots", async function () {
         getRealizedLpFeeForFills([fill6]),
         [fill6.destinationChainId],
         [l1Token_1.address],
-        dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(4), spokePoolClients)
+        dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(5), spokePoolClients)
       );
 
       // Now demonstrate that for a deposit whose first fill is NOT contained in a ProposeRootBundle event, it won't
@@ -747,7 +748,7 @@ describe("Dataworker: Build merkle roots", async function () {
         getRealizedLpFeeForFills([fill7, fill8]),
         [fill7.destinationChainId],
         [l1Token_1.address],
-        dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(5), spokePoolClients)
+        dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(6), spokePoolClients)
       );
 
       // Even after a ProposeRootBundle is submitted with a block range containing both fill7 and fill8, nothing changes
@@ -760,7 +761,7 @@ describe("Dataworker: Build merkle roots", async function () {
         mockTreeRoot
       );
       await updateAllClients();
-      const merkleRoot7 = dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(6), spokePoolClients);
+      const merkleRoot7 = dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(7), spokePoolClients);
       expect(merkleRoot7.runningBalances).to.deep.equal(expectedRunningBalances);
       expect(merkleRoot7.realizedLpFees).to.deep.equal(expectedRealizedLpFees);
 
@@ -788,7 +789,7 @@ describe("Dataworker: Build merkle roots", async function () {
         getRealizedLpFeeForFills([fill9]),
         [fill9.destinationChainId],
         [l1Token_1.address],
-        dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(7), spokePoolClients)
+        dataworkerInstance.buildPoolRebalanceRoot(getDefaultBlockRange(8), spokePoolClients)
       );
     });
     it("Many L1 tokens, testing leaf order and root construction", async function () {


### PR DESCRIPTION
Right now there unknown behavior if dataworker can't find the first fill associated with a slow fill (i.e. the one that triggered the slow fill). We should loudly throw when this happens.

I think what would happen is that `getFillDataForSlowFillFromPreviousRootBundle` would throw: `Cannot read properties of undefined (reading 'blockNumber')`

I don't think this has caused any self-disputes but its possible? 