### PR TITLE
improve: Dump mismatched RPC provider responses

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -246,13 +246,15 @@ class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     if (count < quorumThreshold) throwQuorumError();
 
     // If we've achieved quorum, then we should still log the providers that mismatched with the quorum result.
-    const mismatchedProviders = [...values, ...fallbackValues]
-      .filter(([, result]) => !compareRpcResults(method, result, quorumResult))
-      .map(([provider]) => provider.connection.url);
+    const mismatchedProviders = Object.fromEntries(
+      [...values, ...fallbackValues]
+        .filter(([, result]) => !compareRpcResults(method, result, quorumResult))
+        .map(([provider, result]) => [provider.connection.url, result])
+    );
     const quorumProviders = [...values, ...fallbackValues]
       .filter(([, result]) => compareRpcResults(method, result, quorumResult))
       .map(([provider]) => provider.connection.url);
-    if (mismatchedProviders.length > 0 || errors.length > 0) {
+    if (Object.keys(mismatchedProviders).length > 0 || errors.length > 0) {
       logger.warn({
         at: "ProviderUtils",
         message: "Some providers mismatched with the quorum result or failed 🚸",


### PR DESCRIPTION
Some RPC provider errors that we see are transient, so it's hard to debug them any further unless we capture the actual response that was issued.

This will generate fairly lengthy logging when we do have provider issues, but will also enable us to diagnose and report errors much more quickly.

Fixes ACX-755.