### PR TITLE
improve(validate-script): Script can efficiently reconstruct very old bundle

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -259,6 +259,13 @@ export class HubPoolClient {
     ) as ExecutedRootBundle[];
   }
 
+  getValidatedRootBundles(latestMainnetBlock: number = Number.MAX_SAFE_INTEGER): ProposedRootBundle[] {
+    return this.proposedRootBundles.filter((rootBundle: ProposedRootBundle) => {
+      if (rootBundle.blockNumber > latestMainnetBlock) return false;
+      return this.isRootBundleValid(rootBundle, latestMainnetBlock);
+    });
+  }
+
   getLatestFullyExecutedRootBundle(latestMainnetBlock: number): ProposedRootBundle | undefined {
     // Search for latest ProposeRootBundleExecuted event followed by all of its RootBundleExecuted event suggesting
     // that all pool rebalance leaves were executed. This ignores any proposed bundles that were partially executed.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -728,6 +728,10 @@ export class Dataworker {
         expectedBlockRanges: blockRangesImpliedByBundleEndBlocks,
         expectedPoolRebalanceLeaves: expectedPoolRebalanceRoot.leaves,
         expectedPoolRebalanceRoot: expectedPoolRebalanceRoot.tree.getHexRoot(),
+        expectedRelayerRefundLeaves: expectedRelayerRefundRoot.leaves,
+        expectedRelayerRefundRoot: expectedRelayerRefundRoot.tree.getHexRoot(),
+        expectedSlowRelayLeaves: expectedSlowRelayRoot.leaves,
+        expectedSlowRelayRoot: expectedSlowRelayRoot.tree.getHexRoot(),
         pendingRoot: rootBundle.poolRebalanceRoot,
         pendingPoolRebalanceLeafCount: rootBundle.unclaimedPoolRebalanceLeafCount,
       });

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -22,13 +22,14 @@ import {
   getDisputedProposal,
   getBlockForTimestamp,
   getCurrentTime,
+  sortEventsDescending,
 } from "../utils";
 import {
   constructSpokePoolClientsForFastDataworker,
   getSpokePoolClientEventSearchConfigsForFastDataworker,
   updateDataworkerClients,
 } from "../dataworker/DataworkerClientHelper";
-import { PendingRootBundle } from "../interfaces";
+import { PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
 import { createDataworker } from "../dataworker";
 import { getEndBlockBuffers } from "../dataworker/DataworkerUtils";
@@ -79,13 +80,26 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
     return;
   }
 
-  const precedingProposeRootBundleEvent = await getDisputedProposal(
-    dvm,
-    clients.configStoreClient,
-    priceRequestTime,
-    priceRequestBlock
-  );
-  if (!precedingProposeRootBundleEvent) throw new Error("Failed to identify a root bundle preceding dispute");
+  // If request timestamp corresponds to a dispute, use that to easily find the associated root bundle.
+  let precedingProposeRootBundleEvent: ProposedRootBundle;
+  try {
+    precedingProposeRootBundleEvent = await getDisputedProposal(
+      dvm,
+      clients.configStoreClient,
+      priceRequestTime,
+      priceRequestBlock
+    );
+  } catch (_err) {
+    logger.debug({
+      at: "Dataworker#validate",
+      message: "No dispute found for request time, falling back to most recent root bundle before request time"
+    })
+    // Timestamp doesn't correspond to a dispute, so find the most recent root bundle before the request time.
+    precedingProposeRootBundleEvent = sortEventsDescending(clients.hubPoolClient.getProposedRootBundles()).find(
+      (x) => x.blockNumber <= priceRequestBlock
+    );
+  }
+  if (!precedingProposeRootBundleEvent) throw new Error("No proposed root bundle found before request time")
 
   const rootBundle: PendingRootBundle = {
     poolRebalanceRoot: precedingProposeRootBundleEvent.poolRebalanceRoot,
@@ -108,8 +122,14 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
     throw new Error("Set DATAWORKER_FAST_LOOKBACK_COUNT > 0, otherwise script will take too long to run");
   }
 
