### PR TITLE
feat: Delete IGNORED_BUNDLES constant

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -104,16 +104,6 @@ export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } =
   10: 75,
 };
 
-// Maps chain ID to root bundle ID to ignore because the roots are known to be invalid from the perspective of the
-// latest dataworker code, or there is no matching L1 root bundle, because the root bundle was relayed by an admin.
-export const IGNORED_SPOKE_BUNDLES = {
-  1: [1467, 357, 322, 321, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
-  10: [1467, 105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
-  137: [1466, 105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
-  288: [859, 96, 93, 90, 85, 78, 72, 68, 67, 65, 2],
-  42161: [1468, 105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
-};
-
 // List of proposal block numbers to ignore. This should be ignored because they are administrative bundle proposals
 // with useless bundle block eval numbers and other data that isn't helpful for the dataworker to know. This does not
 // include any invalid bundles that got through, such as at blocks 15001113 or 15049343 which are missing

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -107,11 +107,11 @@ export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } =
 // Maps chain ID to root bundle ID to ignore because the roots are known to be invalid from the perspective of the
 // latest dataworker code, or there is no matching L1 root bundle, because the root bundle was relayed by an admin.
 export const IGNORED_SPOKE_BUNDLES = {
-  1: [357, 322, 321, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
-  10: [105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
-  137: [105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
-  288: [96, 93, 90, 85, 78, 72, 68, 67, 65, 2],
-  42161: [105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
+  1: [1467, 357, 322, 321, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
+  10: [1467, 105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
+  137: [1466, 105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
+  288: [859, 96, 93, 90, 85, 78, 72, 68, 67, 65, 2],
+  42161: [1468, 105, 104, 101, 96, 89, 83, 79, 78, 75, 74, 23, 2],
 };
 
 // List of proposal block numbers to ignore. This should be ignored because they are administrative bundle proposals

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -41,7 +41,7 @@ import {
 } from "./DataworkerUtils";
 import { BalanceAllocator } from "../clients";
 import _ from "lodash";
-import { CONFIG_STORE_VERSION, IGNORED_SPOKE_BUNDLES } from "../common";
+import { CONFIG_STORE_VERSION } from "../common";
 import { isOvmChain, ovmWethTokens } from "../clients/bridges";
 
 // Internal error reasons for labeling a pending root bundle as "invalid" that we don't want to submit a dispute
@@ -826,10 +826,8 @@ export class Dataworker {
     await Promise.all(
       Object.entries(spokePoolClients).map(async ([_chainId, client]) => {
         const chainId = Number(_chainId);
-        let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter((rootBundle) =>
-          isKeyOf(chainId, IGNORED_SPOKE_BUNDLES)
-            ? !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
-            : rootBundle.blockNumber >= client.eventSearchConfig.fromBlock
+        let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter(
+          (rootBundle) => rootBundle.blockNumber >= client.eventSearchConfig.fromBlock
         );
 
         // Filter out roots that are not in the latest N root bundles. This assumes that
@@ -1270,10 +1268,8 @@ export class Dataworker {
     // each chain in parallel, then we'd have to reconstruct identical pool rebalance root more times than necessary.
     for (const [_chainId, client] of Object.entries(spokePoolClients)) {
       const chainId = Number(_chainId);
-      let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter((rootBundle) =>
-        isKeyOf(chainId, IGNORED_SPOKE_BUNDLES)
-          ? !IGNORED_SPOKE_BUNDLES[chainId].includes(rootBundle.rootBundleId)
-          : rootBundle.blockNumber >= client.eventSearchConfig.fromBlock
+      let rootBundleRelays = sortEventsDescending(client.getRootBundleRelays()).filter(
+        (rootBundle) => rootBundle.blockNumber >= client.eventSearchConfig.fromBlock
       );
 
       // Filter out roots that are not in the latest N root bundles. This assumes that


### PR DESCRIPTION
We don't need this anymore as we only try to execute leaves from bundles that are linked to a validated root bundle proposal (sent on Mainnet). So if an admin bundle was relayed directly to the Spoke the executor will never try to execute it.

This constant was a part of legacy code in the executor that looked up root bundle ID's in descending order and tried to execute them, regardless of their relationship to a mainnet root bundle proposal