### PR TITLE
improve: Get spoke pool addresses and deployment blocks using on-chain events

### DIFF
--- a/scripts/disableDepositRoutes.ts
+++ b/scripts/disableDepositRoutes.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-process-exit */
-import { getSigner, winston, Logger, runTransaction } from "../src/utils";
+import { getSigner, winston, Logger } from "../src/utils";
 import {
   CHAIN_ID_LIST_INDICES,
   CommonConfig,
@@ -7,7 +7,6 @@ import {
   constructSpokePoolClientsWithStartBlocks,
   updateClients,
 } from "../src/common";
-import { PopulatedTransaction } from "ethers";
 const args = require("minimist")(process.argv.slice(2), {
   number: ["chainId"],
 });

--- a/scripts/sendTokens.ts
+++ b/scripts/sendTokens.ts
@@ -21,7 +21,7 @@ export async function run(): Promise<void> {
   if (!Object.keys(args).includes("to")) throw new Error("Define `to` as where you want to send funds to");
   if (!Object.keys(args).includes("chainId")) throw new Error("Define `chainId` as the chain you want to connect on");
   const baseSigner = await getSigner();
-  const connectedSigner = baseSigner.connect(getProvider(Number(args.chainId)));
+  const connectedSigner = baseSigner.connect(await getProvider(Number(args.chainId)));
   console.log("Connected to account", connectedSigner.address);
   const recipient = args.to;
   const token = args.token;

--- a/scripts/unwrapWeth.ts
+++ b/scripts/unwrapWeth.ts
@@ -27,7 +27,7 @@ export async function run(): Promise<void> {
   if (!Object.keys(args).includes("chainId")) throw new Error("Define `chainId` as the chain you want to connect on");
   if (!Object.keys(args).includes("amount")) throw new Error("Define `amount` as how much you want to unwrap");
   const baseSigner = await getSigner();
-  const connectedSigner = baseSigner.connect(getProvider(Number(args.chainId)));
+  const connectedSigner = baseSigner.connect(await getProvider(Number(args.chainId)));
   const token = WETH_ADDRESSES[Number(args.chainId)];
   const weth = new ethers.Contract(token, WETH9.abi, connectedSigner);
   const decimals = 18;

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -387,7 +387,8 @@ export class AcrossConfigStoreClient {
       this.hubPoolClient.chainId,
       timestamp,
       getCurrentTime(),
-      this.redisClient
+      this.redisClient,
+      this.blockFinder
     );
   }
 

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -387,8 +387,7 @@ export class AcrossConfigStoreClient {
       this.hubPoolClient.chainId,
       timestamp,
       getCurrentTime(),
-      this.redisClient,
-      this.blockFinder
+      this.redisClient
     );
   }
 

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -387,7 +387,6 @@ export class AcrossConfigStoreClient {
       this.hubPoolClient.chainId,
       timestamp,
       getCurrentTime(),
-      this.redisClient,
       this.blockFinder
     );
   }

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -387,8 +387,8 @@ export class AcrossConfigStoreClient {
       this.hubPoolClient.chainId,
       timestamp,
       getCurrentTime(),
-      this.blockFinder,
-      this.redisClient
+      this.redisClient,
+      this.blockFinder
     );
   }
 

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -64,7 +64,7 @@ export class HubPoolClient {
     return this.disputedRootBundles;
   }
 
