### PR TITLE
improve: If `spokeRootsLookbackCount` is set, only try to execute root bundles from N most recent proposed root bundles rather than root bundle relays

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -811,7 +811,7 @@ export class Dataworker {
         let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter((rootBundle) =>
           isKeyOf(chainId, IGNORED_SPOKE_BUNDLES)
             ? !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
-            : true && rootBundle.blockNumber >= client.eventSearchConfig.fromBlock
+            : rootBundle.blockNumber >= client.eventSearchConfig.fromBlock
         );
 
         // Filter out roots that are not in the latest N root bundles. This assumes that
@@ -1253,7 +1253,7 @@ export class Dataworker {
         let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter((rootBundle) =>
           isKeyOf(chainId, IGNORED_SPOKE_BUNDLES)
             ? !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
-            : true && rootBundle.blockNumber >= client.eventSearchConfig.fromBlock
+            : rootBundle.blockNumber >= client.eventSearchConfig.fromBlock
         );
 
         // Filter out roots that are not in the latest N root bundles. This assumes that

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1245,8 +1245,9 @@ export class Dataworker {
     });
 
     let latestRootBundles = sortEventsDescending(this.clients.hubPoolClient.getValidatedRootBundles());
-    if (this.spokeRootsLookbackCount !== 0)
+    if (this.spokeRootsLookbackCount !== 0) {
       latestRootBundles = latestRootBundles.slice(0, this.spokeRootsLookbackCount);
+    }
 
     await Promise.all(
       Object.entries(spokePoolClients).map(async ([_chainId, client]) => {
@@ -1575,19 +1576,23 @@ export class Dataworker {
     return requiredAmount;
   }
 
-  // Filters out any root bundles that don't have a matching relayerRefundRoot+slowRelayRoot combination in the
-  // list of proposed root bundles `allRootBundleRelays`.
+  /**
+   * Filters out any root bundles that don't have a matching relayerRefundRoot+slowRelayRoot combination in the
+   * list of proposed root bundles `allRootBundleRelays`.
+   * @param targetRootBundles Root bundles whose relayed roots we want to find
+   * @param allRootBundleRelays All relayed roots to search
+   * @returns Relayed roots that originated from rootBundles contained in allRootBundleRelays
+   */
   _getRelayedRootsFromBundles(
-    rootBundles: ProposedRootBundle[],
+    targetRootBundles: ProposedRootBundle[],
     allRootBundleRelays: RootBundleRelayWithBlock[]
   ): RootBundleRelayWithBlock[] {
-    return allRootBundleRelays.filter(
-      (rootBundle) =>
-        rootBundles.find(
-          (_rootBundle) =>
-            _rootBundle.relayerRefundRoot === rootBundle.relayerRefundRoot &&
-            _rootBundle.slowRelayRoot === rootBundle.slowRelayRoot
-        ) !== undefined
+    return allRootBundleRelays.filter((rootBundle) =>
+      targetRootBundles.some(
+        (_rootBundle) =>
+          _rootBundle.relayerRefundRoot === rootBundle.relayerRefundRoot &&
+          _rootBundle.slowRelayRoot === rootBundle.slowRelayRoot
+      )
     );
   }
 }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -802,8 +802,9 @@ export class Dataworker {
     });
 
     let latestRootBundles = sortEventsDescending(this.clients.hubPoolClient.getValidatedRootBundles());
-    if (this.spokeRootsLookbackCount !== 0)
+    if (this.spokeRootsLookbackCount !== 0) {
       latestRootBundles = latestRootBundles.slice(0, this.spokeRootsLookbackCount);
+    }
 
     await Promise.all(
       Object.entries(spokePoolClients).map(async ([_chainId, client]) => {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -15,6 +15,7 @@ import {
   DepositWithBlock,
   FillsToRefund,
   FillWithBlock,
+  ProposedRootBundle,
   RootBundleRelayWithBlock,
   SpokePoolClientsByChain,
   UnfilledDeposit,
@@ -815,14 +816,7 @@ export class Dataworker {
 
         // Filter out roots that are not in the latest N root bundles. This assumes that
         // relayerRefundRoot+slowFillRoot combinations are unique.
-        rootBundleRelays = rootBundleRelays.filter(
-          (rootBundle) =>
-            latestRootBundles.find(
-              (_rootBundle) =>
-                _rootBundle.relayerRefundRoot === rootBundle.relayerRefundRoot &&
-                _rootBundle.slowRelayRoot === rootBundle.slowRelayRoot
-            ) !== undefined
-        );
+        rootBundleRelays = this._getRelayedRootsFromBundles(latestRootBundles, rootBundleRelays);
 
         // Filter out empty slow fill roots:
         rootBundleRelays = rootBundleRelays.filter((rootBundle) => rootBundle.slowRelayRoot !== EMPTY_MERKLE_ROOT);
@@ -1264,14 +1258,7 @@ export class Dataworker {
 
         // Filter out roots that are not in the latest N root bundles. This assumes that
         // relayerRefundRoot+slowFillRoot combinations are unique.
-        rootBundleRelays = rootBundleRelays.filter(
-          (rootBundle) =>
-            latestRootBundles.find(
-              (_rootBundle) =>
-                _rootBundle.relayerRefundRoot === rootBundle.relayerRefundRoot &&
-                _rootBundle.slowRelayRoot === rootBundle.slowRelayRoot
-            ) !== undefined
-        );
+        rootBundleRelays = this._getRelayedRootsFromBundles(latestRootBundles, rootBundleRelays);
 
         // Filter out empty relayer refund root:
         rootBundleRelays = rootBundleRelays.filter((rootBundle) => rootBundle.relayerRefundRoot !== EMPTY_MERKLE_ROOT);
@@ -1585,5 +1572,21 @@ export class Dataworker {
 
     if (leaf.groupIndex === 0) requiredAmount = requiredAmount.add(toBNWei("0.02"));
     return requiredAmount;
+  }
+
+  // Filters out any root bundles that don't have a matching relayerRefundRoot+slowRelayRoot combination in the
+  // list of proposed root bundles `allRootBundleRelays`.
+  _getRelayedRootsFromBundles(
+    rootBundles: ProposedRootBundle[],
+    allRootBundleRelays: RootBundleRelayWithBlock[]
+  ): RootBundleRelayWithBlock[] {
+    return allRootBundleRelays.filter(
+      (rootBundle) =>
+        rootBundles.find(
+          (_rootBundle) =>
+            _rootBundle.relayerRefundRoot === rootBundle.relayerRefundRoot &&
+            _rootBundle.slowRelayRoot === rootBundle.slowRelayRoot
+        ) !== undefined
+    );
   }
 }

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -135,7 +135,8 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
   // We want the bundle end of blocks following the target bundle so add +1 to the index.
   const overriddenConfig = {
     ...config,
-    dataworkerFastStartBundle: closestFollowingValidatedBundleIndex + 1,
+    dataworkerFastStartBundle:
+      closestFollowingValidatedBundleIndex === -1 ? "latest" : closestFollowingValidatedBundleIndex + 1,
   };
 
   const { fromBundle, toBundle, fromBlocks, toBlocks } = getSpokePoolClientEventSearchConfigsForFastDataworker(


### PR DESCRIPTION
Imagine we only want to execute leaves from the last 10 bundles. Intuitively this should only include leaves from the last 10 root bundles, but currently this means we count the latest 10 relayed root bundles for a chain. This means that some chains like Boba which have infrequent relayed root bundles, the lookback needs to be much larger.

This results in a lot of warnings: "Cannot validate bundle with insufficient event data. Set a larger DATAWORKER_FAST_LOOKBACK_COUNT". We should quiet these warnings