### PR TITLE
feat: Add TransactionClient

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -11,18 +11,8 @@ import {
   TransactionResponse,
   TransactionSimulationResult,
 } from "../utils";
-
+import { AugmentedTransaction } from "./TransactionClient";
 import lodash from "lodash";
-
-export interface AugmentedTransaction {
-  contract: Contract;
-  chainId: number;
-  method: string;
-  args: any[];
-  message: string;
-  mrkdwn: string;
-  value?: BigNumber;
-}
 
 // @todo: MultiCallerClient should be generic. For future, permit the class instantiator to supply their own
 // set of known failures that can be suppressed/ignored.

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -1,0 +1,78 @@
+import {
+  winston,
+  getNetworkName,
+  Contract,
+  runTransaction,
+  BigNumber,
+  etherscanLink,
+  TransactionResponse,
+  TransactionSimulationResult,
+} from "../utils";
+
+export interface AugmentedTransaction {
+  contract: Contract;
+  chainId: number;
+  method: string;
+  args: any[];
+  message: string;
+  mrkdwn: string;
+  value?: BigNumber;
+}
+
+export class TransactionClient {
+  // eslint-disable-next-line no-useless-constructor
+  constructor(readonly logger: winston.Logger) {}
+
+  protected async _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
+    const { contract, method, args, value } = txn;
+    return await runTransaction(this.logger, contract, method, args, value, null, nonce);
+  }
+
+  async submit(chainId: number, txns: AugmentedTransaction[]): Promise<TransactionResponse[]> {
+    const networkName = getNetworkName(chainId);
+    const txnResponses: TransactionResponse[] = [];
+
+    this.logger.debug({
+      at: "TransactionClient#submit",
+      message: `Processing ${txns.length} transactions.`,
+      txns,
+    });
+
+    // Transactions are submitted sequentially to avoid nonce collisions. More
+    // advanced nonce management may permit them to be submitted in parallel.
+    let mrkdwn = "";
+    let idx = 1;
+    let nonce: number = null;
+    for (const txn of txns) {
+      let response: TransactionResponse;
+      if (nonce !== null) this.logger.debug({ at: "TransactionClient#submit", message: `Using nonce ${nonce}.` });
+
+      try {
+        response = await this._submit(txn, nonce);
+      } catch (error) {
+        this.logger.info({
+          at: "TransactionClient#submit",
+          message: `Transaction ${idx} submission on ${networkName} failed or timed out.`,
+          mrkdwn,
+          error,
+          notificationPath: "across-error",
+        });
+        return txnResponses;
+      }
+
+      nonce = response.nonce + 1;
+      mrkdwn += `  ${idx}. ${txn.message || "No message"}: ${txn.mrkdwn || "No markdown"}\n`;
+      mrkdwn += `  *Block Explorer:* ${etherscanLink(response.hash, txn.chainId)}\n`;
+      txnResponses.push(response);
+      ++idx;
+    }
+
+    this.logger.info({
+      at: "TransactionClient#submit",
+      message: `Completed ${networkName} transaction submission! 🧙`,
+      mrkdwn,
+    });
+
+    return txnResponses;
+  }
+}

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -41,9 +41,9 @@ export class TransactionClient {
     // Transactions are submitted sequentially to avoid nonce collisions. More
     // advanced nonce management may permit them to be submitted in parallel.
     let mrkdwn = "";
-    let idx = 1;
     let nonce: number = null;
-    for (const txn of txns) {
+    for (let idx = 0; idx < txns.length; ++idx) {
+      const txn: AugmentedTransaction = txns[idx];
       let response: TransactionResponse;
       if (nonce !== null) this.logger.debug({ at: "TransactionClient#submit", message: `Using nonce ${nonce}.` });
 
@@ -52,7 +52,7 @@ export class TransactionClient {
       } catch (error) {
         this.logger.info({
           at: "TransactionClient#submit",
-          message: `Transaction ${idx} submission on ${networkName} failed or timed out.`,
+          message: `Transaction ${idx + 1} submission on ${networkName} failed or timed out.`,
           mrkdwn,
           error,
           notificationPath: "across-error",
@@ -61,10 +61,9 @@ export class TransactionClient {
       }
 
       nonce = response.nonce + 1;
-      mrkdwn += `  ${idx}. ${txn.message || "No message"}: ${txn.mrkdwn || "No markdown"}\n`;
+      mrkdwn += `  ${idx + 1}. ${txn.message || "No message"}: ${txn.mrkdwn || "No markdown"}\n`;
       mrkdwn += `  *Block Explorer:* ${etherscanLink(response.hash, txn.chainId)}\n`;
       txnResponses.push(response);
-      ++idx;
     }
 
     this.logger.info({

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -7,5 +7,6 @@ export * from "./MultiCallerClient";
 export * from "./ProfitClient";
 export * from "./TokenClient";
 export * from "./TokenTransferClient";
+export * from "./TransactionClient";
 export * from "./InventoryClient";
 export * from "./AcrossAPIClient";

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -29,6 +29,25 @@ class MockedMultiCallerClient extends MultiCallerClient {
     this.loggedSimulationFailures = [];
   }
 
+  protected async _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
+    const result = txn.args[0]?.result;
+    if (result && result !== "pass") return Promise.reject(result);
+
+    const txnResponse = {
+      chainId: txn.chainId,
+      nonce: nonce ?? 1,
+      hash: "0x4321",
+    } as TransactionResponse;
+
+    this.logger.debug({
+      at: "MockMultiCallerClient#submitTxns",
+      message: "Transaction submission succeeded!",
+      txn: txnResponse,
+    });
+
+    return txnResponse;
+  }
+
   protected override async simulateTxn(txn: AugmentedTransaction): Promise<TransactionSimulationResult> {
     this.logger.debug({
       at: "MockMultiCallerClient#simulateTxn",

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -92,8 +92,6 @@ describe("TransactionClient", async function () {
 
     const txnResponses: TransactionResponse[] = await txnClient.submit(chainId, txns);
     let nonce = txnResponses[0].nonce;
-    txnResponses.slice(1).forEach((txnResponse) => {
-      expect(txnResponse.nonce).to.equal(++nonce);
-    });
+    txnResponses.slice(1).forEach((txnResponse) => expect(txnResponse.nonce).to.equal(++nonce));
   });
 });

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -1,0 +1,103 @@
+import { ethers } from "ethers";
+import { AugmentedTransaction, TransactionClient } from "../src/clients";
+import { TransactionResponse, TransactionSimulationResult } from "../src/utils";
+import { CHAIN_ID_TEST_LIST as chainIds } from "./constants";
+import { createSpyLogger, Contract, expect, randomAddress, winston, toBN } from "./utils";
+
+class MockedTransactionClient extends TransactionClient {
+  public failSubmit = "";
+
+  constructor(logger: winston.Logger) {
+    super(logger);
+  }
+
+  protected async _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
+    const result = txn.args[0]?.result;
+    if (result && result !== "pass") return Promise.reject(result);
+
+    const txnResponse = {
+      chainId: txn.chainId,
+      nonce: nonce ?? 1,
+      hash: "0x4321",
+    } as TransactionResponse;
+
+    this.logger.debug({
+      at: "MockMultiCallerClient#submitTxns",
+      message: "Transaction submission succeeded!",
+      txn: txnResponse,
+    });
+
+    return txnResponse;
+  }
+}
+
+const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
+const txnClient: MockedTransactionClient = new MockedTransactionClient(spyLogger);
+const provider = new ethers.providers.StaticJsonRpcProvider("127.0.0.1");
+const address = randomAddress(); // Test contract address
+const method = "testMethod";
+const passResult = "pass";
+
+describe("TransactionClient", async function () {
+  beforeEach(async function () {
+    txnClient.failSubmit = "";
+  });
+
+  it("Handles submission success & failure", async function () {
+    const chainId = chainIds[0];
+
+    const nTxns = 4;
+    const txns: AugmentedTransaction[] = [];
+    for (const result of [passResult, "Forced submission failure", passResult]) {
+      const txn: AugmentedTransaction = {
+        chainId,
+        contract: { address } as Contract,
+        method,
+        args: [{ result }],
+        value: toBN(0),
+        mrkdwn: `Sample markdown string for chain ${chainId} transaction`,
+      } as AugmentedTransaction;
+
+      for (let nTxn = 1; nTxn <= nTxns; ++nTxn) {
+        const message = `Test transaction (${nTxn}/${nTxns}) on chain ${chainId}`;
+        txns.push({ ...txn, message } as AugmentedTransaction);
+      }
+    }
+
+    // Should have 4 txn responses before the first bad transaction.
+    let txnResponses: TransactionResponse[];
+    txnResponses = await txnClient.submit(chainId, txns);
+    expect(txnResponses.length).to.equal(nTxns);
+
+    // Skip over the bad txns in the middle; all should pass.
+    txnResponses = await txnClient.submit(chainId, txns.slice(0, nTxns).concat(txns.slice(-nTxns)));
+    expect(txnResponses.length).to.equal(2 * nTxns);
+
+    // The bad txns in the middle should exclusively fail.
+    txnResponses = await txnClient.submit(chainId, txns.slice(nTxns, nTxns + nTxns));
+    expect(txnResponses.length).to.equal(0);
+  });
+
+  it("Validates that successive transactions increment their nonce", async function () {
+    const chainId = chainIds[0];
+
+    const nTxns = 10;
+    const txns: AugmentedTransaction[] = [];
+    for (let txn = 1; txn <= nTxns; ++txn) {
+      const txnRequest: AugmentedTransaction = {
+        chainId,
+        contract: { address } as Contract,
+        method,
+        args: [],
+      } as AugmentedTransaction;
+      txns.push(txnRequest);
+    }
+
+    const txnResponses: TransactionResponse[] = await txnClient.submit(chainId, txns);
+    let nonce = txnResponses[0].nonce;
+    txnResponses.slice(1).forEach((txnResponse) => {
+      expect(txnResponse.nonce).to.equal(nonce + 1);
+      nonce = txnResponse.nonce;
+    });
+  });
+});

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -96,8 +96,7 @@ describe("TransactionClient", async function () {
     const txnResponses: TransactionResponse[] = await txnClient.submit(chainId, txns);
     let nonce = txnResponses[0].nonce;
     txnResponses.slice(1).forEach((txnResponse) => {
-      expect(txnResponse.nonce).to.equal(nonce + 1);
-      nonce = txnResponse.nonce;
+      expect(txnResponse.nonce).to.equal(++nonce);
     });
   });
 });

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -5,7 +5,6 @@ import { CHAIN_ID_TEST_LIST as chainIds } from "./constants";
 import { createSpyLogger, Contract, expect, randomAddress, winston, toBN } from "./utils";
 
 class MockedTransactionClient extends TransactionClient {
-  public failSubmit = "";
 
   constructor(logger: winston.Logger) {
     super(logger);
@@ -39,9 +38,7 @@ const method = "testMethod";
 const passResult = "pass";
 
 describe("TransactionClient", async function () {
-  beforeEach(async function () {
-    txnClient.failSubmit = "";
-  });
+  beforeEach(async function () {});
 
   it("Handles submission success & failure", async function () {
     const chainId = chainIds[0];

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -1,11 +1,10 @@
 import { ethers } from "ethers";
 import { AugmentedTransaction, TransactionClient } from "../src/clients";
-import { TransactionResponse, TransactionSimulationResult } from "../src/utils";
+import { TransactionResponse } from "../src/utils";
 import { CHAIN_ID_TEST_LIST as chainIds } from "./constants";
 import { createSpyLogger, Contract, expect, randomAddress, winston, toBN } from "./utils";
 
 class MockedTransactionClient extends TransactionClient {
-
   constructor(logger: winston.Logger) {
     super(logger);
   }
@@ -31,14 +30,15 @@ class MockedTransactionClient extends TransactionClient {
 }
 
 const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
-const txnClient: MockedTransactionClient = new MockedTransactionClient(spyLogger);
-const provider = new ethers.providers.StaticJsonRpcProvider("127.0.0.1");
 const address = randomAddress(); // Test contract address
 const method = "testMethod";
 const passResult = "pass";
+let txnClient: MockedTransactionClient;
 
 describe("TransactionClient", async function () {
-  beforeEach(async function () {});
+  beforeEach(async function () {
+    txnClient = new MockedTransactionClient(spyLogger);
+  });
 
   it("Handles submission success & failure", async function () {
     const chainId = chainIds[0];

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -2,37 +2,12 @@ import { ethers } from "ethers";
 import { AugmentedTransaction, TransactionClient } from "../src/clients";
 import { TransactionResponse } from "../src/utils";
 import { CHAIN_ID_TEST_LIST as chainIds } from "./constants";
+import { MockedTransactionClient, txnClientPassResult } from "./mocks/MockTransactionClient";
 import { createSpyLogger, Contract, expect, randomAddress, winston, toBN } from "./utils";
-
-class MockedTransactionClient extends TransactionClient {
-  constructor(logger: winston.Logger) {
-    super(logger);
-  }
-
-  protected async _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
-    const result = txn.args[0]?.result;
-    if (result && result !== "pass") return Promise.reject(result);
-
-    const txnResponse = {
-      chainId: txn.chainId,
-      nonce: nonce ?? 1,
-      hash: "0x4321",
-    } as TransactionResponse;
-
-    this.logger.debug({
-      at: "MockMultiCallerClient#submitTxns",
-      message: "Transaction submission succeeded!",
-      txn: txnResponse,
-    });
-
-    return txnResponse;
-  }
-}
 
 const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
 const address = randomAddress(); // Test contract address
 const method = "testMethod";
-const passResult = "pass";
 let txnClient: MockedTransactionClient;
 
 describe("TransactionClient", async function () {
@@ -45,7 +20,7 @@ describe("TransactionClient", async function () {
 
     const nTxns = 4;
     const txns: AugmentedTransaction[] = [];
-    for (const result of [passResult, "Forced submission failure", passResult]) {
+    for (const result of [txnClientPassResult, "Forced submission failure", txnClientPassResult]) {
       const txn: AugmentedTransaction = {
         chainId,
         contract: { address } as Contract,

--- a/test/mocks/MockTransactionClient.ts
+++ b/test/mocks/MockTransactionClient.ts
@@ -20,7 +20,10 @@ export class MockedTransactionClient extends TransactionClient {
     return result && result !== txnClientPassResult;
   }
 
-  protected override async _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
+  protected override async _submit(
+    txn: AugmentedTransaction,
+    nonce: number | null = null
+  ): Promise<TransactionResponse> {
     if (this.txnFailure(txn)) return Promise.reject(this.txnFailureReason(txn));
 
     const _nonce = nonce ?? 1;

--- a/test/mocks/MockTransactionClient.ts
+++ b/test/mocks/MockTransactionClient.ts
@@ -11,7 +11,7 @@ export class MockedTransactionClient extends TransactionClient {
 
   protected async _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
     const result = txn.args[0]?.result;
-    if (result && result !== "pass") return Promise.reject(result);
+    if (result && result !== txnClientPassResult) return Promise.reject(result);
 
     const txnResponse = {
       chainId: txn.chainId,

--- a/test/mocks/MockTransactionClient.ts
+++ b/test/mocks/MockTransactionClient.ts
@@ -1,0 +1,30 @@
+import { AugmentedTransaction, TransactionClient } from "../../src/clients";
+import { TransactionResponse } from "../../src/utils";
+import { winston } from "../utils";
+
+export const txnClientPassResult = "pass";
+
+export class MockedTransactionClient extends TransactionClient {
+  constructor(logger: winston.Logger) {
+    super(logger);
+  }
+
+  protected async _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
+    const result = txn.args[0]?.result;
+    if (result && result !== "pass") return Promise.reject(result);
+
+    const txnResponse = {
+      chainId: txn.chainId,
+      nonce: nonce ?? 1,
+      hash: "0x4321",
+    } as TransactionResponse;
+
+    this.logger.debug({
+      at: "MockMultiCallerClient#submitTxns",
+      message: "Transaction submission succeeded!",
+      txn: txnResponse,
+    });
+
+    return txnResponse;
+  }
+}

--- a/test/mocks/MockTransactionClient.ts
+++ b/test/mocks/MockTransactionClient.ts
@@ -1,3 +1,4 @@
+import { ethers } from "ethers";
 import { AugmentedTransaction, TransactionClient } from "../../src/clients";
 import { TransactionResponse } from "../../src/utils";
 import { winston } from "../utils";
@@ -22,10 +23,11 @@ export class MockedTransactionClient extends TransactionClient {
   protected override async _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
     if (this.txnFailure(txn)) return Promise.reject(this.txnFailureReason(txn));
 
+    const _nonce = nonce ?? 1;
     const txnResponse = {
       chainId: txn.chainId,
-      nonce: nonce ?? 1,
-      hash: "0x4321",
+      nonce: _nonce,
+      hash: ethers.utils.id(`Across-v2-${txn.contract.address}-${txn.method}-${_nonce}`),
     } as TransactionResponse;
 
     this.logger.debug({

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -3,4 +3,5 @@ export * from "./MockHubPoolClient";
 export * from "./MockProfitClient";
 export * from "./MockAdapterManager";
 export * from "./MockTokenClient";
+export * from "./MockTransactionClient";
 export * from "./MockInventoryClient";


### PR DESCRIPTION
This factors out some of the transaction submission functions from the MultiCallerClient implementation. As a result, the MultiCallerClient can become more compact and focused on the task of sorting transactions and bundling the eligible ones.

Note that this PR does not introduce use of the TransactionClient into the MultiCallerClient at this stage, since the TransactionClient includes new behaviour around nonces.

More to come.