### PR TITLE
fix(MultiCallerClient): Correct multicall txn validation

### DIFF
--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -120,7 +120,7 @@ describe("MultiCallerClient", async function () {
         multiCaller.enqueueTransaction({
           chainId: chainId,
           contract: {
-            address: "0x1234",
+            address,
             interface: { encodeFunctionData },
           },
           method: "test",
@@ -143,7 +143,7 @@ describe("MultiCallerClient", async function () {
   it("Correctly filters loggable vs. ignorable simulation failures", async function () {
     const txn: AugmentedTransaction = {
       chainId: chainIds[0],
-      contract: { address: "0x1234" },
+      contract: { address },
     } as AugmentedTransaction;
 
     // Verify that all known revert reasons are ignored.

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -5,7 +5,7 @@ import {
 } from "../src/clients";
 import { TransactionResponse, TransactionSimulationResult } from "../src/utils";
 import { CHAIN_ID_TEST_LIST as chainIds } from "./constants";
-import { createSpyLogger, Contract, expect, winston, toBN } from "./utils";
+import { createSpyLogger, Contract, expect, randomAddress, winston, toBN } from "./utils";
 
 class MockedMultiCallerClient extends MultiCallerClient {
   public failSimulate = "";
@@ -111,6 +111,7 @@ describe("MultiCallerClient", async function () {
 
   it("Validates transaction data before multicall bundle generation", async function () {
     const chainId = chainIds[0];
+    const address = randomAddress();
 
     for (const badField of ["address", "chainId"]) {
       const txns: AugmentedTransaction[] = [];
@@ -119,7 +120,7 @@ describe("MultiCallerClient", async function () {
         const txn = {
           chainId: chainId,
           contract: {
-            address: "0x1234",
+            address,
             interface: { encodeFunctionData },
           } as Contract,
           method: "test",
@@ -137,7 +138,7 @@ describe("MultiCallerClient", async function () {
       switch (badField) {
         case "address":
           badTxn.contract = {
-            address: badTxn.contract.address.concat("badaddr"),
+            address: randomAddress(),
             interface: { encodeFunctionData },
           } as Contract;
           break;

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -56,6 +56,7 @@ function encodeFunctionData(method: string, args?: ReadonlyArray<any>): string {
 const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
 const multiCaller: MockedMultiCallerClient = new MockedMultiCallerClient(spyLogger);
 const provider = new ethers.providers.StaticJsonRpcProvider("127.0.0.1");
+const address = randomAddress(); // Test contract address
 
 describe("MultiCallerClient", async function () {
   beforeEach(async function () {
@@ -69,9 +70,7 @@ describe("MultiCallerClient", async function () {
         const chainId = Number(_chainId);
         return {
           chainId: chainId,
-          contract: {
-            address: "0x1234",
-          },
+          contract: { address }
           message: `Test transaction on chain ${chainId}`,
           mrkdwn: `This transaction is expected to ${fail ? "fail" : "pass"} simulation.`,
         } as AugmentedTransaction;
@@ -111,7 +110,6 @@ describe("MultiCallerClient", async function () {
 
   it("Validates transaction data before multicall bundle generation", async function () {
     const chainId = chainIds[0];
-    const address = randomAddress();
 
     for (const badField of ["address", "chainId"]) {
       const txns: AugmentedTransaction[] = [];

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -115,7 +115,7 @@ describe("MultiCallerClient", async function () {
     for (const badField of ["address", "chainId"]) {
       const txns: AugmentedTransaction[] = [];
 
-      for (const idx of [1,2,3,4,5]) {
+      for (const idx of [1, 2, 3, 4, 5]) {
         const txn = {
           chainId: chainId,
           contract: {

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -70,7 +70,7 @@ describe("MultiCallerClient", async function () {
         const chainId = Number(_chainId);
         return {
           chainId: chainId,
-          contract: { address }
+          contract: { address },
           message: `Test transaction on chain ${chainId}`,
           mrkdwn: `This transaction is expected to ${fail ? "fail" : "pass"} simulation.`,
         } as AugmentedTransaction;


### PR DESCRIPTION
The existing implementation incorrectly checks that _each_ enqueued transaction has the wrong contract address. This is impossible because the contract address used as a reference is sourced from the first transaction in the queue.

While here, add a test for this and expand the logic to validate that all enqueued transactions are destined for the same chain ID as well..