### PR TITLE
chore(config): Prevent non-zero POLLING_DELAY

### DIFF
--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -40,7 +40,8 @@ export class CommonConfig {
     this.maxRelayerLookBack = Number(MAX_RELAYER_DEPOSIT_LOOK_BACK ?? Constants.MAX_RELAYER_DEPOSIT_LOOK_BACK);
     this.hubPoolChainId = Number(HUB_CHAIN_ID ?? 1);
     this.spokePoolChains = CONFIGURED_NETWORKS ? JSON.parse(CONFIGURED_NETWORKS) : Constants.CHAIN_ID_LIST_INDICES;
-    this.pollingDelay = Number(POLLING_DELAY ?? 60);
+    this.pollingDelay = Number(POLLING_DELAY ?? 0);
+    assert(this.pollingDelay === 0, "Non-zero POLLING_DELAY is currently unsupported");
     this.maxBlockLookBack = MAX_BLOCK_LOOK_BACK ? JSON.parse(MAX_BLOCK_LOOK_BACK) : {};
     if (Object.keys(this.maxBlockLookBack).length > 0)
       for (const chainId of this.spokePoolChains)

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -84,6 +84,7 @@ describe("Monitor", async function () {
       MONITOR_REPORT_INTERVAL: "10",
       MONITORED_RELAYERS: `["${depositor.address}"]`,
       CONFIGURED_NETWORKS: JSON.stringify(configuredNetworks),
+      POLLING_DELAY: "60",
     });
 
     // Set the config store version to 0 to match the default version in the ConfigStoreClient.


### PR DESCRIPTION
This is an administrative change to temporarily prevent operators from running in
looping mode. The justification for this is that we currently do not apply the same
QA to non-zero polling delay (looping mode) as we do to serverless mode.

Looping mode is useful for third-party operators and the intention is ultimately to
support it.