### PR TITLE
feat: Cache providers by chainId and cache/noCache flag

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -66,7 +66,7 @@ export async function constructSpokePoolClientsWithLookback(
   // on chains that are enabled between [currentTime - initialLookBackOverride, currentTime].
   const blockFinders = Object.fromEntries(
     CHAIN_ID_LIST_INDICES.map((chainId) => {
-      const providerForChain = getProvider(chainId);
+      const providerForChain = getProvider(chainId, undefined, configStoreClient.redisClient);
       if (chainId === hubPoolChainId) return [hubPoolChainId, configStoreClient.blockFinder];
       else return [chainId, new BlockFinder<Block>(providerForChain.getBlock.bind(providerForChain), [], chainId)];
     })

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -8,9 +8,9 @@ import {
   getNetworkName,
   etherscanLink,
   Block,
-  getProvider,
   getBlockForTimestamp,
   getCurrentTime,
+  getCachedProvider,
 } from "../utils";
 import { winston } from "../utils";
 import {
@@ -63,7 +63,10 @@ export async function finalize(
 ): Promise<void> {
   const blockFinders = Object.fromEntries(
     configuredChainIds.map((chainId) => {
-      return [chainId, new BlockFinder<Block>(hubSigner.provider.getBlock.bind(getProvider(chainId)), [], chainId)];
+      return [
+        chainId,
+        new BlockFinder<Block>(hubSigner.provider.getBlock.bind(getCachedProvider(chainId, true)), [], chainId),
+      ];
     })
   );
 

--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -1,4 +1,12 @@
-import { Wallet, winston, convertFromWei, groupObjectCountsByProp, Contract, ethers, getCachedProvider } from "../../utils";
+import {
+  Wallet,
+  winston,
+  convertFromWei,
+  groupObjectCountsByProp,
+  Contract,
+  ethers,
+  getCachedProvider,
+} from "../../utils";
 import { L2ToL1MessageStatus, L2TransactionReceipt, getL2Network, IL2ToL1MessageWriter } from "@arbitrum/sdk";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient } from "../../clients";

--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -1,4 +1,4 @@
-import { getProvider, Wallet, winston, convertFromWei, groupObjectCountsByProp, Contract } from "../../utils";
+import { Wallet, winston, convertFromWei, groupObjectCountsByProp, Contract, ethers, getCachedProvider } from "../../utils";
 import { L2ToL1MessageStatus, L2TransactionReceipt, getL2Network, IL2ToL1MessageWriter } from "@arbitrum/sdk";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient } from "../../clients";
@@ -35,7 +35,7 @@ export async function multicallArbitrumFinalizations(
 }
 
 export async function finalizeArbitrum(message: IL2ToL1MessageWriter): Promise<Multicall2Call> {
-  const l2Provider = getProvider(CHAIN_ID);
+  const l2Provider = getCachedProvider(CHAIN_ID, true);
   const proof = await message.getOutboxProof(l2Provider);
   const outbox = new Contract((await getL2Network(l2Provider)).ethBridge.outbox, outboxAbi);
   const eventData = (message as any).nitroWriter.event; // nitroWriter is a private property on the
@@ -109,7 +109,7 @@ export async function getMessageOutboxStatusAndProof(
   message: IL2ToL1MessageWriter;
   status: string;
 }> {
-  const l2Provider = getProvider(CHAIN_ID);
+  const l2Provider = getCachedProvider(CHAIN_ID, true);
   const receipt = await l2Provider.getTransactionReceipt(event.transactionHash);
   const l2Receipt = new L2TransactionReceipt(receipt);
 

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -1,18 +1,15 @@
 import { setProofApi, use, POSClient } from "@maticnetwork/maticjs";
 import { Web3ClientPlugin } from "@maticnetwork/maticjs-ethers";
 import {
-  BigNumber,
   Contract,
   convertFromWei,
-  ERC20,
+  getCachedProvider,
   getDeployedContract,
-  getProvider,
   groupObjectCountsByProp,
-  toBN,
   Wallet,
   winston,
 } from "../../utils";
-import { L1Token, TokensBridged } from "../../interfaces";
+import { TokensBridged } from "../../interfaces";
 import { HubPoolClient } from "../../clients";
 import { Multicall2Call, Withdrawal } from "..";
 
@@ -49,7 +46,7 @@ export async function getPosClient(mainnetSigner: Wallet) {
       },
     },
     child: {
-      provider: mainnetSigner.connect(getProvider(CHAIN_ID)),
+      provider: mainnetSigner.connect(getCachedProvider(CHAIN_ID, true)),
       defaultConfig: {
         from: mainnetSigner.address,
       },

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -380,7 +380,7 @@ class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
 // Global provider cache to avoid creating multiple providers for the same chain.
 const providerCache: { [chainId: number]: RetryProvider } = {};
 
-function getProviderCachekey(chainId: number, redisEnabled) {
+function getProviderCacheKey(chainId: number, redisEnabled) {
   return `${chainId}_${redisEnabled ? "cache" : "nocache"}`;
 }
 
@@ -392,9 +392,9 @@ function getProviderCachekey(chainId: number, redisEnabled) {
  * @returns ethers.provider
  */
 export function getCachedProvider(chainId: number, redisEnabled = true): RetryProvider {
-  if (!providerCache[getProviderCachekey(chainId, redisEnabled)])
+  if (!providerCache[getProviderCacheKey(chainId, redisEnabled)])
     throw new Error(`No cached provider for chainId ${chainId} and redisEnabled ${redisEnabled}`);
-  return providerCache[getProviderCachekey(chainId, redisEnabled)];
+  return providerCache[getProviderCacheKey(chainId, redisEnabled)];
 }
 
 export function getProvider(
@@ -404,7 +404,7 @@ export function getProvider(
   useCache = true
 ): RetryProvider {
   if (useCache) {
-    const cachedProvider = providerCache[getProviderCachekey(chainId, redisClient !== undefined)];
+    const cachedProvider = providerCache[getProviderCacheKey(chainId, redisClient !== undefined)];
     if (cachedProvider) return cachedProvider;
   }
   const {
@@ -491,7 +491,7 @@ export function getProvider(
     disableProviderCache ? undefined : redisClient
   );
 
-  if (useCache) providerCache[getProviderCachekey(chainId, redisClient !== undefined)] = provider;
+  if (useCache) providerCache[getProviderCacheKey(chainId, redisClient !== undefined)] = provider;
   return provider;
 }
 

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -387,8 +387,8 @@ function getProviderCachekey(chainId: number, redisEnabled) {
 /**
  * @notice should be used after `getProvider` has been called once to fetch an already cached provider.
  * This will never return undefined since it will throw if the requested provider hasn't been cached.
- * @param chainId 
- * @param redisEnabled 
+ * @param chainId
+ * @param redisEnabled
  * @returns ethers.provider
  */
 export function getCachedProvider(chainId: number, redisEnabled = true): RetryProvider {
@@ -397,7 +397,12 @@ export function getCachedProvider(chainId: number, redisEnabled = true): RetryPr
   return providerCache[getProviderCachekey(chainId, redisEnabled)];
 }
 
-export function getProvider(chainId: number, logger?: winston.Logger, redisClient?: RedisClient, useCache = true): RetryProvider {
+export function getProvider(
+  chainId: number,
+  logger?: winston.Logger,
+  redisClient?: RedisClient,
+  useCache = true
+): RetryProvider {
   if (useCache) {
     const cachedProvider = providerCache[getProviderCachekey(chainId, redisClient !== undefined)];
     if (cachedProvider) return cachedProvider;

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -380,9 +380,26 @@ class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
 // Global provider cache to avoid creating multiple providers for the same chain.
 const providerCache: { [chainId: number]: RetryProvider } = {};
 
-export function getProvider(chainId: number, logger?: winston.Logger, redisClient?: RedisClient, useCache = true) {
+function getProviderCachekey(chainId: number, redisEnabled) {
+  return `${chainId}_${redisEnabled ? "cache" : "nocache"}`;
+}
+
+/**
+ * @notice should be used after `getProvider` has been called once to fetch an already cached provider.
+ * This will never return undefined since it will throw if the requested provider hasn't been cached.
+ * @param chainId 
+ * @param redisEnabled 
+ * @returns ethers.provider
+ */
+export function getCachedProvider(chainId: number, redisEnabled = true): RetryProvider {
+  if (!providerCache[getProviderCachekey(chainId, redisEnabled)])
+    throw new Error(`No cached provider for chainId ${chainId} and redisEnabled ${redisEnabled}`);
+  return providerCache[getProviderCachekey(chainId, redisEnabled)];
+}
+
+export function getProvider(chainId: number, logger?: winston.Logger, redisClient?: RedisClient, useCache = true): RetryProvider {
   if (useCache) {
-    const cachedProvider = providerCache[chainId];
+    const cachedProvider = providerCache[getProviderCachekey(chainId, redisClient !== undefined)];
     if (cachedProvider) return cachedProvider;
   }
   const {
@@ -469,7 +486,7 @@ export function getProvider(chainId: number, logger?: winston.Logger, redisClien
     disableProviderCache ? undefined : redisClient
   );
 
-  if (useCache) providerCache[chainId] = provider;
+  if (useCache) providerCache[getProviderCachekey(chainId, redisClient !== undefined)] = provider;
   return provider;
 }
 


### PR DESCRIPTION
This fixes an issue where the order in which `getProvider()` is called determines which kind of provider is cached: either one with redis or without. However, `getProvider` should always return the expected "cached" provider, with redis or without as the caller expects.

This PR fixes the issue by caching the provider with its redis flag.

Additionally, any calls in the repo to `getProvider` are all modified to be called the same way, with `redis` enabled.