### PR TITLE
fix: Subtract buffer from mainnet bundle end block when proposing new  bundle

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -269,7 +269,7 @@ export class Dataworker {
     // to construct the potential next bundle block range.
     const blockRangesForProposal = await this._getWidestPossibleBlockRangeForNextBundle(
       spokePoolClients,
-      this.clients.hubPoolClient.latestBlockNumber
+      this.clients.hubPoolClient.latestBlockNumber - this.blockRangeEndBlockBuffer[1]
     );
 
     // Exit early if spoke pool clients don't have early enough event data to satisfy block ranges for the


### PR DESCRIPTION
This opens the dataworker to slight chance that "latest" disabled chain list isn't valid for a bundle because the bundle lags `latest` by 100 blocks