### PR TITLE
improve: Set 90 day expiry on redis keys

### DIFF
--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -331,7 +331,7 @@ export class AcrossConfigStoreClient {
     if (result === null) {
       const { current, post } = await this.hubPoolClient.getPostRelayPoolUtilization(l1Token, blockNumber, amount);
       if (shouldCache(getCurrentTime(), timestamp))
-        await setRedisKey(key, `${current.toString()},${post.toString()}`, 60 * 60 * 24 * 90, this.redisClient);
+        await setRedisKey(key, `${current.toString()},${post.toString()}`, this.redisClient,  60 * 60 * 24 * 90);
       return { current, post };
     } else {
       const [current, post] = result.split(",").map(BigNumber.from);

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -331,7 +331,7 @@ export class AcrossConfigStoreClient {
     if (result === null) {
       const { current, post } = await this.hubPoolClient.getPostRelayPoolUtilization(l1Token, blockNumber, amount);
       if (shouldCache(getCurrentTime(), timestamp))
-        await setRedisKey(key, `${current.toString()},${post.toString()}`, this.redisClient,  60 * 60 * 24 * 90);
+        await setRedisKey(key, `${current.toString()},${post.toString()}`, this.redisClient, 60 * 60 * 24 * 90);
       return { current, post };
     } else {
       const [current, post] = result.split(",").map(BigNumber.from);

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -14,6 +14,7 @@ import {
   max,
   getBlockForTimestamp,
   shouldCache,
+  setRedisKey,
 } from "../utils";
 
 import { CONFIG_STORE_VERSION, DEFAULT_CONFIG_STORE_VERSION } from "../common/Constants";
@@ -330,7 +331,7 @@ export class AcrossConfigStoreClient {
     if (result === null) {
       const { current, post } = await this.hubPoolClient.getPostRelayPoolUtilization(l1Token, blockNumber, amount);
       if (shouldCache(getCurrentTime(), timestamp))
-        await this.redisClient.set(key, `${current.toString()},${post.toString()}`);
+        await setRedisKey(key, `${current.toString()},${post.toString()}`, 60 * 60 * 24 * 90, this.redisClient);
       return { current, post };
     } else {
       const [current, post] = result.split(",").map(BigNumber.from);

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -12,10 +12,12 @@ export async function setRedisKey(
   key: string,
   val: string,
   redisClient: RedisClient,
-  expirySeconds = 0,
+  expirySeconds = 0
 ): Promise<void> {
-  // EX: Expire key after expirySeconds.
-  await redisClient.set(key, val, { EX: expirySeconds });
+  if (expirySeconds > 0) {
+    // EX: Expire key after expirySeconds.
+    await redisClient.set(key, val, { EX: expirySeconds });
+  } else await redisClient.set(key, val);
 }
 
 // Get the block number for a given timestamp fresh from on-chain data if not found in redis cache.

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -11,8 +11,8 @@ export const REDIS_CACHEABLE_AGE = 300;
 export async function setRedisKey(
   key: string,
   val: string,
-  expirySeconds: number,
-  redisClient: RedisClient
+  redisClient: RedisClient,
+  expirySeconds = 0,
 ): Promise<void> {
   // EX: Expire key after expirySeconds.
   await redisClient.set(key, val, { EX: expirySeconds });
@@ -36,7 +36,7 @@ export async function getBlockForTimestamp(
     const blockNumber = (await blockFinder.getBlockForTimestamp(timestamp)).number;
     // Expire key after 90 days.
     if (shouldCache(timestamp, currentChainTime))
-      await setRedisKey(key, blockNumber.toString(), 60 * 60 * 24 * 90, redisClient);
+      await setRedisKey(key, blockNumber.toString(), redisClient, 60 * 60 * 24 * 90);
     return blockNumber;
   } else {
     return parseInt(result);

--- a/src/utils/UmaUtils.ts
+++ b/src/utils/UmaUtils.ts
@@ -1,28 +1,33 @@
-import { Contract, ethers, isEventOlder, sortEventsDescending } from ".";
+import { Contract, ethers, getBlockForTimestamp, getCurrentTime, isEventOlder, sortEventsDescending } from ".";
 import * as uma from "@uma/contracts-node";
-import { HubPoolClient } from "../clients";
+import { AcrossConfigStoreClient } from "../clients";
 import { ProposedRootBundle, SortableEvent } from "../interfaces";
-import { BlockFinder } from "@uma/financial-templates-lib";
 
 export async function getDvmContract(mainnetProvider: ethers.providers.Provider): Promise<Contract> {
   return new Contract(await uma.getVotingAddress(1), uma.getAbi("Voting"), mainnetProvider);
 }
 export async function getDisputedProposal(
   dvm: Contract,
-  hubPoolClient: HubPoolClient,
+  configStoreClient: AcrossConfigStoreClient,
   disputeRequestTimestamp: number,
   disputeRequestBlock?: number
 ): Promise<ProposedRootBundle> {
   const filter = dvm.filters.PriceRequestAdded();
-  const blockFinder = new BlockFinder(dvm.provider.getBlock.bind(dvm.provider));
   const priceRequestBlock =
     disputeRequestBlock !== undefined
       ? disputeRequestBlock
-      : (await blockFinder.getBlockForTimestamp(disputeRequestTimestamp)).number;
+      : await getBlockForTimestamp(
+          configStoreClient.hubPoolClient.chainId,
+          configStoreClient.hubPoolClient.chainId,
+          disputeRequestTimestamp,
+          getCurrentTime(),
+          configStoreClient.blockFinder,
+          configStoreClient.redisClient
+        );
   const disputes = await dvm.queryFilter(filter, priceRequestBlock, priceRequestBlock);
   const dispute = disputes.find((e) => e.args.time.toString() === disputeRequestTimestamp.toString());
   if (!dispute) throw new Error("Could not find PriceRequestAdded event on DVM matching price request time");
-  return sortEventsDescending(hubPoolClient.getProposedRootBundles()).find((e) =>
+  return sortEventsDescending(configStoreClient.hubPoolClient.getProposedRootBundles()).find((e) =>
     isEventOlder(e as SortableEvent, dispute as SortableEvent)
   );
 }


### PR DESCRIPTION
RedisClient currently stores two keys:
- block for timestamp
- utilizations at block

These are used by ConfigStoreClient to compute a realized lp fee % and by dataworker to construct spoke pool clients' `fromBlocks`. They're also used by the validateRootBundle script which shouldnt ever be used to validate bundles older than 90 days

Expiring these keys after 90 days seems very safe assuming bundle block ranges stay steady

RedisJS [documentation](https://github.com/redis/node-redis#redis-commands)

Redis.API [documentation](https://redis.io/commands/set/)