### PR TITLE
fix: Dataworker should count a chain as disabled if it is disabled at mainnet bundle end block

### DIFF
--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -206,6 +206,12 @@ export class AcrossConfigStoreClient {
       .sort((a, b) => a - b);
   }
 
+  getEnabledChains(block = Number.MAX_SAFE_INTEGER, allPossibleChains = CHAIN_ID_LIST_INDICES): number[] {
+    // Get most recent disabled chain list before the block specified.
+    const currentlyDisabledChains = this.getDisabledChainsForBlock(block);
+    return allPossibleChains.filter((chainId) => !currentlyDisabledChains.includes(chainId));
+  }
+
   getDisabledChainsForBlock(blockNumber: number = Number.MAX_SAFE_INTEGER): number[] {
     return (
       sortEventsDescending(this.cumulativeDisabledChainUpdates).find((config) => config.blockNumber <= blockNumber)

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -391,12 +391,8 @@ export async function getWidestPossibleExpectedBlockRange(
   latestMainnetBlock: number,
   mainnetBundleEndBlock: number
 ): Promise<number[][]> {
-  const enabledChains = clients.configStoreClient.getEnabledChainsInBlockRange(
-    clients.hubPoolClient.getNextBundleStartBlockNumber(
-      chainIdListForBundleEvaluationBlockNumbers,
-      mainnetBundleEndBlock,
-      1
-    ),
+  // A chain is only enabled for a bundle range if it was not disabled at the time of the mainnet bundle end block.
+  const enabledChains = clients.configStoreClient.getEnabledChains(
     mainnetBundleEndBlock,
     chainIdListForBundleEvaluationBlockNumbers
   );


### PR DESCRIPTION
Currently dataworker only treats a chain as disabled if it disabled for entire block range, this is a bug as it should be disabled as soon as the bundle's end block is greater than the time the chain was added to the disabled list