### PR TITLE
improve(PriceClient): Add DefiLlama as a backstop

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -52,7 +52,7 @@ const QUERY_HANDLERS: {
 };
 
 const { PriceClient } = priceClient;
-const { acrossApi, coingecko } = priceClient.adapters;
+const { acrossApi, coingecko, defiLlama } = priceClient.adapters;
 
 export class ProfitClient {
   private readonly priceClient;
@@ -85,6 +85,7 @@ export class ProfitClient {
     this.priceClient = new PriceClient(logger, [
       new acrossApi.PriceFeed(),
       new coingecko.PriceFeed({ apiKey: process.env.COINGECKO_PRO_API_KEY }),
+      new defiLlama.PriceFeed(),
     ]);
 
     for (const chainId of this.enabledChainIds) {


### PR DESCRIPTION
The recent CoinGecko blip led to a short period of relayer unavailability. DefiLlama have a price feed that is primarily backed by CoinGecko, but which can also fall back to on-chain sources for the major tokens.

Resolves ACX-597.