### PR TITLE
improve(MultiCallerClient): Lint

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -12,6 +12,7 @@ import {
   TransactionSimulationResult,
 } from "../utils";
 
+
 import lodash from "lodash";
 
 export interface AugmentedTransaction {

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -79,7 +79,7 @@ export class MultiCallerClient {
     this.transactions = [];
   }
 
-  async executeTransactionQueue(simulationModeOn = false) {
+  async executeTransactionQueue(simulationModeOn = false): Promise<string[]> {
     if (this.transactions.length === 0) return;
     this.logger.debug({
       at: "MultiCallerClient",
@@ -92,7 +92,7 @@ export class MultiCallerClient {
       const transactions = await this.simulateTransactionQueue(this.transactions);
       if (transactions.length === 0) {
         this.logger.debug({ at: "MultiCallerClient", message: "No valid transactions in the queue." });
-        return;
+        return [];
       }
 
       const valueTransactions = transactions.filter((transaction) => transaction.value && transaction.value.gt(0));
@@ -150,7 +150,7 @@ export class MultiCallerClient {
         });
         this.logger.info({ at: "MultiCallerClient", message: "Exiting simulation mode 🎮", mrkdwn });
         this.clearTransactionQueue();
-        return;
+        return [];
       }
 
       const groupedValueTransactions: { [networkId: number]: AugmentedTransaction[] } = lodash.groupBy(
@@ -258,7 +258,7 @@ export class MultiCallerClient {
     }
   }
 
-  buildMultiCallBundle(transactions: AugmentedTransaction[]) {
+  buildMultiCallBundle(transactions: AugmentedTransaction[]): Promise<TransactionResponse> {
     // Validate all transactions in the batch have the same target contract.
     const target = transactions[0].contract;
     if (transactions.every((tx) => tx.contract.address !== target.address)) {
@@ -286,7 +286,7 @@ export class MultiCallerClient {
     return runTransaction(this.logger, target, "multicall", [callData]);
   }
 
-  private async simulateTransactionQueue(transactions: AugmentedTransaction[]) {
+  private async simulateTransactionQueue(transactions: AugmentedTransaction[]): Promise<AugmentedTransaction[]> {
     // Simulate the transaction execution for the whole queue.
     const _transactionsSucceed = await Promise.all(
       transactions.map((transaction: AugmentedTransaction) => willSucceed(transaction))

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -80,7 +80,7 @@ export class MultiCallerClient {
   }
 
   async executeTransactionQueue(simulationModeOn = false): Promise<string[]> {
-    if (this.transactions.length === 0) return;
+    if (this.transactions.length === 0) return [];
     this.logger.debug({
       at: "MultiCallerClient",
       message: "Executing tx bundle",

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -12,7 +12,6 @@ import {
   TransactionSimulationResult,
 } from "../utils";
 
-
 import lodash from "lodash";
 
 export interface AugmentedTransaction {

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -110,7 +110,6 @@ export class ProfitClient {
   }
 
   getTotalGasCost(chainId: number): BigNumber {
-    // TODO: Figure out where the mysterious BigNumber -> string conversion happens.
     return this.totalGasCosts[chainId] ? toBN(this.totalGasCosts[chainId]) : toBN(0);
   }
 

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -110,6 +110,7 @@ export class ProfitClient {
   }
 
   getTotalGasCost(chainId: number): BigNumber {
+    // TODO: Figure out where the mysterious BigNumber -> string conversion happens.
     return this.totalGasCosts[chainId] ? toBN(this.totalGasCosts[chainId]) : toBN(0);
   }
 


### PR DESCRIPTION
This reduces warnings about missing return-type annotations, and removes a comment
relaying to an odd number->string conversion that was occurring in the logging module.
That issue was resolved here: https://github.com/UMAprotocol/protocol/commit/e7cd6c52e4cb8a18041dac1046bb0c78649fc945