### PR TITLE
improve: Remove extra properties from cumulative l1TokenUpdate objects

### DIFF
--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -245,8 +245,6 @@ export class AcrossConfigStoreClient {
             spokeTargetBalances: targetBalances,
             l1Token,
           });
-        } else {
-          this.cumulativeSpokeTargetBalanceUpdates.push({ ...passedArgs, spokeTargetBalances: {}, l1Token });
         }
 
         // Store route-specific rate models
@@ -257,8 +255,6 @@ export class AcrossConfigStoreClient {
             })
           );
           this.cumulativeRouteRateModelUpdates.push({ ...passedArgs, routeRateModel, l1Token });
-        } else {
-          this.cumulativeRouteRateModelUpdates.push({ ...passedArgs, routeRateModel: {}, l1Token });
         }
       } catch (err) {
         continue;

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -240,9 +240,13 @@ export class AcrossConfigStoreClient {
               return [chainId, { target, threshold }];
             })
           ) as SpokeTargetBalanceUpdate["spokeTargetBalances"];
-          this.cumulativeSpokeTargetBalanceUpdates.push({ ...args, spokeTargetBalances: targetBalances, l1Token });
+          this.cumulativeSpokeTargetBalanceUpdates.push({
+            ...passedArgs,
+            spokeTargetBalances: targetBalances,
+            l1Token,
+          });
         } else {
-          this.cumulativeSpokeTargetBalanceUpdates.push({ ...args, spokeTargetBalances: {}, l1Token });
+          this.cumulativeSpokeTargetBalanceUpdates.push({ ...passedArgs, spokeTargetBalances: {}, l1Token });
         }
 
         // Store route-specific rate models
@@ -252,9 +256,9 @@ export class AcrossConfigStoreClient {
               return [path, JSON.stringify(routeRateModel)];
             })
           );
-          this.cumulativeRouteRateModelUpdates.push({ ...args, routeRateModel, l1Token });
+          this.cumulativeRouteRateModelUpdates.push({ ...passedArgs, routeRateModel, l1Token });
         } else {
-          this.cumulativeRouteRateModelUpdates.push({ ...args, routeRateModel: {}, l1Token });
+          this.cumulativeRouteRateModelUpdates.push({ ...passedArgs, routeRateModel: {}, l1Token });
         }
       } catch (err) {
         continue;

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -245,6 +245,8 @@ export class AcrossConfigStoreClient {
             spokeTargetBalances: targetBalances,
             l1Token,
           });
+        } else {
+          this.cumulativeSpokeTargetBalanceUpdates.push({ ...passedArgs, spokeTargetBalances: {}, l1Token });
         }
 
         // Store route-specific rate models
@@ -255,6 +257,8 @@ export class AcrossConfigStoreClient {
             })
           );
           this.cumulativeRouteRateModelUpdates.push({ ...passedArgs, routeRateModel, l1Token });
+        } else {
+          this.cumulativeRouteRateModelUpdates.push({ ...passedArgs, routeRateModel: {}, l1Token });
         }
       } catch (err) {
         continue;

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -94,11 +94,7 @@ export class Relayer {
     const latestHubPoolTime = this.clients.hubPoolClient.currentTime;
 
     // Require that all fillable deposits meet the minimum specified number of confirmations.
-    const confirmedUnfilledDeposits = getUnfilledDeposits(
-      this.clients.spokePoolClients,
-      this.config.maxRelayerLookBack,
-      this.clients.configStoreClient
-    )
+    const confirmedUnfilledDeposits = unfilledDeposits
       .filter((x) => {
         return (
           x.deposit.quoteTimestamp + this.config.quoteTimeBuffer <= latestHubPoolTime &&

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,14 +1,6 @@
 import { AcrossConfigStoreClient, HubPoolClient } from "../clients";
 import { DepositWithBlock, Fill, FillsToRefund, FillWithBlock, SpokePoolClientsByChain } from "../interfaces";
-import {
-  BigNumber,
-  assign,
-  getRealizedLpFeeForFills,
-  getRefundForFills,
-  sortEventsDescending,
-  toBN,
-  winston,
-} from "./";
+import { BigNumber, assign, getRealizedLpFeeForFills, getRefundForFills, sortEventsDescending, toBN } from "./";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 import _ from "lodash";
 


### PR DESCRIPTION
Per the comment on line 221 "Drop value and key before passing args." we should be constructing cumulative l1 token config updates with `passedArgs` not `args` which includes the full key-value string which is unused after parsing it