### PR TITLE
improve(MultiCallerClient): Simplify sim failure logging

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -310,7 +310,7 @@ export class MultiCallerClient {
       if (txn.succeed) validTxns.push(txn.transaction);
       else invalidTxns.push(txn);
     });
-    this.logSimulationFailures(invalidTxns);
+    if (invalidTxns.length > 0) this.logSimulationFailures(invalidTxns);
 
     return validTxns;
   }

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -315,10 +315,9 @@ export class MultiCallerClient {
     return validTxns;
   }
 
-  // Filter out transactions that revert for non-critical expected reasons. For example, the "relay filled" error will
+  // Filter out transactions that revert for non-critical, expected reasons. For example, the "relay filled" error may
   // will occur frequently if there are multiple relayers running at the same time. Similarly, the "already claimed"
-  // error will occur if there are overlapping dataworker executor runs. These are non critical errors we can ignore to
-  // filter out the noise.
+  // error will occur if there are overlapping dataworker executor runs.
   // @todo: Figure out a less hacky way to reduce these errors rather than ignoring them.
   // @todo: Consider logging key txn information with the failures?
   protected logSimulationFailures(failures: TransactionSimulationResult[]): void {

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -7,7 +7,6 @@ import { TransactionResponse, TransactionSimulationResult } from "../src/utils";
 import { CHAIN_ID_TEST_LIST as chainIds } from "./constants";
 import { createSpyLogger, Contract, expect, winston, toBN } from "./utils";
 
-// @todo: Consider overriding MultiCallerClient.logSimulationFailres().
 class MockedMultiCallerClient extends MultiCallerClient {
   public failSimulate = "";
   public failSubmit = "";

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -21,11 +21,7 @@ class MockedMultiCallerClient extends MultiCallerClient {
   }
 
   simulationFailureCount(): number {
-    let nFailures = 0;
-    nFailures += this.loggedSimulationFailures.length;
-    nFailures += this.ignoredSimulationFailures.length;
-
-    return nFailures;
+    return this.loggedSimulationFailures.length + this.ignoredSimulationFailures.length;
   }
 
   clearSimulationFailures(): void {


### PR DESCRIPTION
Makes the code a bit more compact and more clearly separates between simulation and logging. This also allows for the logging function to be verified in test by mocking it out.

As a minor benefit, the existing implementation performs 3 complete loops over the array of transaction simulation results. This change performs only one complete loop, and then a secondary loop over the list of failures to determine which to log. It should be marginally faster, and probably more memory efficient.