### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These owners will be the default owners for everything in
 # the repo unless a later match takes precedence.
-*       @mrice32 @nicholaspai @chrismaree @pxrl
+*       @mrice32 @nicholaspai @pxrl


### PR DESCRIPTION
This update removes @chrismaree to avoid tagging him on all PRs.