### PR TITLE
fix: Filter out tokens that don't have any non-mainnet destination chains before calling /limits

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -72,7 +72,14 @@ export class AcrossApiClient {
       })
     );
     for (let i = 0; i < tokensQuery.length; i++) {
-      if (data[i] === undefined) continue;
+      if (data[i] === undefined) {
+        this.logger.debug({
+          at: "AcrossAPIClient",
+          message: "No valid deposit routes for token, skipping",
+          token: tokensQuery[i],
+        });
+        continue;
+      }
       const l1Token = tokensQuery[i];
       this.limits[l1Token] = data[i].maxDeposit;
     }

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -63,7 +63,7 @@ export class AcrossApiClient {
           return (
             mainnetSpokePoolClient.isDepositRouteEnabled(l1Token, Number(chainId)) &&
             Number(chainId) !== CHAIN_IDs.MAINNET &&
-            CHAIN_ID_LIST_INDICES.includes(Number(chainId));
+            CHAIN_ID_LIST_INDICES.includes(Number(chainId))
           );
         });
         // No valid deposit routes from mainnet for this token. We won't record a limit for it.

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -4,6 +4,7 @@ import get from "lodash.get";
 import { HubPoolClient } from "./HubPoolClient";
 import { CHAIN_ID_LIST_INDICES } from "../common";
 import { constants } from "@across-protocol/sdk-v2";
+import { SpokePoolClientsByChain } from "../interfaces";
 const { TOKEN_SYMBOLS_MAP, CHAIN_IDs } = constants;
 
 export interface DepositLimits {
@@ -21,6 +22,7 @@ export class AcrossApiClient {
   constructor(
     readonly logger: winston.Logger,
     readonly hubPoolClient: HubPoolClient,
+    readonly spokePoolClients: SpokePoolClientsByChain,
     readonly tokensQuery: string[] = [],
     readonly timeout: number = 60000
   ) {
@@ -51,18 +53,26 @@ export class AcrossApiClient {
     // - Store the max deposit limit for each L1 token. DestinationChainId doesn't matter since HubPool
     // liquidity is shared for all tokens and affects maxDeposit. We don't care about maxDepositInstant
     // when deciding whether a relay will be refunded.
+    const mainnetSpokePoolClient = this.spokePoolClients[this.hubPoolClient.chainId];
+    if (!mainnetSpokePoolClient.isUpdated)
+      throw new Error(`Mainnet SpokePoolClient for chainId must be updated before AcrossAPIClient`);
     const data = await Promise.all(
       tokensQuery.map((l1Token) => {
         const l2TokenAddresses = getL2TokenAddresses(l1Token);
-        const validDestinationChainForL1Token = Number(
+        const validDestinationChainForL1Token = 
           Object.keys(l2TokenAddresses).find(
-            (chainId) => Number(chainId) !== CHAIN_IDs.MAINNET && CHAIN_ID_LIST_INDICES.includes(Number(chainId))
+            (chainId) => {
+              return mainnetSpokePoolClient.isDepositRouteEnabled(l1Token, Number(chainId)) && Number(chainId) !== CHAIN_IDs.MAINNET && CHAIN_ID_LIST_INDICES.includes(Number(chainId))
+            }
           )
-        );
-        return this.callLimits(l1Token, validDestinationChainForL1Token);
+        ;
+        // No valid deposit routes from mainnet for this token. We won't record a limit for it.
+        if (validDestinationChainForL1Token === undefined) return undefined;
+        return this.callLimits(l1Token, Number(validDestinationChainForL1Token));
       })
-    );
+    )
     for (let i = 0; i < tokensQuery.length; i++) {
+      if (data[i] === undefined) continue;
       const l1Token = tokensQuery[i];
       this.limits[l1Token] = data[i].maxDeposit;
     }

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -75,7 +75,7 @@ export class AcrossApiClient {
       if (data[i] === undefined) {
         this.logger.debug({
           at: "AcrossAPIClient",
-          message: "No valid deposit routes for token, skipping",
+          message: "No valid deposit routes for enabled LP token, skipping",
           token: tokensQuery[i],
         });
         continue;

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -55,22 +55,22 @@ export class AcrossApiClient {
     // when deciding whether a relay will be refunded.
     const mainnetSpokePoolClient = this.spokePoolClients[this.hubPoolClient.chainId];
     if (!mainnetSpokePoolClient.isUpdated)
-      throw new Error(`Mainnet SpokePoolClient for chainId must be updated before AcrossAPIClient`);
+      throw new Error("Mainnet SpokePoolClient for chainId must be updated before AcrossAPIClient");
     const data = await Promise.all(
       tokensQuery.map((l1Token) => {
         const l2TokenAddresses = getL2TokenAddresses(l1Token);
-        const validDestinationChainForL1Token = 
-          Object.keys(l2TokenAddresses).find(
-            (chainId) => {
-              return mainnetSpokePoolClient.isDepositRouteEnabled(l1Token, Number(chainId)) && Number(chainId) !== CHAIN_IDs.MAINNET && CHAIN_ID_LIST_INDICES.includes(Number(chainId))
-            }
-          )
-        ;
+        const validDestinationChainForL1Token = Object.keys(l2TokenAddresses).find((chainId) => {
+          return (
+            mainnetSpokePoolClient.isDepositRouteEnabled(l1Token, Number(chainId)) &&
+            Number(chainId) !== CHAIN_IDs.MAINNET &&
+            CHAIN_ID_LIST_INDICES.includes(Number(chainId));
+          );
+        });
         // No valid deposit routes from mainnet for this token. We won't record a limit for it.
         if (validDestinationChainForL1Token === undefined) return undefined;
         return this.callLimits(l1Token, Number(validDestinationChainForL1Token));
       })
-    )
+    );
     for (let i = 0; i < tokensQuery.length; i++) {
       if (data[i] === undefined) continue;
       const l1Token = tokensQuery[i];

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -34,7 +34,12 @@ export async function constructRelayerClients(
     config.hubPoolChainId
   );
 
-  const acrossApiClient = new AcrossApiClient(logger, commonClients.hubPoolClient, spokePoolClients, config.relayerTokens);
+  const acrossApiClient = new AcrossApiClient(
+    logger,
+    commonClients.hubPoolClient,
+    spokePoolClients,
+    config.relayerTokens
+  );
   const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);
 
   // If `relayerDestinationChains` is a non-empty array, then copy its value, otherwise default to all chains.

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -34,7 +34,7 @@ export async function constructRelayerClients(
     config.hubPoolChainId
   );
 
-  const acrossApiClient = new AcrossApiClient(logger, commonClients.hubPoolClient, config.relayerTokens);
+  const acrossApiClient = new AcrossApiClient(logger, commonClients.hubPoolClient, spokePoolClients, config.relayerTokens);
   const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);
 
   // If `relayerDestinationChains` is a non-empty array, then copy its value, otherwise default to all chains.

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -97,7 +97,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
       },
       {
         relayerTokens: [],
@@ -176,7 +176,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
       },
       {
         relayerTokens: [],
@@ -212,7 +212,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
       },
       {
         relayerTokens: [],
@@ -300,7 +300,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -84,7 +84,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -84,7 +84,7 @@ describe("Relayer: Token balance shortfall", async function () {
         profitClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
       },
       {
         relayerTokens: [],

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -100,7 +100,7 @@ describe("Relayer: Unfilled Deposits", async function () {
         tokenClient,
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
-        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient),
+        acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
       },
       {
         relayerTokens: [],


### PR DESCRIPTION
For example, BOBA has no destination chains besides 1 so there is no need to call /limits on it