+  // Calculate the latest blocks we should query in the spoke pool client so we can efficiently reconstruct
+  // older bundles. We do this by setting toBlocks equal to the bundle end blocks of the first validated bundle
+  // following the target bundle.
+  const closestFollowingValidatedBundleIndex = clients.hubPoolClient.getValidatedRootBundles().findIndex((x) => x.blockNumber >= rootBundle.proposalBlockNumber);
+  const overriddenConfig = {...config, dataworkerFastStartBundle: closestFollowingValidatedBundleIndex + 1}
+
   const { fromBundle, toBundle, fromBlocks, toBlocks } = getSpokePoolClientEventSearchConfigsForFastDataworker(
-    config,
+    overriddenConfig,
     clients,
     dataworker
   );

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -92,14 +92,14 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
   } catch (_err) {
     logger.debug({
       at: "Dataworker#validate",
-      message: "No dispute found for request time, falling back to most recent root bundle before request time"
-    })
+      message: "No dispute found for request time, falling back to most recent root bundle before request time",
+    });
     // Timestamp doesn't correspond to a dispute, so find the most recent root bundle before the request time.
     precedingProposeRootBundleEvent = sortEventsDescending(clients.hubPoolClient.getProposedRootBundles()).find(
       (x) => x.blockNumber <= priceRequestBlock
     );
   }
-  if (!precedingProposeRootBundleEvent) throw new Error("No proposed root bundle found before request time")
+  if (!precedingProposeRootBundleEvent) throw new Error("No proposed root bundle found before request time");
 
   const rootBundle: PendingRootBundle = {
     poolRebalanceRoot: precedingProposeRootBundleEvent.poolRebalanceRoot,
@@ -125,8 +125,10 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
   // Calculate the latest blocks we should query in the spoke pool client so we can efficiently reconstruct
   // older bundles. We do this by setting toBlocks equal to the bundle end blocks of the first validated bundle
   // following the target bundle.
-  const closestFollowingValidatedBundleIndex = clients.hubPoolClient.getValidatedRootBundles().findIndex((x) => x.blockNumber >= rootBundle.proposalBlockNumber);
-  const overriddenConfig = {...config, dataworkerFastStartBundle: closestFollowingValidatedBundleIndex + 1}
+  const closestFollowingValidatedBundleIndex = clients.hubPoolClient
+    .getValidatedRootBundles()
+    .findIndex((x) => x.blockNumber >= rootBundle.proposalBlockNumber);
+  const overriddenConfig = { ...config, dataworkerFastStartBundle: closestFollowingValidatedBundleIndex + 1 };
 
   const { fromBundle, toBundle, fromBlocks, toBlocks } = getSpokePoolClientEventSearchConfigsForFastDataworker(
     overriddenConfig,

--- a/src/utils/UmaUtils.ts
+++ b/src/utils/UmaUtils.ts
@@ -6,12 +6,21 @@ import { ProposedRootBundle, SortableEvent } from "../interfaces";
 export async function getDvmContract(mainnetProvider: ethers.providers.Provider): Promise<Contract> {
   return new Contract(await uma.getVotingAddress(1), uma.getAbi("Voting"), mainnetProvider);
 }
-export async function getDisputedProposal(
+export function getDisputedProposal(
+  configStoreClient: AcrossConfigStoreClient,
+  disputeEvent: SortableEvent
+): ProposedRootBundle | undefined {
+  return sortEventsDescending(configStoreClient.hubPoolClient.getProposedRootBundles()).find((e) =>
+    isEventOlder(e as SortableEvent, disputeEvent)
+  );
+}
+
+export async function getDisputeForTimestamp(
   dvm: Contract,
   configStoreClient: AcrossConfigStoreClient,
   disputeRequestTimestamp: number,
   disputeRequestBlock?: number
-): Promise<ProposedRootBundle> {
+): Promise<SortableEvent | undefined> {
   const filter = dvm.filters.PriceRequestAdded();
   const priceRequestBlock =
     disputeRequestBlock !== undefined
@@ -25,9 +34,5 @@ export async function getDisputedProposal(
           configStoreClient.redisClient
         );
   const disputes = await dvm.queryFilter(filter, priceRequestBlock, priceRequestBlock);
-  const dispute = disputes.find((e) => e.args.time.toString() === disputeRequestTimestamp.toString());
-  if (!dispute) throw new Error("Could not find PriceRequestAdded event on DVM matching price request time");
-  return sortEventsDescending(configStoreClient.hubPoolClient.getProposedRootBundles()).find((e) =>
-    isEventOlder(e as SortableEvent, dispute as SortableEvent)
-  );
+  return disputes.find((e) => e.args.time.toString() === disputeRequestTimestamp.toString()) as SortableEvent;
 }


### PR DESCRIPTION
Script  essentially figures out the latest events it should need to query to reconstruct an older bundle, so the range of events to query is fixed based on DATAWORKER_FAST_LOOKBACK_COUNT
