### PR TITLE
improve(MultiCallerClient): Caller-supplied chunksize

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_MULTICALL_CHUNK_SIZE, CHAIN_MULTICALL_CHUNK_SIZE } from "../common";
+import { DEFAULT_MULTICALL_CHUNK_SIZE, DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE } from "../common";
 import {
   winston,
   getNetworkName,
@@ -53,7 +53,7 @@ export class MultiCallerClient {
   // eslint-disable-next-line no-useless-constructor
   constructor(
     readonly logger: winston.Logger,
-    readonly chunkSize: { [chainId: number]: number } = CHAIN_MULTICALL_CHUNK_SIZE
+    readonly chunkSize: { [chainId: number]: number } = DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE
   ) {}
 
   // Adds all information associated with a transaction to the transaction queue. This is the intention of the

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -51,7 +51,10 @@ export const unknownRevertReasonMethodsToIgnore = new Set([
 export class MultiCallerClient {
   private transactions: AugmentedTransaction[] = [];
   // eslint-disable-next-line no-useless-constructor
-  constructor(readonly logger: winston.Logger) {}
+  constructor(
+    readonly logger: winston.Logger,
+    readonly chunkSize: { [chainId: number]: number } = CHAIN_MULTICALL_CHUNK_SIZE
+  ) {}
 
   // Adds all information associated with a transaction to the transaction queue. This is the intention of the
   // caller to send a transaction. The transaction might not be executable, which should be filtered later.
@@ -97,7 +100,7 @@ export class MultiCallerClient {
       const chunkedTransactions: { [chainId: number]: AugmentedTransaction[][] } = Object.fromEntries(
         Object.entries(groupedTransactions).map(([_chainId, transactions]) => {
           const chainId = Number(_chainId);
-          const chunkSize: number = CHAIN_MULTICALL_CHUNK_SIZE[chainId] || DEFAULT_MULTICALL_CHUNK_SIZE;
+          const chunkSize: number = this.chunkSize[chainId] || DEFAULT_MULTICALL_CHUNK_SIZE;
           if (transactions.length > chunkSize) {
             const dropped: Array<{ address: string; method: string; args: any[] }> = transactions
               .slice(chunkSize)

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -100,7 +100,7 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
 export const DEFAULT_RELAYER_GAS_MULTIPLIER = 1.2;
 
 export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
-export const CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
+export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {
   1: DEFAULT_MULTICALL_CHUNK_SIZE,
   10: 75,
   137: DEFAULT_MULTICALL_CHUNK_SIZE,

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -16,8 +16,8 @@ class MockedMultiCallerClient extends MultiCallerClient {
   public ignoredSimulationFailures: TransactionSimulationResult[] = [];
   public loggedSimulationFailures: TransactionSimulationResult[] = [];
 
-  constructor(logger: winston.Logger) {
-    super(logger);
+  constructor(logger: winston.Logger, chunkSize: { [chainId: number]: number } = {}) {
+    super(logger, chunkSize);
   }
 
   simulationFailureCount(): number {


### PR DESCRIPTION
Makes it possible to supply the chunkSize from within test cases. Also allows for multiple concurrent instances of the MultiCallerClient to use different chunk sizes, if that should ever be desirable.