### PR TITLE
fix(dataworker): amount to send to SpokePool for slow fill should be unfilled amount minus LP fee

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -206,8 +206,7 @@ export class BundleDataClient {
       allValidFills.push(fillWithBlock);
 
       // If fill is outside block range, we can skip it now since we're not going to add a refund for it.
-      if (fillWithBlock.blockNumber < blockRangeForChain[0])
-        return;
+      if (fillWithBlock.blockNumber < blockRangeForChain[0]) return;
 
       // Now create a copy of fill with block data removed, and use its data to update the fills to refund obj.
       const { blockNumber, transactionIndex, transactionHash, logIndex, ...fill } = fillWithBlock;
@@ -294,10 +293,7 @@ export class BundleDataClient {
         // return fill events that are younger than the bundle end block.
         const fillsForOriginChain = destinationClient
           .getFillsForOriginChain(Number(originChainId))
-          .filter(
-            (fillWithBlock) =>
-              fillWithBlock.blockNumber <= blockRangeForChain[1]
-          );
+          .filter((fillWithBlock) => fillWithBlock.blockNumber <= blockRangeForChain[1]);
         await Promise.all(fillsForOriginChain.map(async (fill) => validateFillAndSaveData(fill, blockRangeForChain)));
       }
     }

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -206,7 +206,7 @@ export class BundleDataClient {
       allValidFills.push(fillWithBlock);
 
       // If fill is outside block range, we can skip it now since we're not going to add a refund for it.
-      if (fillWithBlock.blockNumber < blockRangeForChain[0] || fillWithBlock.blockNumber > blockRangeForChain[1])
+      if (fillWithBlock.blockNumber < blockRangeForChain[0])
         return;
 
       // Now create a copy of fill with block data removed, and use its data to update the fills to refund obj.
@@ -296,7 +296,7 @@ export class BundleDataClient {
           .getFillsForOriginChain(Number(originChainId))
           .filter(
             (fillWithBlock) =>
-              fillWithBlock.blockNumber <= blockRangeForChain[1] && fillWithBlock.blockNumber >= blockRangeForChain[0]
+              fillWithBlock.blockNumber <= blockRangeForChain[1]
           );
         await Promise.all(fillsForOriginChain.map(async (fill) => validateFillAndSaveData(fill, blockRangeForChain)));
       }

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -206,7 +206,8 @@ export class BundleDataClient {
       allValidFills.push(fillWithBlock);
 
       // If fill is outside block range, we can skip it now since we're not going to add a refund for it.
-      if (fillWithBlock.blockNumber < blockRangeForChain[0]) return;
+      if (fillWithBlock.blockNumber < blockRangeForChain[0] || fillWithBlock.blockNumber > blockRangeForChain[1])
+        return;
 
       // Now create a copy of fill with block data removed, and use its data to update the fills to refund obj.
       const { blockNumber, transactionIndex, transactionHash, logIndex, ...fill } = fillWithBlock;
@@ -293,7 +294,10 @@ export class BundleDataClient {
         // return fill events that are younger than the bundle end block.
         const fillsForOriginChain = destinationClient
           .getFillsForOriginChain(Number(originChainId))
-          .filter((fillWithBlock) => fillWithBlock.blockNumber <= blockRangeForChain[1]);
+          .filter(
+            (fillWithBlock) =>
+              fillWithBlock.blockNumber <= blockRangeForChain[1] && fillWithBlock.blockNumber >= blockRangeForChain[0]
+          );
         await Promise.all(fillsForOriginChain.map(async (fill) => validateFillAndSaveData(fill, blockRangeForChain)));
       }
     }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -226,7 +226,7 @@ export class Dataworker {
     else {
       const poolRebalanceLeafExecutionBlocks = executedPoolRebalanceLeaves.map((execution) => execution.blockNumber);
       const mostRecentPoolRebalanceLeafExecutionBlock = Math.max(...poolRebalanceLeafExecutionBlocks);
-      if (mostRecentPoolRebalanceLeafExecutionBlock >= mainnetBundleEndBlock) {
+      if (mostRecentPoolRebalanceLeafExecutionBlock > mainnetBundleEndBlock) {
         return {
           shouldWait: true,
           poolRebalanceLeafExecutionBlocks,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -226,7 +226,7 @@ export class Dataworker {
     else {
       const poolRebalanceLeafExecutionBlocks = executedPoolRebalanceLeaves.map((execution) => execution.blockNumber);
       const mostRecentPoolRebalanceLeafExecutionBlock = Math.max(...poolRebalanceLeafExecutionBlocks);
-      if (mostRecentPoolRebalanceLeafExecutionBlock < mainnetBundleEndBlock) {
+      if (mostRecentPoolRebalanceLeafExecutionBlock >= mainnetBundleEndBlock) {
         return {
           shouldWait: true,
           poolRebalanceLeafExecutionBlocks,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -221,19 +221,6 @@ export class Dataworker {
         mostRecentProposedRootBundle: mostRecentProposedRootBundle.transactionHash,
       };
     }
-    // If all leaves are executed, we should wait if the most recent execution came after the mainnet bundle end
-    // block.
-    else {
-      return {
-        shouldWait:
-          bufferToPropose > 0
-            ? mainnetBundleEndBlock - bufferToPropose < mostRecentProposedRootBundle.blockNumber
-            : false,
-        bufferToPropose,
-        poolRebalanceLeafExecutionBlocks,
-        mainnetBundleEndBlock,
-      };
-    }
   }
 
   async proposeRootBundle(

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -196,6 +196,7 @@ export class Dataworker {
     // If any leaves are unexecuted, we should wait. This can also happen if the most recent proposed root bundle
     // was disputed or is still pending in the challenge period.
     if (expectedPoolRebalanceLeaves !== executedPoolRebalanceLeaves.length) {
+      const poolRebalanceLeafExecutionBlocks = executedPoolRebalanceLeaves.map((execution) => execution.blockNumber);
       return {
         shouldWait: true,
         poolRebalanceLeafExecutionBlocks,
@@ -224,31 +225,15 @@ export class Dataworker {
     // If all leaves are executed, we should wait if the most recent execution came after the mainnet bundle end
     // block.
     else {
-      const poolRebalanceLeafExecutionBlocks = executedPoolRebalanceLeaves.map((execution) => execution.blockNumber);
-      const mostRecentPoolRebalanceLeafExecutionBlock = Math.max(...poolRebalanceLeafExecutionBlocks);
-      if (mostRecentPoolRebalanceLeafExecutionBlock > mainnetBundleEndBlock) {
-        return {
-          shouldWait: true,
-          poolRebalanceLeafExecutionBlocks,
-          mainnetBundleEndBlock,
-          mostRecentProposedRootBundle: mostRecentProposedRootBundle.transactionHash,
-          expectedPoolRebalanceLeaves,
-          executedPoolRebalanceLeaves: executedPoolRebalanceLeaves.length,
-        };
-      }
-      // We should now only wait if the bufferToPropose is larger than the time between the mainnetBundleEndBlock
-      // and the latest proposal block.
-      else {
-        return {
-          shouldWait:
-            bufferToPropose > 0
-              ? mainnetBundleEndBlock - bufferToPropose < mostRecentProposedRootBundle.blockNumber
-              : false,
-          expectedPoolRebalanceLeaves,
-          bufferToPropose,
-          mainnetBundleEndBlock,
-        };
-      }
+      return {
+        shouldWait:
+          bufferToPropose > 0
+            ? mainnetBundleEndBlock - bufferToPropose < mostRecentProposedRootBundle.blockNumber
+            : false,
+        expectedPoolRebalanceLeaves,
+        bufferToPropose,
+        mainnetBundleEndBlock,
+      };
     }
   }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -190,13 +190,12 @@ export class Dataworker {
       mainnetBundleEndBlock
     );
     const expectedPoolRebalanceLeaves = mostRecentProposedRootBundle.poolRebalanceLeafCount;
-    if (expectedPoolRebalanceLeaves === 0) throw new Error("Pool rebalanc leaf count must be > 0");
+    if (expectedPoolRebalanceLeaves === 0) throw new Error("Pool rebalance leaf count must be > 0");
     const poolRebalanceLeafExecutionBlocks = executedPoolRebalanceLeaves.map((execution) => execution.blockNumber);
 
     // If any leaves are unexecuted, we should wait. This can also happen if the most recent proposed root bundle
     // was disputed or is still pending in the challenge period.
     if (expectedPoolRebalanceLeaves !== executedPoolRebalanceLeaves.length) {
-      const poolRebalanceLeafExecutionBlocks = executedPoolRebalanceLeaves.map((execution) => execution.blockNumber);
       return {
         shouldWait: true,
         poolRebalanceLeafExecutionBlocks,
@@ -230,8 +229,8 @@ export class Dataworker {
           bufferToPropose > 0
             ? mainnetBundleEndBlock - bufferToPropose < mostRecentProposedRootBundle.blockNumber
             : false,
-        expectedPoolRebalanceLeaves,
         bufferToPropose,
+        poolRebalanceLeafExecutionBlocks,
         mainnetBundleEndBlock,
       };
     }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -226,7 +226,7 @@ export class Dataworker {
     else {
       const poolRebalanceLeafExecutionBlocks = executedPoolRebalanceLeaves.map((execution) => execution.blockNumber);
       const mostRecentPoolRebalanceLeafExecutionBlock = Math.max(...poolRebalanceLeafExecutionBlocks);
-      if (mostRecentPoolRebalanceLeafExecutionBlock <= mainnetBundleEndBlock) {
+      if (mostRecentPoolRebalanceLeafExecutionBlock < mainnetBundleEndBlock) {
         return {
           shouldWait: true,
           poolRebalanceLeafExecutionBlocks,

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -210,15 +210,17 @@ export async function subtractExcessFromPreviousSlowFillsFromRunningBalances(
         if (rootBundleEndBlockContainingFirstFill === rootBundleEndBlockContainingFullFill) return;
 
         // Recompute how much the matched root bundle sent for this slow fill.
-        const amountSentForSlowFill = getRefund(
-          lastMatchingFillInSameBundle.amount.sub(lastMatchingFillInSameBundle.totalFilledAmount),
-          lastMatchingFillInSameBundle.realizedLpFeePct
+        const preFeeAmountSentForSlowFill = lastMatchingFillInSameBundle.amount.sub(
+          lastMatchingFillInSameBundle.totalFilledAmount
         );
 
         // If this fill is a slow fill, then the excess remaining in the contract is equal to the amount sent originally
         // for this slow fill, and the amount filled. If this fill was not a slow fill, then that means the slow fill
         // was never sent, so we need to send the full slow fill back.
-        const excess = fill.isSlowRelay ? amountSentForSlowFill.sub(fill.fillAmount) : amountSentForSlowFill;
+        const excess = getRefund(
+          fill.isSlowRelay ? preFeeAmountSentForSlowFill.sub(fill.fillAmount) : preFeeAmountSentForSlowFill,
+          fill.realizedLpFeePct
+        );
         if (excess.eq(toBN(0))) return;
 
         // Log excesses for debugging since this logic is so complex.

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -23,6 +23,7 @@ import {
   winston,
   toBNWei,
   formatFeePct,
+  getRefund,
 } from "../utils";
 import { DataworkerClients } from "./DataworkerClientHelper";
 import { getFillDataForSlowFillFromPreviousRootBundle } from "../utils";
@@ -133,7 +134,7 @@ export function addSlowFillsToRunningBalances(
       runningBalances,
       unfilledDeposit.deposit.destinationChainId,
       l1TokenCounterpart,
-      unfilledDeposit.unfilledAmount
+      getRefund(unfilledDeposit.unfilledAmount, unfilledDeposit.deposit.realizedLpFeePct)
     );
   });
 }
@@ -209,8 +210,9 @@ export async function subtractExcessFromPreviousSlowFillsFromRunningBalances(
         if (rootBundleEndBlockContainingFirstFill === rootBundleEndBlockContainingFullFill) return;
 
         // Recompute how much the matched root bundle sent for this slow fill.
-        const amountSentForSlowFill = lastMatchingFillInSameBundle.amount.sub(
-          lastMatchingFillInSameBundle.totalFilledAmount
+        const amountSentForSlowFill = getRefund(
+          lastMatchingFillInSameBundle.amount.sub(lastMatchingFillInSameBundle.totalFilledAmount),
+          lastMatchingFillInSameBundle.realizedLpFeePct
         );
 
         // If this fill is a slow fill, then the excess remaining in the contract is equal to the amount sent originally

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -23,7 +23,6 @@ import {
   winston,
   toBNWei,
   formatFeePct,
-  getRefund,
 } from "../utils";
 import { DataworkerClients } from "./DataworkerClientHelper";
 import { getFillDataForSlowFillFromPreviousRootBundle } from "../utils";
@@ -134,7 +133,7 @@ export function addSlowFillsToRunningBalances(
       runningBalances,
       unfilledDeposit.deposit.destinationChainId,
       l1TokenCounterpart,
-      getRefund(unfilledDeposit.unfilledAmount, unfilledDeposit.deposit.realizedLpFeePct)
+      unfilledDeposit.unfilledAmount
     );
   });
 }
@@ -210,9 +209,8 @@ export async function subtractExcessFromPreviousSlowFillsFromRunningBalances(
         if (rootBundleEndBlockContainingFirstFill === rootBundleEndBlockContainingFullFill) return;
 
         // Recompute how much the matched root bundle sent for this slow fill.
-        const amountSentForSlowFill = getRefund(
-          lastMatchingFillInSameBundle.amount.sub(lastMatchingFillInSameBundle.totalFilledAmount),
-          lastMatchingFillInSameBundle.realizedLpFeePct
+        const amountSentForSlowFill = lastMatchingFillInSameBundle.amount.sub(
+          lastMatchingFillInSameBundle.totalFilledAmount
         );
 
         // If this fill is a slow fill, then the excess remaining in the contract is equal to the amount sent originally

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -209,52 +209,54 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
                 }
               }
             }
+          }
 
-            // Make sure that previous root bundle's netSendAmount has been deposited into the spoke pool. We only
-            // perform this check for chains 10, 137, 288, and 42161 because transfers from the hub pool to spoke
-            // pools on those chains can take a variable amount of time, unlike transfers to the spoke pool on
-            // mainnet. Additionally, deposits to those chains emit transfer events where the from address
-            // is the zero address, making it easy to track.
-            if ([10, 137, 288, 42161].includes(leaf.chainId)) {
-              const _followingBlockNumber =
-                clients.hubPoolClient.getFollowingRootBundle(previousValidatedBundle)?.blockNumber ||
-                clients.hubPoolClient.latestBlockNumber;
-              const previousBundlePoolRebalanceLeaves = clients.hubPoolClient.getExecutedLeavesForRootBundle(
-                previousValidatedBundle,
-                _followingBlockNumber
-              );
-              const previousBundleEndBlockForChain =
-                previousValidatedBundle.bundleEvaluationBlockNumbers[
-                  dataworker.chainIdListForBundleEvaluationBlockNumbers.indexOf(leaf.chainId)
-                ];
-              const previousPoolRebalanceLeaf = previousBundlePoolRebalanceLeaves.find(
-                (_leaf) => _leaf.chainId === leaf.chainId && _leaf.l1Tokens.includes(l1Token)
-              );
-              if (previousPoolRebalanceLeaf) {
-                const previousNetSendAmount =
-                  previousPoolRebalanceLeaf.netSendAmounts[previousPoolRebalanceLeaf.l1Tokens.indexOf(l1Token)];
-                console.log(`- previous net send amount: ${fromWei(previousNetSendAmount.toString(), decimals)}`);
-                if (previousNetSendAmount.gt(toBN(0))) {
-                  const depositsToSpokePool = (
-                    await paginatedEventQuery(
-                      l2TokenContract,
-                      l2TokenContract.filters.Transfer(ZERO_ADDRESS, spokePools[leaf.chainId].address),
-                      {
-                        fromBlock: previousBundleEndBlockForChain.toNumber(),
-                        toBlock: bundleEndBlockForChain.toNumber(),
-                        maxBlockLookBack: config.maxBlockLookBack[leaf.chainId],
-                      }
-                    )
-                  ).filter((e) => e.args.value.eq(previousNetSendAmount));
-                  if (depositsToSpokePool.length === 0) {
-                    console.log(
-                      `    - adding previous leaf's netSendAmount (${fromWei(
-                        previousNetSendAmount.toString(),
-                        decimals
-                      )}) to token balance because it did not arrive at spoke pool before bundle end block.`
-                    );
-                    tokenBalanceAtBundleEndBlock = tokenBalanceAtBundleEndBlock.add(previousNetSendAmount);
-                  }
+          // Make sure that previous root bundle's netSendAmount has been deposited into the spoke pool. We only
+          // perform this check for chains 10, 137, 288, and 42161 because transfers from the hub pool to spoke
+          // pools on those chains can take a variable amount of time, unlike transfers to the spoke pool on
+          // mainnet. Additionally, deposits to those chains emit transfer events where the from address
+          // is the zero address, making it easy to track.
+          if ([10, 137, 288, 42161].includes(leaf.chainId)) {
+            const _followingBlockNumber =
+              clients.hubPoolClient.getFollowingRootBundle(previousValidatedBundle)?.blockNumber ||
+              clients.hubPoolClient.latestBlockNumber;
+            const previousBundlePoolRebalanceLeaves = clients.hubPoolClient.getExecutedLeavesForRootBundle(
+              previousValidatedBundle,
+              _followingBlockNumber
+            );
+            const previousBundleEndBlockForChain =
+              previousValidatedBundle.bundleEvaluationBlockNumbers[
+                dataworker.chainIdListForBundleEvaluationBlockNumbers.indexOf(leaf.chainId)
+              ];
+            const previousPoolRebalanceLeaf = previousBundlePoolRebalanceLeaves.find(
+              (_leaf) => _leaf.chainId === leaf.chainId && _leaf.l1Tokens.includes(l1Token)
+            );
+            if (previousPoolRebalanceLeaf) {
+              const previousNetSendAmount =
+                previousPoolRebalanceLeaf.netSendAmounts[previousPoolRebalanceLeaf.l1Tokens.indexOf(l1Token)];
+              console.log(`- previous net send amount: ${fromWei(previousNetSendAmount.toString(), decimals)}`);
+              if (previousNetSendAmount.gt(toBN(0))) {
+                // This part might fail if the token is ETH since deposits of ETH do not emit Transfer events, so
+                // in these cases the `tokenBalanceAtBundleEndBlock` might look artificially higher for this bundle.
+                const depositsToSpokePool = (
+                  await paginatedEventQuery(
+                    l2TokenContract,
+                    l2TokenContract.filters.Transfer(ZERO_ADDRESS, spokePools[leaf.chainId].address),
+                    {
+                      fromBlock: previousBundleEndBlockForChain.toNumber(),
+                      toBlock: bundleEndBlockForChain.toNumber(),
+                      maxBlockLookBack: config.maxBlockLookBack[leaf.chainId],
+                    }
+                  )
+                ).filter((e) => e.args.value.eq(previousNetSendAmount));
+                if (depositsToSpokePool.length === 0) {
+                  console.log(
+                    `    - adding previous leaf's netSendAmount (${fromWei(
+                      previousNetSendAmount.toString(),
+                      decimals
+                    )}) to token balance because it did not arrive at spoke pool before bundle end block.`
+                  );
+                  tokenBalanceAtBundleEndBlock = tokenBalanceAtBundleEndBlock.add(previousNetSendAmount);
                 }
               }
             }

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -340,6 +340,12 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
           mostRecentValidatedBundle.relayerRefundRoot
         );
 
+        // NOTE: There are several ways in which excess can be incorrect:
+        // - A relayer refund leaf from a bundle more than 2 bundles ago has not been executed.
+        // - A slow fill from a bundle more than 2 bundles ago has not been executed and has not been replaced
+        // by a partial fill.
+        // - A deposit from HubPool to Spoke took too long to arrive and those deposits are not trackable via
+        // Transfer events where the sender is 0x0.
         let excess = toBN(tokenBalanceAtBundleEndBlock).add(netSendAmount).add(runningBalance);
 
         if (relayedRoot === undefined || relayedRoot[l2Token] === undefined) {

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -209,6 +209,55 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
                 }
               }
             }
+
+            // Make sure that previous root bundle's netSendAmount has been deposited into the spoke pool. We only
+            // perform this check for chains 10, 137, 288, and 42161 because transfers from the hub pool to spoke
+            // pools on those chains can take a variable amount of time, unlike transfers to the spoke pool on
+            // mainnet. Additionally, deposits to those chains emit transfer events where the from address
+            // is the zero address, making it easy to track.
+            if ([10, 137, 288, 42161].includes(leaf.chainId)) {
+              const _followingBlockNumber =
+                clients.hubPoolClient.getFollowingRootBundle(previousValidatedBundle)?.blockNumber ||
+                clients.hubPoolClient.latestBlockNumber;
+              const previousBundlePoolRebalanceLeaves = clients.hubPoolClient.getExecutedLeavesForRootBundle(
+                previousValidatedBundle,
+                _followingBlockNumber
+              );
+              const previousBundleEndBlockForChain =
+                previousValidatedBundle.bundleEvaluationBlockNumbers[
+                  dataworker.chainIdListForBundleEvaluationBlockNumbers.indexOf(leaf.chainId)
+                ];
+              const previousPoolRebalanceLeaf = previousBundlePoolRebalanceLeaves.find(
+                (_leaf) => _leaf.chainId === leaf.chainId && _leaf.l1Tokens.includes(l1Token)
+              );
+              if (previousPoolRebalanceLeaf) {
+                const previousNetSendAmount =
+                  previousPoolRebalanceLeaf.netSendAmounts[previousPoolRebalanceLeaf.l1Tokens.indexOf(l1Token)];
+                console.log(`- previous net send amount: ${fromWei(previousNetSendAmount.toString(), decimals)}`);
+                if (previousNetSendAmount.gt(toBN(0))) {
+                  const depositsToSpokePool = (
+                    await paginatedEventQuery(
+                      l2TokenContract,
+                      l2TokenContract.filters.Transfer(ZERO_ADDRESS, spokePools[leaf.chainId].address),
+                      {
+                        fromBlock: previousBundleEndBlockForChain.toNumber(),
+                        toBlock: bundleEndBlockForChain.toNumber(),
+                        maxBlockLookBack: config.maxBlockLookBack[leaf.chainId],
+                      }
+                    )
+                  ).filter((e) => e.args.value.eq(previousNetSendAmount));
+                  if (depositsToSpokePool.length === 0) {
+                    console.log(
+                      `    - adding previous leaf's netSendAmount (${fromWei(
+                        previousNetSendAmount.toString(),
+                        decimals
+                      )}) to token balance because it did not arrive at spoke pool before bundle end block.`
+                    );
+                    tokenBalanceAtBundleEndBlock = tokenBalanceAtBundleEndBlock.add(previousNetSendAmount);
+                  }
+                }
+              }
+            }
           }
 
           // Check if previous bundle has any slow fills that haven't executed by the time of the bundle end block.

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -35,7 +35,6 @@ let depositor: SignerWithAddress, relayer: SignerWithAddress, dataworker: Signer
 
 let hubPoolClient: HubPoolClient, configStoreClient: AcrossConfigStoreClient;
 let dataworkerInstance: Dataworker;
-let spy: sinon.SinonSpy;
 let spokePoolClients: { [chainId: number]: SpokePoolClient };
 
 let spy: sinon.SinonSpy;
@@ -58,7 +57,6 @@ describe("Dataworker: Build merkle roots", async function () {
       relayer,
       dataworkerInstance,
       dataworker,
-      spy,
       timer,
       spokePoolClients,
       spy,

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -35,6 +35,7 @@ let depositor: SignerWithAddress, relayer: SignerWithAddress, dataworker: Signer
 
 let hubPoolClient: HubPoolClient, configStoreClient: AcrossConfigStoreClient;
 let dataworkerInstance: Dataworker;
+let spy: sinon.SinonSpy;
 let spokePoolClients: { [chainId: number]: SpokePoolClient };
 
 let spy: sinon.SinonSpy;
@@ -57,6 +58,7 @@ describe("Dataworker: Build merkle roots", async function () {
       relayer,
       dataworkerInstance,
       dataworker,
+      spy,
       timer,
       spokePoolClients,
       spy,

--- a/test/Dataworker.proposeRootBundle.ts
+++ b/test/Dataworker.proposeRootBundle.ts
@@ -1,6 +1,6 @@
 import { buildFillForRepaymentChain, lastSpyLogIncludes, lastSpyLogLevel } from "./utils";
 import { SignerWithAddress, expect, ethers, Contract, buildDeposit, toBNWei } from "./utils";
-import { HubPoolClient, AcrossConfigStoreClient, SpokePoolClient, MultiCallerClient } from "../src/clients";
+import { HubPoolClient, SpokePoolClient, MultiCallerClient } from "../src/clients";
 import { amountToDeposit, destinationChainId, originChainId, utf8ToHex } from "./constants";
 import { CHAIN_ID_TEST_LIST } from "./constants";
 import { setupFastDataworker } from "./fixtures/Dataworker.Fixture";


### PR DESCRIPTION
When a slow fill is executed, its `unfilledAmount` is sent to the `recipient` minus any fees where `relayerFeePct == 0` and `lpFeePct >= 0`. Therefore, this fixes an issue where every slow fill executed is leaving the `lpFee` in the SpokePool.

I discovered this bug while running the `validateRunningBundle` script and noticed that the `excess` amount increases after slow fill. This is corroborated by looking at spoke pool balances over time, for example the BAL balance of the EtheruemSpokePool which recently had some slow fills: https://etherscan.io/token/0xba100000625a3754423978a60c9317c58a424e3d?a=0x4d9079bb4165aeb4084c526a32695dcfd2f77381#tokenAnalytics