### PR TITLE
improve(MultiCallerClient): Simplify sim failure logging

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -79,7 +79,7 @@ export class MultiCallerClient {
     this.transactions = [];
   }
 
-  async executeTransactionQueue(simulationModeOn = false) {
+  async executeTransactionQueue(simulationModeOn = false): Promise<string[]> {
     if (this.transactions.length === 0) return;
     this.logger.debug({
       at: "MultiCallerClient",
@@ -92,7 +92,7 @@ export class MultiCallerClient {
       const transactions = await this.simulateTransactionQueue(this.transactions);
       if (transactions.length === 0) {
         this.logger.debug({ at: "MultiCallerClient", message: "No valid transactions in the queue." });
-        return;
+        return [];
       }
 
       const valueTransactions = transactions.filter((transaction) => transaction.value && transaction.value.gt(0));
@@ -150,7 +150,7 @@ export class MultiCallerClient {
         });
         this.logger.info({ at: "MultiCallerClient", message: "Exiting simulation mode 🎮", mrkdwn });
         this.clearTransactionQueue();
-        return;
+        return [];
       }
 
       const groupedValueTransactions: { [networkId: number]: AugmentedTransaction[] } = lodash.groupBy(
@@ -258,7 +258,7 @@ export class MultiCallerClient {
     }
   }
 
-  buildMultiCallBundle(transactions: AugmentedTransaction[]) {
+  buildMultiCallBundle(transactions: AugmentedTransaction[]): Promise<TransactionResponse> {
     // Validate all transactions in the batch have the same target contract.
     const target = transactions[0].contract;
     if (transactions.every((tx) => tx.contract.address !== target.address)) {
@@ -286,7 +286,7 @@ export class MultiCallerClient {
     return runTransaction(this.logger, target, "multicall", [callData]);
   }
 
-  private async simulateTransactionQueue(transactions: AugmentedTransaction[]) {
+  private async simulateTransactionQueue(transactions: AugmentedTransaction[]): Promise<AugmentedTransaction[]> {
     // Simulate the transaction execution for the whole queue.
     const _transactionsSucceed = await Promise.all(
       transactions.map((transaction: AugmentedTransaction) => willSucceed(transaction))

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -9,6 +9,7 @@ import {
   willSucceed,
   etherscanLink,
   TransactionResponse,
+  TransactionSimulationResult
 } from "../utils";
 
 import lodash from "lodash";
@@ -46,11 +47,7 @@ const unknownRevertReasonMethodsToIgnore = new Set([
 
 // Ignore the general unknown revert reason for specific methods or uniformly ignore specific revert reasons
 // for any contract method.
-const canIgnoreRevertReasons = (obj: {
-  succeed: boolean;
-  reason: string;
-  transaction: AugmentedTransaction;
-}): boolean => {
+const canIgnoreRevertReasons = (obj: TransactionSimulationResult): boolean => {
   // prettier-ignore
   return (
     !obj.succeed && (

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -47,6 +47,9 @@ const unknownRevertReasonMethodsToIgnore = new Set([
 
 // Ignore the general unknown revert reason for specific methods or uniformly ignore specific revert reasons
 // for any contract method.
+// Note: Check for exact revert reason instead of using .includes() to partially match reason string in order
+// to not ignore errors thrown by non-contract reverts. For example, a NodeJS error might result in a reason
+// string that includes more than just the contract revert reason.
 const canIgnoreRevertReasons = (obj: TransactionSimulationResult): boolean => {
   // prettier-ignore
   return (
@@ -284,55 +287,63 @@ export class MultiCallerClient {
   }
 
   private async simulateTransactionQueue(transactions: AugmentedTransaction[]): Promise<AugmentedTransaction[]> {
+    const validTxns: AugmentedTransaction[] = [];
+    const invalidTxns: TransactionSimulationResult[] = [];
+
     // Simulate the transaction execution for the whole queue.
-    const _transactionsSucceed = await Promise.all(
-      transactions.map((transaction: AugmentedTransaction) => willSucceed(transaction))
+    const txnSimulations = await Promise.all(
+      transactions.map((transaction: AugmentedTransaction) => this.simulateTxn(transaction))
     );
 
-    // Filter out transactions that revert for expected reasons. For example, the "relay filled" error
-    // will occur frequently if there are multiple relayers running at the same time because only one relay
-    // can go through. Similarly, the "already claimed" error will occur if the dataworker executor is running at a
-    // practical cadence of ~10 mins per run, because it takes ~5-7 mins per run, these runs can overlap and
-    // execution collisions can occur. These are non critical errors we can ignore to filter out the noise.
-    // TODO: Figure out less hacky way to reduce these errors rather than ignoring them.
+    txnSimulations.forEach((txn) => {
+      if (txn.succeed) validTxns.push(txn.transaction);
+      else invalidTxns.push(txn);
+    });
+    this.logSimulationFailures(invalidTxns);
 
-    // Note: Check for exact revert reason instead of using .includes() to partially match reason string in order
-    // to not ignore errors thrown by non-contract reverts. For example, a NodeJS error might result in a reason
-    // string that includes more than just the contract revert reason.
-    const transactionRevertsToIgnore = _transactionsSucceed.filter(
-      (txn) => !txn.succeed && canIgnoreRevertReasons(txn)
-    );
-    const transactionRevertsToLog = _transactionsSucceed.filter((txn) => !txn.succeed && !canIgnoreRevertReasons(txn));
-    if (transactionRevertsToIgnore.length > 0)
+    return validTxns;
+  }
+
+  // Filter out transactions that revert for non-critical expected reasons.
+  // For example, the "relay filled" error will occur frequently if there are multiple relayers
+  // running at the same time because only one relay can go through. Similarly, the "already
+  // claimed" error will occur if the dataworker executor is running at a practical cadence of
+  // ~10 mins per run, because it takes ~5-7 mins per run, these runs can overlap and execution
+  // collisions can occur. These are non critical errors we can ignore to filter out the noise.
+  // @todo: Figure out a less hacky way to reduce these errors rather than ignoring them.
+  // @todo: Consider logging key txn information with the failures?
+  protected logSimulationFailures(failures: TransactionSimulationResult[]): void {
+    const ignoredFailures: TransactionSimulationResult[] = [];
+    const loggedFailures: TransactionSimulationResult[] = [];
+
+    failures.forEach((failure) => {
+      (canIgnoreRevertReasons(failure) ? ignoredFailures : loggedFailures).push(failure)
+    });
+
+    if (ignoredFailures.length > 0) {
       this.logger.debug({
-        at: "MultiCallerClient",
-        message: `Filtering out ${transactionRevertsToIgnore.length} transactions with revert reasons we can ignore.`,
-        revertReasons: transactionRevertsToIgnore.map((txn) => txn.reason),
-        totalTransactions: _transactionsSucceed.length,
+        at: "MultiCallerClient#LogSimulationFailures",
+        message: `Filtering out ${ignoredFailures.length} transactions with revert reasons we can ignore.`,
+        revertReasons: ignoredFailures.map((txn) => txn.reason),
       });
+    }
 
-    // If any transactions will revert then log the reason.
-    if (transactionRevertsToLog.length > 0)
+    // Log unexpected/noteworthy failures.
+    if (loggedFailures.length > 0) {
       this.logger.error({
-        at: "MultiCallerClient",
-        message: "Some transaction in the queue will revert!",
-        count: transactionRevertsToLog.length,
-        revertingTransactions: transactionRevertsToLog.map((transaction) => {
+        at: "MultiCallerClient#LogSimulationFailures",
+        message: `${loggedFailures.length} in the queue may revert!`,
+        revertingTransactions: loggedFailures.map((txn) => {
           return {
-            target: getTarget(transaction.transaction.contract.address),
-            args: transaction.transaction.args,
-            reason: transaction.reason,
-            message: transaction.transaction.message,
-            mrkdwn: transaction.transaction.mrkdwn,
+            target: getTarget(txn.transaction.contract.address),
+            args: txn.transaction.args,
+            reason: txn.reason,
+            message: txn.transaction.message,
+            mrkdwn: txn.transaction.mrkdwn,
           };
         }),
         notificationPath: "across-error",
       });
-
-    const validTransactions = _transactionsSucceed
-      .filter((txn) => txn.succeed)
-      .map((transaction) => transaction.transaction);
-
-    return validTransactions;
+    }
   }
 }

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -110,7 +110,6 @@ export class ProfitClient {
   }
 
   getTotalGasCost(chainId: number): BigNumber {
-    // TODO: Figure out where the mysterious BigNumber -> string conversion happens.
     return this.totalGasCosts[chainId] ? toBN(this.totalGasCosts[chainId]) : toBN(0);
   }
 

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -2,6 +2,12 @@ import { AugmentedTransaction } from "../clients";
 import { winston, Contract, getContractInfoFromAddress, fetch, ethers } from "../utils";
 import { toBNWei, BigNumber, toBN, toGWei, TransactionResponse } from "../utils";
 
+export type TransactionSimulationResult = {
+  transaction: AugmentedTransaction;
+  succeed: boolean;
+  reason: string;
+};
+
 // Note that this function will throw if the call to the contract on method for given args reverts. Implementers
 // of this method should be considerate of this and catch the response to deal with the error accordingly.
 export async function runTransaction(
@@ -50,9 +56,7 @@ export async function getGasPrice(provider: ethers.providers.Provider, priorityS
   } else return { gasPrice: scaleByNumber(feeData.gasPrice, priorityScaler) };
 }
 
-export async function willSucceed(
-  transaction: AugmentedTransaction
-): Promise<{ transaction: AugmentedTransaction; succeed: boolean; reason: string }> {
+export async function willSucceed(transaction: AugmentedTransaction): Promise<TransactionSimulationResult> {
   try {
     const args = transaction.value ? [...transaction.args, { value: transaction.value }] : transaction.args;
     await transaction.contract.callStatic[transaction.method](...args);


### PR DESCRIPTION
Makes the code a bit more compact and more clearly separates between
simulation and logging. This also allows for the logging function to
be verified in test by mocking it out.
    
As a minor benefit, the existing implementation performs 3 complete
loops over the array of transaction simulation results. This change
performs only one complete loop, and then a secondary loop over the
resulting list of failures to determine which to log. It should be
marginally faster, and probably more memory efficient.