-  getSpokePoolForBlock(block: number, chain: number): string {
+  getSpokePoolForBlock(chain: number, block: number = Number.MAX_SAFE_INTEGER): string {
     if (!this.crossChainContracts[chain]) throw new Error(`No cross chain contracts set for ${chain}`);
     const mostRecentSpokePoolUpdateBeforeBlock = (
       sortEventsDescending(this.crossChainContracts[chain]) as CrossChainContractsSet[]

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -9,7 +9,7 @@ import {
   MakeOptional,
 } from "../utils";
 import { sortEventsDescending, spreadEvent, spreadEventWithBlockNumber, paginatedEventQuery, toBN } from "../utils";
-import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES } from "../common";
+import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES, DISABLED_CHAINS } from "../common";
 import { Deposit, L1Token, CancelledRootBundle, DisputedRootBundle, LpToken } from "../interfaces";
 import { ExecutedRootBundle, PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { CrossChainContractsSet, DestinationTokenWithBlock, SetPoolRebalanceRoot } from "../interfaces";

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -9,7 +9,7 @@ import {
   MakeOptional,
 } from "../utils";
 import { sortEventsDescending, spreadEvent, spreadEventWithBlockNumber, paginatedEventQuery, toBN } from "../utils";
-import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES, DISABLED_CHAINS } from "../common";
+import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES } from "../common";
 import { Deposit, L1Token, CancelledRootBundle, DisputedRootBundle, LpToken } from "../interfaces";
 import { ExecutedRootBundle, PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { CrossChainContractsSet, DestinationTokenWithBlock, SetPoolRebalanceRoot } from "../interfaces";

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -66,12 +66,21 @@ export class HubPoolClient {
 
   getSpokePoolForBlock(block: number, chain: number): string {
     if (!this.crossChainContracts[chain]) throw new Error(`No cross chain contracts set for ${chain}`);
-    const mostRecentSpokePoolUpdatebeforeBlock = (
+    const mostRecentSpokePoolUpdateBeforeBlock = (
       sortEventsDescending(this.crossChainContracts[chain]) as CrossChainContractsSet[]
     ).find((crossChainContract) => crossChainContract.blockNumber <= block);
-    if (!mostRecentSpokePoolUpdatebeforeBlock)
+    if (!mostRecentSpokePoolUpdateBeforeBlock)
       throw new Error(`No cross chain contract found before block ${block} for chain ${chain}`);
-    else return mostRecentSpokePoolUpdatebeforeBlock.spokePool;
+    else return mostRecentSpokePoolUpdateBeforeBlock.spokePool;
+  }
+
+  getSpokePoolActivationBlock(chain: number, spokePool: string): number {
+    // Return first time that this spoke pool was registered in the HubPool as a cross chain contract. We can use
+    // this block as the oldest block that we should query for SpokePoolClient purposes.
+    const mostRecentSpokePoolUpdateBeforeBlock = this.crossChainContracts[chain].find(
+      (crossChainContract) => crossChainContract.spokePool === spokePool
+    );
+    return mostRecentSpokePoolUpdateBeforeBlock?.blockNumber;
   }
 
   getDestinationTokenForDeposit(deposit: { originChainId: number; originToken: string; destinationChainId: number }) {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -17,6 +17,7 @@ import {
   sortEventsAscending,
   filledSameDeposit,
   getCurrentTime,
+  getRedis,
 } from "../utils";
 import { toBN, ZERO_ADDRESS, winston, paginatedEventQuery, spreadEventWithBlockNumber } from "../utils";
 
@@ -290,8 +291,9 @@ export class SpokePoolClient {
       return this.getDepositForFill(fill);
 
     let deposit: DepositWithBlock, cachedDeposit: Deposit | undefined;
-    if (this.configStoreClient.redisClient) {
-      cachedDeposit = await getDeposit(getRedisDepositKey(fill), this.configStoreClient.redisClient);
+    const redisClient = await getRedis(this.logger);
+    if (redisClient) {
+      cachedDeposit = await getDeposit(getRedisDepositKey(fill), redisClient);
     }
     if (cachedDeposit) {
       deposit = cachedDeposit as DepositWithBlock;
@@ -345,8 +347,7 @@ export class SpokePoolClient {
         message: "Queried RPC for deposit outside SpokePoolClient's search range",
         deposit,
       });
-      if (this.configStoreClient.redisClient)
-        await setDeposit(deposit, getCurrentTime(), this.configStoreClient.redisClient, 24 * 60 * 60);
+      if (redisClient) await setDeposit(deposit, getCurrentTime(), redisClient, 24 * 60 * 60);
     }
 
     const { blockNumber, ...fillCopy } = fill as FillWithBlock; // Ignore blockNumber when validating the fill

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -9,7 +9,6 @@ import {
   sortEventsAscendingInPlace,
   DefaultLogLevels,
   MakeOptional,
-  getDeploymentBlockNumber,
   getDeposit,
   setDeposit,
   getNetworkName,
@@ -69,13 +68,9 @@ export class SpokePoolClient {
     // Can be excluded. This disables some deposit validation.
     readonly configStoreClient: AcrossConfigStoreClient | null,
     readonly chainId: number,
-    readonly eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 },
-    public spokePoolDeploymentBlock?: number
+    public spokePoolDeploymentBlock: number,
+    readonly eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 }
   ) {
-    this.spokePoolDeploymentBlock =
-      spokePoolDeploymentBlock === undefined
-        ? getDeploymentBlockNumber("SpokePool", chainId)
-        : spokePoolDeploymentBlock;
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
   }
 

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -8,7 +8,6 @@ import {
   ethers,
   getBlockForTimestamp,
   getCurrentTime,
-  getRedis,
   SpokePool,
 } from "../utils";
 import { HubPoolClient, MultiCallerClient, AcrossConfigStoreClient, SpokePoolClient } from "../clients";

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -162,9 +162,9 @@ export async function constructSpokePoolClientsWithStartBlocks(
   const spokePoolSigners = await getSpokePoolSigners(baseSigner, enabledChains, config.redisUrl);
   const spokePools = await Promise.all(
     enabledChains.map(async (chainId) => {
-      // Assume that spoke pool hasn't changed since the start block for Mainnet. We might need to change this
-      // if we want to run any bots covering events on multiple spoke pools.
-      const latestSpokePool = configStoreClient.hubPoolClient.getSpokePoolForBlock(startBlocks[1], chainId);
+      // Grab latest spoke pool as of `toBlockOverride[1]`. If `toBlockOverride[1]` is undefined, then grabs current
+      // spoke pool.
+      const latestSpokePool = configStoreClient.hubPoolClient.getSpokePoolForBlock(chainId, toBlockOverride[1]);
       const spokePoolContract = new Contract(latestSpokePool, SpokePool.abi, spokePoolSigners[chainId]);
       const spokePoolRegistrationBlock = configStoreClient.hubPoolClient.getSpokePoolActivationBlock(
         chainId,

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -13,7 +13,6 @@ export class CommonConfig {
   readonly maxTxWait: number;
   readonly spokePoolChainsOverride: number[];
   readonly sendingTransactionsEnabled: boolean;
-  readonly redisUrl: string | undefined;
   readonly bundleRefundLookback: number;
   readonly maxRelayerLookBack: number;
   readonly multiCallChunkSize: { [chainId: number]: number };
@@ -29,7 +28,6 @@ export class CommonConfig {
       MAX_BLOCK_LOOK_BACK,
       MAX_TX_WAIT_DURATION,
       SEND_TRANSACTIONS,
-      REDIS_URL,
       BUNDLE_REFUND_LOOKBACK,
       SPOKE_POOL_CHAINS_OVERRIDE,
       ACROSS_BOT_VERSION,
@@ -58,7 +56,6 @@ export class CommonConfig {
     else this.maxBlockLookBack = Constants.CHAIN_MAX_BLOCK_LOOKBACK;
     this.maxTxWait = Number(MAX_TX_WAIT_DURATION ?? 180); // 3 minutes
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
-    this.redisUrl = REDIS_URL;
     this.bundleRefundLookback = Number(BUNDLE_REFUND_LOOKBACK ?? 2);
 
     // Multicall chunk size precedence: Environment, chain-specific config, global default.

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -15,6 +15,8 @@ export const DEFAULT_CONFIG_STORE_VERSION = 0;
 // of this list, so this list is simply the list of all possible Chain ID's that Across could support.
 export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];
 
+export const DISABLED_CHAINS = [288];
+
 export const RELAYER_MIN_FEE_PCT = 0.0003;
 
 // Target ~4 hours

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -79,6 +79,8 @@ export const MIN_DEPOSIT_CONFIRMATIONS: { [threshold: number | string]: { [chain
 };
 export const QUOTE_TIME_BUFFER = 12 * 5; // 5 blocks on Mainnet.
 
+export const REDIS_URL_DEFAULT = "redis://localhost:6379";
+
 // Quicknode is the bottleneck here and imposes a 10k block limit on an event search.
 // Alchemy-Polygon imposes a 3500 block limit.
 // Note: a 0 value here leads to an infinite lookback, which would be useful and reduce RPC requests

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -15,8 +15,6 @@ export const DEFAULT_CONFIG_STORE_VERSION = 0;
 // of this list, so this list is simply the list of all possible Chain ID's that Across could support.
 export const CHAIN_ID_LIST_INDICES = [1, 10, 137, 288, 42161];
 
-export const DISABLED_CHAINS = [288];
-
 export const RELAYER_MIN_FEE_PCT = 0.0003;
 
 // Target ~4 hours

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -30,6 +30,7 @@ export class DataworkerConfig extends CommonConfig {
   readonly dataworkerFastStartBundle: number | string;
 
   readonly bufferToPropose: number;
+  readonly disabledChainsOverride: number[];
 
   constructor(env: ProcessEnv) {
     const {
@@ -49,9 +50,11 @@ export class DataworkerConfig extends CommonConfig {
       BUFFER_TO_PROPOSE,
       DATAWORKER_FAST_LOOKBACK_COUNT,
       DATAWORKER_FAST_START_BUNDLE,
+      DISABLED_CHAINS_OVERRIDE,
     } = env;
     super(env);
 
+    this.disabledChainsOverride = DISABLED_CHAINS_OVERRIDE ? JSON.parse(DISABLED_CHAINS_OVERRIDE) : [];
     this.bufferToPropose = BUFFER_TO_PROPOSE ? Number(BUFFER_TO_PROPOSE) : (20 * 60) / 15; // 20 mins of blocks;
     // Should we assert that the leaf count caps are > 0?
     this.maxPoolRebalanceLeafSizeOverride = MAX_POOL_REBALANCE_LEAF_SIZE_OVERRIDE

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -30,7 +30,6 @@ export class DataworkerConfig extends CommonConfig {
   readonly dataworkerFastStartBundle: number | string;
 
   readonly bufferToPropose: number;
-  readonly disabledChainsOverride: number[];
 
   constructor(env: ProcessEnv) {
     const {
@@ -50,11 +49,9 @@ export class DataworkerConfig extends CommonConfig {
       BUFFER_TO_PROPOSE,
       DATAWORKER_FAST_LOOKBACK_COUNT,
       DATAWORKER_FAST_START_BUNDLE,
-      DISABLED_CHAINS_OVERRIDE,
     } = env;
     super(env);
 
-    this.disabledChainsOverride = DISABLED_CHAINS_OVERRIDE ? JSON.parse(DISABLED_CHAINS_OVERRIDE) : [];
     this.bufferToPropose = BUFFER_TO_PROPOSE ? Number(BUFFER_TO_PROPOSE) : (20 * 60) / 15; // 20 mins of blocks;
     // Should we assert that the leaf count caps are > 0?
     this.maxPoolRebalanceLeafSizeOverride = MAX_POOL_REBALANCE_LEAF_SIZE_OVERRIDE

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -39,6 +39,12 @@ export function getEndBlockBuffers(
   return chainIdListForBundleEvaluationBlockNumbers.map((chainId: number) => blockRangeEndBlockBuffer[chainId] ?? 0);
 }
 
+export function filterDisabledChains(disabledChains: number[]): number[] {
+  // If any chain ID's are not integers then ignore. UMIP-157 requires that this key cannot include
+  // the chain ID 1.
+  return disabledChains.filter((chainId: number) => !isNaN(chainId) && Number.isInteger(chainId) && chainId !== 1);
+}
+
 export function getBlockRangeForChain(
   blockRange: number[][],
   chain: number,

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -39,12 +39,6 @@ export function getEndBlockBuffers(
   return chainIdListForBundleEvaluationBlockNumbers.map((chainId: number) => blockRangeEndBlockBuffer[chainId] ?? 0);
 }
 
-export function filterDisabledChains(disabledChains: number[]): number[] {
-  // If any chain ID's are not integers then ignore. UMIP-157 requires that this key cannot include
-  // the chain ID 1.
-  return disabledChains.filter((chainId: number) => !isNaN(chainId) && Number.isInteger(chainId) && chainId !== 1);
-}
-
 export function getBlockRangeForChain(
   blockRange: number[][],
   chain: number,

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -39,9 +39,8 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
   logger = _logger;
 
   const { clients, config, dataworker } = await createDataworker(logger, baseSigner);
-  logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });
-
   try {
+    logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });
     for (;;) {
       const loopStart = Date.now();
       await updateDataworkerClients(clients);

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -1,4 +1,4 @@
-import { processEndPollingLoop, winston, config, startupLogLevel, Wallet } from "../utils";
+import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, getRedis } from "../utils";
 import { spokePoolClientsToProviders } from "../common";
 import * as Constants from "../common";
 import { Dataworker } from "./Dataworker";
@@ -133,10 +133,11 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       if (await processEndPollingLoop(logger, "Dataworker", config.pollingDelay)) break;
     }
   } catch (error) {
-    if (clients.configStoreClient.redisClient !== undefined) {
+    const redisClient = await getRedis(logger);
+    if (redisClient !== undefined) {
       // todo understand why redisClient isn't GCed automagically.
       logger.debug("Disconnecting from redis server.");
-      clients.configStoreClient.redisClient.disconnect();
+      redisClient.disconnect();
     }
 
     throw error;

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -45,6 +45,16 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
     for (;;) {
       const loopStart = Date.now();
       await updateDataworkerClients(clients);
+      const disabledChains = [288]//clients.configStoreClient.getDisabledChainsForTimestamp()
+      const configWithDisabledChains = {
+        ...config,
+        spokePoolChains: config.spokePoolChains.filter((chainId) => !disabledChains.includes(chainId)),
+      };
+      logger.debug({
+        at: "Dataworker#index",
+        message: "Disabled chains listed in config store",
+        disabledChains 
+      })
 
       // Determine the spoke client's lookback:
       // 1. We initiate the spoke client event search windows based on a start bundle's bundle block end numbers and
@@ -64,7 +74,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
 
       // Get block range for spoke clients using the dataworker fast lookback bundle count.
       const { fromBundle, toBundle, fromBlocks, toBlocks } = getSpokePoolClientEventSearchConfigsForFastDataworker(
-        config,
+        configWithDisabledChains,
         clients,
         dataworker
       );
@@ -82,7 +92,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       const spokePoolClients = await constructSpokePoolClientsForFastDataworker(
         logger,
         clients.configStoreClient,
-        config,
+        configWithDisabledChains,
         baseSigner,
         fromBlocks,
         toBlocks

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -1,4 +1,12 @@
-import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, getRedis } from "../utils";
+import {
+  processEndPollingLoop,
+  winston,
+  config,
+  startupLogLevel,
+  Wallet,
+  getRedis,
+  disconnectRedisClient,
+} from "../utils";
 import { spokePoolClientsToProviders } from "../common";
 import * as Constants from "../common";
 import { Dataworker } from "./Dataworker";
@@ -133,13 +141,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       if (await processEndPollingLoop(logger, "Dataworker", config.pollingDelay)) break;
     }
   } catch (error) {
-    const redisClient = await getRedis(logger);
-    if (redisClient !== undefined) {
-      // todo understand why redisClient isn't GCed automagically.
-      logger.debug("Disconnecting from redis server.");
-      redisClient.disconnect();
-    }
-
+    await disconnectRedisClient(logger);
     throw error;
   }
 }

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -37,10 +37,10 @@ export async function createDataworker(_logger: winston.Logger, baseSigner: Wall
 }
 export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
   logger = _logger;
-
   const { clients, config, dataworker } = await createDataworker(logger, baseSigner);
   try {
     logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });
+    
     for (;;) {
       const loopStart = Date.now();
       await updateDataworkerClients(clients);

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -51,16 +51,17 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       const disabledChains =
         config.disabledChainsOverride.length > 0
           ? config.disabledChainsOverride
-          : commonClients.configStoreClient.getDisabledChainsForBlock();
+          : clients.configStoreClient.getDisabledChainsForBlock();
+      if (disabledChains.length > 0)
+        logger.debug({
+          at: "Dataworker#index",
+          message: "Disabling constructing spoke pool clients for chains",
+          disabledChains,
+        });
       const configWithDisabledChains = {
         ...config,
         spokePoolChains: config.spokePoolChains.filter((chainId) => !disabledChains.includes(chainId)),
       };
-      logger.debug({
-        at: "Dataworker#index",
-        message: "Disabled chains listed in config store",
-        disabledChains,
-      });
 
       // Determine the spoke client's lookback:
       // 1. We initiate the spoke client event search windows based on a start bundle's bundle block end numbers and

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -48,7 +48,10 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       // Caller can optionally override the disabled chains list, which is useful for executing leaves or validating
       // older bundles. The Caller should be careful when setting when running the disputer or proposer functionality
       // as it can lead to proposing disputable bundles or disputing valid bundles.
-      const disabledChains = config.disabledChainsOverride ?? clients.configStoreClient.getDisabledChainsForBlock();
+      const disabledChains =
+        config.disabledChainsOverride.length > 0
+          ? config.disabledChainsOverride
+          : commonClients.configStoreClient.getDisabledChainsForBlock();
       const configWithDisabledChains = {
         ...config,
         spokePoolChains: config.spokePoolChains.filter((chainId) => !disabledChains.includes(chainId)),

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -42,11 +42,10 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
   logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });
 
   try {
-
     for (;;) {
       const loopStart = Date.now();
       await updateDataworkerClients(clients);
-      const disabledChains = [288]//clients.configStoreClient.getDisabledChainsForTimestamp()
+      const disabledChains = [288]; // clients.configStoreClient.getDisabledChainsForTimestamp()
       const configWithDisabledChains = {
         ...config,
         spokePoolChains: config.spokePoolChains.filter((chainId) => !disabledChains.includes(chainId)),
@@ -54,8 +53,8 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       logger.debug({
         at: "Dataworker#index",
         message: "Disabled chains listed in config store",
-        disabledChains 
-      })
+        disabledChains,
+      });
 
       // Determine the spoke client's lookback:
       // 1. We initiate the spoke client event search windows based on a start bundle's bundle block end numbers and

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -40,7 +40,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
   const { clients, config, dataworker } = await createDataworker(logger, baseSigner);
   try {
     logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Dataworker started 👩‍🔬", config });
-    
+
     for (;;) {
       const loopStart = Date.now();
       await updateDataworkerClients(clients);

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -45,7 +45,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
     for (;;) {
       const loopStart = Date.now();
       await updateDataworkerClients(clients);
-      const disabledChains = [288]//clients.configStoreClient.getDisabledChainsForTimestamp()
+      const disabledChains = [288]; // clients.configStoreClient.getDisabledChainsForTimestamp()
       const configWithDisabledChains = {
         ...config,
         spokePoolChains: config.spokePoolChains.filter((chainId) => !disabledChains.includes(chainId)),
@@ -53,8 +53,8 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       logger.debug({
         at: "Dataworker#index",
         message: "Disabled chains listed in config store",
-        disabledChains 
-      })
+        disabledChains,
+      });
 
       // Determine the spoke client's lookback:
       // 1. We initiate the spoke client event search windows based on a start bundle's bundle block end numbers and

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -45,16 +45,6 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
     for (;;) {
       const loopStart = Date.now();
       await updateDataworkerClients(clients);
-      const disabledChains = [288]; // clients.configStoreClient.getDisabledChainsForTimestamp()
-      const configWithDisabledChains = {
-        ...config,
-        spokePoolChains: config.spokePoolChains.filter((chainId) => !disabledChains.includes(chainId)),
-      };
-      logger.debug({
-        at: "Dataworker#index",
-        message: "Disabled chains listed in config store",
-        disabledChains,
-      });
 
       // Determine the spoke client's lookback:
       // 1. We initiate the spoke client event search windows based on a start bundle's bundle block end numbers and
@@ -74,7 +64,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
 
       // Get block range for spoke clients using the dataworker fast lookback bundle count.
       const { fromBundle, toBundle, fromBlocks, toBlocks } = getSpokePoolClientEventSearchConfigsForFastDataworker(
-        configWithDisabledChains,
+        config,
         clients,
         dataworker
       );
@@ -92,7 +82,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       const spokePoolClients = await constructSpokePoolClientsForFastDataworker(
         logger,
         clients.configStoreClient,
-        configWithDisabledChains,
+        config,
         baseSigner,
         fromBlocks,
         toBlocks

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -45,7 +45,10 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
     for (;;) {
       const loopStart = Date.now();
       await updateDataworkerClients(clients);
-      const disabledChains = [288]; // clients.configStoreClient.getDisabledChainsForTimestamp()
+      // Caller can optionally override the disabled chains list, which is useful for executing leaves or validating
+      // older bundles. The Caller should be careful when setting when running the disputer or proposer functionality
+      // as it can lead to proposing disputable bundles or disputing valid bundles.
+      const disabledChains = config.disabledChainsOverride ?? clients.configStoreClient.getDisabledChainsForBlock();
       const configWithDisabledChains = {
         ...config,
         spokePoolChains: config.spokePoolChains.filter((chainId) => !disabledChains.includes(chainId)),

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -10,6 +10,7 @@ import {
   getBlockForTimestamp,
   getCurrentTime,
   getRedis,
+  disconnectRedisClient,
 } from "../utils";
 import { winston } from "../utils";
 import {
@@ -276,12 +277,7 @@ export async function runFinalizer(_logger: winston.Logger, baseSigner: Wallet):
       if (await processEndPollingLoop(logger, "Dataworker", config.pollingDelay)) break;
     }
   } catch (error) {
-    const redisClient = await getRedis(logger);
-    if (redisClient !== undefined) {
-      // If this throws an exception, it will mask the underlying error.
-      logger.debug("Disconnecting from redis server.");
-      redisClient.disconnect();
-    }
+    await disconnectRedisClient(logger);
     throw error;
   }
 }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -31,7 +31,7 @@ import {
   ProcessEnv,
   FINALIZER_TOKENBRIDGE_LOOKBACK,
   DISABLED_CHAINS,
-  CHAIN_ID_LIST_INDICES
+  CHAIN_ID_LIST_INDICES,
 } from "../common";
 import { Multicall2Ethers__factory } from "@uma/contracts-node";
 import { BlockFinder } from "@uma/financial-templates-lib";

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -239,9 +239,7 @@ export async function constructFinalizerClients(_logger: winston.Logger, config,
     config,
     baseSigner,
     config.maxFinalizerLookback,
-    config.hubPoolChainId,
-    true // Include disabled chains for finalizer if caller wants to finalize. This is useful if a chain is disabled
-    // but not all of its SpokePool withdrawals have finalized yet.
+    config.hubPoolChainId
   );
 
   return {

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -92,8 +92,7 @@ export async function finalize(
         hubPoolClient.chainId,
         chainId,
         getCurrentTime() - optimisticRollupFinalizationWindow,
-        getCurrentTime(),
-        configStoreClient.redisClient
+        getCurrentTime()
       );
       logger.debug({
         at: "Finalizer",
@@ -116,8 +115,7 @@ export async function finalize(
         hubPoolClient.chainId,
         chainId,
         getCurrentTime() - polygonFinalizationWindow,
-        getCurrentTime(),
-        configStoreClient.redisClient
+        getCurrentTime()
       );
       logger.debug({
         at: "Finalizer",
@@ -142,8 +140,7 @@ export async function finalize(
         hubPoolClient.chainId,
         chainId,
         getCurrentTime() - optimisticRollupFinalizationWindow,
-        getCurrentTime(),
-        configStoreClient.redisClient
+        getCurrentTime()
       );
       logger.debug({
         at: "Finalizer",
@@ -167,8 +164,7 @@ export async function finalize(
         hubPoolClient.chainId,
         chainId,
         getCurrentTime() - optimisticRollupFinalizationWindow,
-        getCurrentTime(),
-        configStoreClient.redisClient
+        getCurrentTime()
       );
       logger.debug({
         at: "Finalizer",

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -29,8 +29,6 @@ import {
   Clients,
   ProcessEnv,
   FINALIZER_TOKENBRIDGE_LOOKBACK,
-  DISABLED_CHAINS,
-  CHAIN_ID_LIST_INDICES,
 } from "../common";
 import { Multicall2Ethers__factory } from "@uma/contracts-node";
 import * as optimismSDK from "@eth-optimism/sdk";

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -9,6 +9,7 @@ import {
   etherscanLink,
   getBlockForTimestamp,
   getCurrentTime,
+  getRedis,
 } from "../utils";
 import { winston } from "../utils";
 import {
@@ -275,10 +276,11 @@ export async function runFinalizer(_logger: winston.Logger, baseSigner: Wallet):
       if (await processEndPollingLoop(logger, "Dataworker", config.pollingDelay)) break;
     }
   } catch (error) {
-    if (commonClients.configStoreClient.redisClient !== undefined) {
+    const redisClient = await getRedis(logger);
+    if (redisClient !== undefined) {
       // If this throws an exception, it will mask the underlying error.
       logger.debug("Disconnecting from redis server.");
-      commonClients.configStoreClient.redisClient.disconnect();
+      redisClient.disconnect();
     }
     throw error;
   }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -30,6 +30,8 @@ import {
   Clients,
   ProcessEnv,
   FINALIZER_TOKENBRIDGE_LOOKBACK,
+  DISABLED_CHAINS,
+  CHAIN_ID_LIST_INDICES
 } from "../common";
 import { Multicall2Ethers__factory } from "@uma/contracts-node";
 import { BlockFinder } from "@uma/financial-templates-lib";

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -9,7 +9,6 @@ import {
   etherscanLink,
   getBlockForTimestamp,
   getCurrentTime,
-  getCachedProvider,
 } from "../utils";
 import { winston } from "../utils";
 import {

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -239,7 +239,9 @@ export async function constructFinalizerClients(_logger: winston.Logger, config,
     config,
     baseSigner,
     config.maxFinalizerLookback,
-    config.hubPoolChainId
+    config.hubPoolChainId,
+    true // Include disabled chains for finalizer if caller wants to finalize. This is useful if a chain is disabled
+    // but not all of its SpokePool withdrawals have finalized yet.
   );
 
   return {

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -1,13 +1,6 @@
 import { setProofApi, use, POSClient } from "@maticnetwork/maticjs";
 import { Web3ClientPlugin } from "@maticnetwork/maticjs-ethers";
-import {
-  convertFromWei,
-  getDeployedContract,
-  groupObjectCountsByProp,
-  Wallet,
-  winston,
-  Contract,
-} from "../../utils";
+import { convertFromWei, getDeployedContract, groupObjectCountsByProp, Wallet, winston, Contract } from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient } from "../../clients";
 import { Multicall2Call, Withdrawal } from "..";

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -1,6 +1,14 @@
 import { setProofApi, use, POSClient } from "@maticnetwork/maticjs";
 import { Web3ClientPlugin } from "@maticnetwork/maticjs-ethers";
-import { convertFromWei, getDeployedContract, groupObjectCountsByProp, Wallet, winston, Contract } from "../../utils";
+import {
+  convertFromWei,
+  getDeployedContract,
+  groupObjectCountsByProp,
+  Wallet,
+  winston,
+  Contract,
+  getCachedProvider,
+} from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient } from "../../clients";
 import { Multicall2Call, Withdrawal } from "..";

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -6,6 +6,7 @@ import {
   groupObjectCountsByProp,
   Wallet,
   winston,
+  Contract
 } from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient } from "../../clients";
@@ -177,7 +178,7 @@ export async function multicallPolygonFinalizations(
   };
 }
 
-export function getMainnetTokenBridger(mainnetSigner: Wallet) {
+export function getMainnetTokenBridger(mainnetSigner: Wallet): Contract {
   return getDeployedContract("PolygonTokenBridger", 1, mainnetSigner);
 }
 

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -6,7 +6,7 @@ import {
   groupObjectCountsByProp,
   Wallet,
   winston,
-  Contract
+  Contract,
 } from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient } from "../../clients";

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -1,9 +1,7 @@
 import { setProofApi, use, POSClient } from "@maticnetwork/maticjs";
 import { Web3ClientPlugin } from "@maticnetwork/maticjs-ethers";
 import {
-  Contract,
   convertFromWei,
-  getCachedProvider,
   getDeployedContract,
   groupObjectCountsByProp,
   Wallet,

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -62,7 +62,7 @@ export class Monitor {
   public constructor(
     readonly logger: winston.Logger,
     readonly monitorConfig: MonitorConfig,
-    readonly clients: MonitorClients,
+    readonly clients: MonitorClients
   ) {
     this.monitorChains = Object.keys(clients.spokePoolClients).map((chainId) => Number(chainId));
     for (const chainId of this.monitorChains) {

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -62,7 +62,7 @@ export class Monitor {
   public constructor(
     readonly logger: winston.Logger,
     readonly monitorConfig: MonitorConfig,
-    readonly clients: MonitorClients
+    readonly clients: MonitorClients,
   ) {
     this.monitorChains = Object.keys(clients.spokePoolClients).map((chainId) => Number(chainId));
     for (const chainId of this.monitorChains) {

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -1,4 +1,12 @@
-import { winston, processEndPollingLoop, config, startupLogLevel, Wallet, getRedis } from "../utils";
+import {
+  winston,
+  processEndPollingLoop,
+  config,
+  startupLogLevel,
+  Wallet,
+  getRedis,
+  disconnectRedisClient,
+} from "../utils";
 import { Monitor } from "./Monitor";
 import { MonitorConfig } from "./MonitorConfig";
 import { constructMonitorClients } from "./MonitorClientHelper";
@@ -44,12 +52,7 @@ export async function runMonitor(_logger: winston.Logger, baseSigner: Wallet) {
       if (await processEndPollingLoop(logger, "Monitor", config.pollingDelay)) break;
     }
   } catch (error) {
-    const redisClient = await getRedis(logger);
-    if (redisClient !== undefined) {
-      // If this throws an exception, it will mask the underlying error.
-      logger.debug("Disconnecting from redis server.");
-      redisClient.disconnect();
-    }
+    await disconnectRedisClient(logger);
     throw error;
   }
 }

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -1,4 +1,4 @@
-import { winston, processEndPollingLoop, config, startupLogLevel, Wallet } from "../utils";
+import { winston, processEndPollingLoop, config, startupLogLevel, Wallet, getRedis } from "../utils";
 import { Monitor } from "./Monitor";
 import { MonitorConfig } from "./MonitorConfig";
 import { constructMonitorClients } from "./MonitorClientHelper";
@@ -44,10 +44,11 @@ export async function runMonitor(_logger: winston.Logger, baseSigner: Wallet) {
       if (await processEndPollingLoop(logger, "Monitor", config.pollingDelay)) break;
     }
   } catch (error) {
-    if (clients !== undefined && clients.configStoreClient.redisClient !== undefined) {
-      // todo understand why redisClient isn't GCed automagically.
+    const redisClient = await getRedis(logger);
+    if (redisClient !== undefined) {
+      // If this throws an exception, it will mask the underlying error.
       logger.debug("Disconnecting from redis server.");
-      clients.configStoreClient.redisClient.disconnect();
+      redisClient.disconnect();
     }
     throw error;
   }

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -1,4 +1,4 @@
-import { processEndPollingLoop, winston, config, startupLogLevel, Wallet } from "../utils";
+import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, getRedis } from "../utils";
 import { Relayer } from "./Relayer";
 import { RelayerConfig } from "./RelayerConfig";
 import { constructRelayerClients, updateRelayerClients } from "./RelayerClientHelper";
@@ -39,10 +39,11 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Wallet): P
       if (await processEndPollingLoop(logger, "Relayer", config.pollingDelay)) break;
     }
   } catch (error) {
-    if (relayerClients !== undefined && relayerClients.configStoreClient.redisClient !== undefined) {
-      // todo understand why redisClient isn't GCed automagically.
+    const redisClient = await getRedis(logger);
+    if (redisClient !== undefined) {
+      // If this throws an exception, it will mask the underlying error.
       logger.debug("Disconnecting from redis server.");
-      relayerClients.configStoreClient.redisClient.disconnect();
+      redisClient.disconnect();
     }
     throw error;
   }

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -1,4 +1,12 @@
-import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, getRedis } from "../utils";
+import {
+  processEndPollingLoop,
+  winston,
+  config,
+  startupLogLevel,
+  Wallet,
+  getRedis,
+  disconnectRedisClient,
+} from "../utils";
 import { Relayer } from "./Relayer";
 import { RelayerConfig } from "./RelayerConfig";
 import { constructRelayerClients, updateRelayerClients } from "./RelayerClientHelper";
@@ -39,12 +47,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Wallet): P
       if (await processEndPollingLoop(logger, "Relayer", config.pollingDelay)) break;
     }
   } catch (error) {
-    const redisClient = await getRedis(logger);
-    if (redisClient !== undefined) {
-      // If this throws an exception, it will mask the underlying error.
-      logger.debug("Disconnecting from redis server.");
-      redisClient.disconnect();
-    }
+    await disconnectRedisClient(logger);
     throw error;
   }
 }

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -66,7 +66,6 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
     clients.hubPoolClient.chainId,
     priceRequestTime,
     getCurrentTime(),
-    clients.configStoreClient.blockFinder,
     clients.configStoreClient.redisClient
   );
 

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -32,7 +32,7 @@ import {
 import { PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
 import { createDataworker } from "../dataworker";
-import { getEndBlockBuffers } from "../dataworker/DataworkerUtils";
+import { getBlockForChain, getEndBlockBuffers } from "../dataworker/DataworkerUtils";
 import { CONFIG_STORE_VERSION } from "../common";
 
 config();

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -65,8 +65,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
     clients.hubPoolClient.chainId,
     clients.hubPoolClient.chainId,
     priceRequestTime,
-    getCurrentTime(),
-    clients.configStoreClient.redisClient
+    getCurrentTime()
   );
 
   // Find dispute transaction so we can gain additional confidence that the preceding root bundle is older than the

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -160,10 +160,32 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
     toBundleTxn: toBundle?.transactionHash,
   });
 
+  // Get disabled chains at mainnet bundle end block of root bundle that we're validating.
+  const disabledChains =
+    config.disabledChainsOverride.length > 0
+      ? config.disabledChainsOverride
+      : clients.configStoreClient.getDisabledChainsForBlock(
+          getBlockForChain(
+            rootBundle.bundleEvaluationBlockNumbers,
+            1,
+            dataworker.chainIdListForBundleEvaluationBlockNumbers
+          )
+        );
+  if (disabledChains.length > 0)
+    logger.debug({
+      at: "RootBundleValidator#index",
+      message: "Disabling constructing spoke pool clients for chains",
+      disabledChains,
+    });
+  const configWithDisabledChains = {
+    ...config,
+    spokePoolChains: config.spokePoolChains.filter((chainId) => !disabledChains.includes(chainId)),
+  };
+
   const spokePoolClients = await constructSpokePoolClientsForFastDataworker(
     logger,
     clients.configStoreClient,
-    config,
+    configWithDisabledChains,
     baseSigner,
     fromBlocks,
     toBlocks

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -32,7 +32,7 @@ import {
 import { PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
 import { createDataworker } from "../dataworker";
-import { getBlockForChain, getEndBlockBuffers } from "../dataworker/DataworkerUtils";
+import { getEndBlockBuffers } from "../dataworker/DataworkerUtils";
 import { CONFIG_STORE_VERSION } from "../common";
 
 config();

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -23,6 +23,7 @@ import {
   getCurrentTime,
   sortEventsDescending,
   getDisputeForTimestamp,
+  disconnectRedisClient,
 } from "../utils";
 import {
   constructSpokePoolClientsForFastDataworker,
@@ -202,7 +203,8 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
 export async function run(_logger: winston.Logger): Promise<void> {
   const baseSigner: Wallet = await getSigner();
   await validate(_logger, baseSigner);
+  await disconnectRedisClient(logger);
 }
 
 // eslint-disable-next-line no-process-exit
-run(Logger).then(() => process.exit(0));
+run(Logger).then(async () => process.exit(0));

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -160,32 +160,10 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
     toBundleTxn: toBundle?.transactionHash,
   });
 
-  // Get disabled chains at mainnet bundle end block of root bundle that we're validating.
-  const disabledChains =
-    config.disabledChainsOverride.length > 0
-      ? config.disabledChainsOverride
-      : clients.configStoreClient.getDisabledChainsForBlock(
-          getBlockForChain(
-            rootBundle.bundleEvaluationBlockNumbers,
-            1,
-            dataworker.chainIdListForBundleEvaluationBlockNumbers
-          )
-        );
-  if (disabledChains.length > 0)
-    logger.debug({
-      at: "RootBundleValidator#index",
-      message: "Disabling constructing spoke pool clients for chains",
-      disabledChains,
-    });
-  const configWithDisabledChains = {
-    ...config,
-    spokePoolChains: config.spokePoolChains.filter((chainId) => !disabledChains.includes(chainId)),
-  };
-
   const spokePoolClients = await constructSpokePoolClientsForFastDataworker(
     logger,
     clients.configStoreClient,
-    configWithDisabledChains,
+    config,
     baseSigner,
     fromBlocks,
     toBlocks

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -45,10 +45,6 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
   }
   const priceRequestTime = Number(process.env.REQUEST_TIME);
 
-  // Enable all networks so we can validate historical bundles. Comment this out if a disabled network has RPC issues
-  // for some reason.
-  process.env.DISABLED_NETWORKS = "[]";
-
   // Override default config with sensible defaults:
   // - DATAWORKER_FAST_LOOKBACK_COUNT=8 balances limiting RPC requests with querying
   // enough data to limit # of excess historical deposit queries.

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -45,6 +45,10 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
   }
   const priceRequestTime = Number(process.env.REQUEST_TIME);
 
+  // Enable all networks so we can validate historical bundles. Comment this out if a disabled network has RPC issues
+  // for some reason.
+  process.env.DISABLED_NETWORKS = "[]";
+
   // Override default config with sensible defaults:
   // - DATAWORKER_FAST_LOOKBACK_COUNT=8 balances limiting RPC requests with querying
   // enough data to limit # of excess historical deposit queries.

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -106,7 +106,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
         console.group(`Leaf for chain ID ${leaf.chainId} and token ${tokenInfo.symbol} (${l1Token})`);
         const decimals = tokenInfo.decimals;
         const l2Token = clients.hubPoolClient.getDestinationTokenForL1Token(l1Token, leaf.chainId);
-        const l2TokenContract = new Contract(l2Token, ERC20.abi, getProvider(leaf.chainId));
+        const l2TokenContract = new Contract(l2Token, ERC20.abi, await getProvider(leaf.chainId));
         const runningBalance = leaf.runningBalances[i];
         const netSendAmount = leaf.netSendAmounts[i];
         const bundleEndBlockForChain =

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -35,6 +35,7 @@ import {
   paginatedEventQuery,
   ZERO_ADDRESS,
   getRefund,
+  disconnectRedisClient,
 } from "../utils";
 import { updateDataworkerClients } from "../dataworker/DataworkerClientHelper";
 import { createDataworker } from "../dataworker";
@@ -416,6 +417,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
 export async function run(_logger: winston.Logger): Promise<void> {
   const baseSigner: Wallet = await getSigner();
   await runScript(_logger, baseSigner);
+  await disconnectRedisClient(logger);
 }
 
 // eslint-disable-next-line no-process-exit

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -51,10 +51,6 @@ const slowRootCache = {};
 export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
   logger = _logger;
 
-  // Enable all networks so we can validate historical bundles. Comment this out if a disabled network has RPC issues
-  // for some reason.
-  process.env.DISABLED_NETWORKS = "[]";
-
   const { clients, dataworker, config } = await createDataworker(logger, baseSigner);
   await updateDataworkerClients(clients, false);
 

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -51,6 +51,10 @@ const slowRootCache = {};
 export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
   logger = _logger;
 
+  // Enable all networks so we can validate historical bundles. Comment this out if a disabled network has RPC issues
+  // for some reason.
+  process.env.DISABLED_NETWORKS = "[]";
+
   const { clients, dataworker, config } = await createDataworker(logger, baseSigner);
   await updateDataworkerClients(clients, false);
 

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -63,9 +63,9 @@ export async function getDeposit(key: string, redisClient: RedisClient): Promise
   if (depositRaw) return JSON.parse(depositRaw, objectWithBigNumberReviver);
 }
 
-export function getBlockFinder(chainId: number): BlockFinder<Block> {
+export function getBlockFinder(chainId: number, redisClient?: RedisClient): BlockFinder<Block> {
   if (!blockFinders[chainId]) {
-    const providerForChain = getProvider(chainId);
+    const providerForChain = getProvider(chainId, undefined, redisClient);
     blockFinders[chainId] = new BlockFinder<Block>(providerForChain.getBlock.bind(providerForChain), [], chainId);
   }
   return blockFinders[chainId];
@@ -80,7 +80,7 @@ export async function getBlockForTimestamp(
   redisClient?: RedisClient,
   blockFinder?: BlockFinder<Block>
 ): Promise<number> {
-  if (blockFinder === undefined) blockFinder = getBlockFinder(chainId);
+  if (blockFinder === undefined) blockFinder = getBlockFinder(chainId, undefined, redisClient);
   if (redisClient === undefined) return (await blockFinder.getBlockForTimestamp(timestamp)).number;
   // We already cache blocks in the ConfigStore on the HubPool chain so re-use that key if the chainId
   // matches the HubPool's.

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -119,6 +119,15 @@ export async function getBlockForTimestamp(
   }
 }
 
+export async function disconnectRedisClient(logger?: winston.Logger): Promise<void> {
+  const redisClient = await getRedis(logger);
+  if (redisClient !== undefined) {
+    // todo understand why redisClient isn't GCed automagically.
+    logger.debug("Disconnecting from redis server.");
+    redisClient.disconnect();
+  }
+}
+
 export function shouldCache(eventTimestamp: number, latestTime: number): boolean {
   assert(eventTimestamp.toString().length === 10, "eventTimestamp must be in seconds");
   assert(latestTime.toString().length === 10, "eventTimestamp must be in seconds");

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -63,7 +63,7 @@ export async function getDeposit(key: string, redisClient: RedisClient): Promise
   if (depositRaw) return JSON.parse(depositRaw, objectWithBigNumberReviver);
 }
 
-export function getBlockFinder(chainId: number, redisClient?: RedisClient): BlockFinder<Block> {
+function getBlockFinder(chainId: number, redisClient?: RedisClient): BlockFinder<Block> {
   if (!blockFinders[chainId]) {
     const providerForChain = getProvider(chainId, undefined, redisClient);
     blockFinders[chainId] = new BlockFinder<Block>(providerForChain.getBlock.bind(providerForChain), [], chainId);
@@ -80,7 +80,7 @@ export async function getBlockForTimestamp(
   redisClient?: RedisClient,
   blockFinder?: BlockFinder<Block>
 ): Promise<number> {
-  if (blockFinder === undefined) blockFinder = getBlockFinder(chainId, undefined, redisClient);
+  if (blockFinder === undefined) blockFinder = getBlockFinder(chainId, redisClient);
   if (redisClient === undefined) return (await blockFinder.getBlockForTimestamp(timestamp)).number;
   // We already cache blocks in the ConfigStore on the HubPool chain so re-use that key if the chainId
   // matches the HubPool's.

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -32,7 +32,11 @@ export async function getRedis(logger?: winston.Logger, url = REDIS_URL): Promis
         });
       redisClients[url] = redisClient;
     } catch (err) {
-      // No redis client at URL
+      if (logger)
+        logger.debug({
+          at: "Dataworker#ClientHelper",
+          message: `Failed to connec to redis server at ${url}.`,
+        });
     }
   }
 

--- a/src/utils/UmaUtils.ts
+++ b/src/utils/UmaUtils.ts
@@ -29,8 +29,7 @@ export async function getDisputeForTimestamp(
           configStoreClient.hubPoolClient.chainId,
           configStoreClient.hubPoolClient.chainId,
           disputeRequestTimestamp,
-          getCurrentTime(),
-          configStoreClient.redisClient
+          getCurrentTime()
         );
   const disputes = await dvm.queryFilter(filter, priceRequestBlock, priceRequestBlock);
   return disputes.find((e) => e.args.time.toString() === disputeRequestTimestamp.toString()) as SortableEvent;

--- a/src/utils/UmaUtils.ts
+++ b/src/utils/UmaUtils.ts
@@ -30,7 +30,6 @@ export async function getDisputeForTimestamp(
           configStoreClient.hubPoolClient.chainId,
           disputeRequestTimestamp,
           getCurrentTime(),
-          configStoreClient.blockFinder,
           configStoreClient.redisClient
         );
   const disputes = await dvm.queryFilter(filter, priceRequestBlock, priceRequestBlock);

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -711,8 +711,8 @@ describe("Dataworker: Build merkle roots", async function () {
         spokePool_2,
         configStoreClient,
         destinationChainId,
-        { fromBlock: fill1Block + 1 }, // Set fromBlock to now, after first fill for same deposit as the slowFill1
-        spokePoolClients[destinationChainId].spokePoolDeploymentBlock
+        spokePoolClients[destinationChainId].spokePoolDeploymentBlock,
+        { fromBlock: fill1Block + 1 } // Set fromBlock to now, after first fill for same deposit as the slowFill1
       );
       await shortRangeSpokePoolClient.update();
       expect(shortRangeSpokePoolClient.getFills().length).to.equal(2); // We should only be able to see 2 fills
@@ -886,8 +886,8 @@ describe("Dataworker: Build merkle roots", async function () {
         spokePool_2,
         configStoreClient,
         destinationChainId,
-        { fromBlock: fill2Block + 1 },
-        spokePoolClients[destinationChainId].spokePoolDeploymentBlock
+        spokePoolClients[destinationChainId].spokePoolDeploymentBlock,
+        { fromBlock: fill2Block + 1 }
       );
 
       // Send a third partial fill, this will produce an excess since a slow fill is already in flight for the deposit.

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -377,17 +377,17 @@ describe("HubPoolClient: RootBundle Events", async function () {
     const secondUpdateBlockNumber = await hubPool.provider.getBlockNumber();
 
     // Default case when there are no events for a chain.
-    expect(() => hubPoolClient.getSpokePoolForBlock(firstUpdateBlockNumber, 11)).to.throw(
+    expect(() => hubPoolClient.getSpokePoolForBlock(11, firstUpdateBlockNumber)).to.throw(
       /No cross chain contracts set/
     );
     await hubPoolClient.update();
 
     // Happy case where latest spoke pool at block is returned
-    expect(hubPoolClient.getSpokePoolForBlock(firstUpdateBlockNumber, 11)).to.equal(spokePool1);
-    expect(hubPoolClient.getSpokePoolForBlock(secondUpdateBlockNumber, 11)).to.equal(spokePool2);
+    expect(hubPoolClient.getSpokePoolForBlock(11, firstUpdateBlockNumber)).to.equal(spokePool1);
+    expect(hubPoolClient.getSpokePoolForBlock(11, secondUpdateBlockNumber)).to.equal(spokePool2);
 
     // Chain has events but none before block
-    expect(() => hubPoolClient.getSpokePoolForBlock(firstUpdateBlockNumber - 1, 11)).to.throw(
+    expect(() => hubPoolClient.getSpokePoolForBlock(11, firstUpdateBlockNumber - 1)).to.throw(
       /No cross chain contract found before block/
     );
   });

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -95,7 +95,6 @@ describe("ProfitClient: Consider relay profit", async function () {
       spokePool_1.connect(owner),
       null,
       originChainId,
-      undefined,
       spokePool1DeploymentBlock
     );
     const spokePoolClient_2 = new SpokePoolClient(
@@ -103,7 +102,6 @@ describe("ProfitClient: Consider relay profit", async function () {
       spokePool_2.connect(owner),
       null,
       destinationChainId,
-      undefined,
       spokePool2DeploymentBlock
     );
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -72,7 +72,6 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       spokePool_1.connect(relayer),
       configStoreClient,
       originChainId,
-      undefined,
       spokePool1DeploymentBlock
     );
     spokePoolClient_2 = new SpokePoolClient(
@@ -80,7 +79,6 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       spokePool_2.connect(relayer),
       configStoreClient,
       destinationChainId,
-      undefined,
       spokePool2DeploymentBlock
     );
     spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -61,7 +61,6 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       spokePool_1.connect(relayer),
       configStoreClient,
       originChainId,
-      undefined,
       spokePool1DeploymentBlock
     );
     spokePoolClient_2 = new SpokePoolClient(
@@ -69,7 +68,6 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       spokePool_2.connect(relayer),
       configStoreClient,
       destinationChainId,
-      undefined,
       spokePool2DeploymentBlock
     );
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -59,7 +59,6 @@ describe("Relayer: Token balance shortfall", async function () {
       spokePool_1.connect(relayer),
       configStoreClient,
       originChainId,
-      undefined,
       spokePool1DeploymentBlock
     );
     spokePoolClient_2 = new SpokePoolClient(
@@ -67,7 +66,6 @@ describe("Relayer: Token balance shortfall", async function () {
       spokePool_2.connect(relayer),
       configStoreClient,
       destinationChainId,
-      undefined,
       spokePool2DeploymentBlock
     );
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -73,7 +73,6 @@ describe("Relayer: Unfilled Deposits", async function () {
       spokePool_1,
       configStoreClient,
       originChainId,
-      undefined,
       spokePool1DeploymentBlock
     );
     spokePoolClient_2 = new SpokePoolClient(
@@ -81,8 +80,8 @@ describe("Relayer: Unfilled Deposits", async function () {
       spokePool_2,
       configStoreClient,
       destinationChainId,
-      { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 },
-      spokePool2DeploymentBlock
+      spokePool2DeploymentBlock,
+      { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 }
     );
 
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };

--- a/test/SpokePoolClient.DepositRoutes.ts
+++ b/test/SpokePoolClient.DepositRoutes.ts
@@ -17,14 +17,7 @@ describe("SpokePoolClient: Deposit Routes", async function () {
     ).deploy(owner.address, owner.address, zeroAddress, zeroAddress);
     const deploymentBlock = await spokePool.provider.getBlockNumber();
 
-    spokePoolClient = new SpokePoolClient(
-      createSpyLogger().spyLogger,
-      spokePool,
-      null,
-      originChainId,
-      undefined,
-      deploymentBlock
-    );
+    spokePoolClient = new SpokePoolClient(createSpyLogger().spyLogger, spokePool, null, originChainId, deploymentBlock);
   });
 
   it("Fetches enabled deposit routes", async function () {

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -16,14 +16,7 @@ describe("SpokePoolClient: SpeedUp", async function () {
     [owner, depositor] = await ethers.getSigners();
     ({ spokePool, erc20, destErc20, weth, deploymentBlock } = await deploySpokePoolWithToken(originChainId));
     await enableRoutes(spokePool, [{ originToken: erc20.address, destinationChainId: destinationChainId2 }]);
-    spokePoolClient = new SpokePoolClient(
-      createSpyLogger().spyLogger,
-      spokePool,
-      null,
-      originChainId,
-      undefined,
-      deploymentBlock
-    );
+    spokePoolClient = new SpokePoolClient(createSpyLogger().spyLogger, spokePool, null, originChainId, deploymentBlock);
 
     await setupTokensForWallet(spokePool, depositor, [erc20, destErc20], weth, 10);
   });

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -75,7 +75,6 @@ describe("SpokePoolClient: Fill Validation", async function () {
       spokePool_1,
       configStoreClient,
       originChainId,
-      undefined,
       spokePool1DeploymentBlock
     );
     spokePoolClient2 = new SpokePoolClient(
@@ -83,7 +82,6 @@ describe("SpokePoolClient: Fill Validation", async function () {
       spokePool_2,
       null,
       destinationChainId,
-      undefined,
       spokePool2DeploymentBlock
     );
 
@@ -130,7 +128,6 @@ describe("SpokePoolClient: Fill Validation", async function () {
       spokePool_1,
       null,
       destinationChainId,
-      undefined,
       spokePool1DeploymentBlock
     ); // create spoke pool client on the "target" chain.
     // expect(spokePoolClientForDestinationChain.getDepositForFill(fill_1)).to.equal(undefined);
@@ -523,7 +520,6 @@ describe("SpokePoolClient: Fill Validation", async function () {
       spokePool_1,
       null,
       destinationChainId,
-      undefined,
       spokePool2DeploymentBlock
     ); // create spoke pool client on the "target" chain.
     await spokePoolClientForDestinationChain.update();

--- a/test/SpokePoolClient.deposits.ts
+++ b/test/SpokePoolClient.deposits.ts
@@ -15,14 +15,7 @@ describe("SpokePoolClient: Deposits", async function () {
     [owner, depositor1, depositor2] = await ethers.getSigners();
     ({ spokePool, erc20, destErc20, weth, deploymentBlock } = await deploySpokePoolWithToken(originChainId));
     await enableRoutes(spokePool, [{ originToken: erc20.address, destinationChainId: destinationChainId2 }]);
-    spokePoolClient = new SpokePoolClient(
-      createSpyLogger().spyLogger,
-      spokePool,
-      null,
-      originChainId,
-      undefined,
-      deploymentBlock
-    );
+    spokePoolClient = new SpokePoolClient(createSpyLogger().spyLogger, spokePool, null, originChainId, deploymentBlock);
 
     await setupTokensForWallet(spokePool, depositor1, [erc20, destErc20], weth, 10);
     await setupTokensForWallet(spokePool, depositor2, [erc20, destErc20], weth, 10);

--- a/test/SpokePoolClient.fills.ts
+++ b/test/SpokePoolClient.fills.ts
@@ -24,7 +24,6 @@ describe("SpokePoolClient: Fills", async function () {
       spokePool,
       null,
       destinationChainId,
-      undefined,
       deploymentBlock
     );
 

--- a/test/TokenClient.Approval.ts
+++ b/test/TokenClient.Approval.ts
@@ -43,7 +43,6 @@ describe("TokenClient: Origin token approval", async function () {
       spokePool_1,
       null,
       originChainId,
-      undefined,
       spokePool1DeploymentBlock
     );
     spokePoolClient_2 = new SpokePoolClient(
@@ -51,7 +50,6 @@ describe("TokenClient: Origin token approval", async function () {
       spokePool_2,
       null,
       destinationChainId,
-      undefined,
       spokePool2DeploymentBlock
     );
 

--- a/test/TokenClient.BalanceAlowance.ts
+++ b/test/TokenClient.BalanceAlowance.ts
@@ -35,7 +35,6 @@ describe("TokenClient: Balance and Allowance", async function () {
       spokePool_1,
       null,
       originChainId,
-      undefined,
       spokePool1DeploymentBlock
     );
     spokePoolClient_2 = new SpokePoolClient(
@@ -43,7 +42,6 @@ describe("TokenClient: Balance and Allowance", async function () {
       spokePool_2,
       null,
       destinationChainId,
-      undefined,
       spokePool2DeploymentBlock
     );
 

--- a/test/TokenClient.TokenShortfall.ts
+++ b/test/TokenClient.TokenShortfall.ts
@@ -31,7 +31,6 @@ describe("TokenClient: Token shortfall", async function () {
       spokePool_1,
       null,
       originChainId,
-      undefined,
       spokePool1DeploymentBlock
     );
     spokePoolClient_2 = new SpokePoolClient(
@@ -39,7 +38,6 @@ describe("TokenClient: Token shortfall", async function () {
       spokePool_2,
       null,
       destinationChainId,
-      undefined,
       spokePool2DeploymentBlock
     );
 

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -42,8 +42,8 @@ async function _constructSpokePoolClientsWithLookback(
       pool.connect(signer),
       configStoreClient,
       spokePoolChains[i],
-      lookbackForAllChains === undefined ? undefined : { fromBlock: latestBlocks[i] - lookbackForAllChains },
-      deploymentBlocks && deploymentBlocks[spokePoolChains[i]]
+      deploymentBlocks && deploymentBlocks[spokePoolChains[i]],
+      lookbackForAllChains === undefined ? undefined : { fromBlock: latestBlocks[i] - lookbackForAllChains }
     );
   });
 }

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -252,7 +252,6 @@ export async function deploySpokePoolForIterativeTest(
     spokePool.connect(signer),
     configStoreClient,
     desiredChainId,
-    undefined,
     deploymentBlock
   );
 


### PR DESCRIPTION
Removes need to update hardcoded mapping of spoke pool addresses and deployment blocks. Will make upgrading spoke pools easier in future.

This PR also introduces some optimizations:
- `getProvider` always tries to load `redisClient` instead of asking caller to pass it in as a param
- `getBlockForTimestamp` similarly always tries to load `redisClient` and fetch the block from the redis cache instead of asking user to pass it in