### PR TITLE
improve: Log quorum result data

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -342,6 +342,7 @@ class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
         message: "Some providers mismatched with the quorum result or failed 🚸",
         method,
         params,
+        quorumResult,
         quorumProviders,
         mismatchedProviders,
         erroringProviders: errors.map(([provider, errorText]) => formatProviderError(provider, errorText)),


### PR DESCRIPTION
Currently we log only mismatched provider data but we should log the expected quorum result