### PR TITLE
fix: Should pass in latestMainnetBlock into `hubPoolClient.getLatestBundleEndBlockForChain`

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -107,7 +107,10 @@ export class BundleDataClient {
       getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber,
-      this.clients.hubPoolClient.latestBlockNumber
+      this.clients.configStoreClient.getEnabledChains(
+        this.clients.hubPoolClient.latestBlockNumber,
+        this.chainIdListForBundleEvaluationBlockNumbers
+      )
     );
     // Refunds that will be processed in the next bundle that will be proposed after the current pending bundle
     // (if any) has been fully executed.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1635,7 +1635,10 @@ export class Dataworker {
       getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber,
-      mainnetBundleEndBlock
+      this.clients.configStoreClient.getEnabledChains(
+        mainnetBundleEndBlock,
+        this.chainIdListForBundleEvaluationBlockNumbers
+      )
     );
   }
 }

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -470,7 +470,10 @@ export function generateMarkdownForRootBundle(
   // Create helpful logs to send to slack transport
   let bundleBlockRangePretty = "";
   chainIdListForBundleEvaluationBlockNumbers.forEach((chainId, index) => {
-    bundleBlockRangePretty += `\n\t\t${chainId}: ${JSON.stringify(bundleBlockRange[index])}`;
+    const isChainDisabled = bundleBlockRange[index][0] === bundleBlockRange[index][1];
+    bundleBlockRangePretty += `\n\t\t${chainId}: ${JSON.stringify(bundleBlockRange[index])}${
+      isChainDisabled ? " 🥶" : ""
+    }`;
   });
 
   const convertTokenListFromWei = (chainId: number, tokenAddresses: string[], weiVals: string[]) => {

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -389,20 +389,15 @@ export async function getWidestPossibleExpectedBlockRange(
   endBlockBuffers: number[],
   clients: Clients,
   latestMainnetBlock: number,
-  mainnetBundleEndBlock: number
+  enabledChains: number[]
 ): Promise<number[][]> {
-  // A chain is only enabled for a bundle range if it was not disabled at the time of the mainnet bundle end block.
-  const enabledChains = clients.configStoreClient.getEnabledChains(
-    mainnetBundleEndBlock,
-    chainIdListForBundleEvaluationBlockNumbers
-  );
   return chainIdListForBundleEvaluationBlockNumbers.map((chainId: number, index) => {
     // If chain is disabled, re-use the latest bundle end block for the chain as both the start
     // and end block.
     if (!enabledChains.includes(chainId)) {
       const lastEndBlockForDisabledChain = clients.hubPoolClient.getLatestBundleEndBlockForChain(
         chainIdListForBundleEvaluationBlockNumbers,
-        mainnetBundleEndBlock,
+        latestMainnetBlock,
         chainId
       );
       return [lastEndBlockForDisabledChain, lastEndBlockForDisabledChain];

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -179,7 +179,10 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
     getEndBlockBuffers(dataworker.chainIdListForBundleEvaluationBlockNumbers, dataworker.blockRangeEndBlockBuffer),
     clients,
     priceRequestBlock,
-    mainnetBundleEndBlock
+    clients.configStoreClient.getEnabledChains(
+      mainnetBundleEndBlock,
+      dataworker.chainIdListForBundleEvaluationBlockNumbers
+    )
   );
 
   // Validate the event:

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -381,7 +381,10 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
         getEndBlockBuffers(dataworker.chainIdListForBundleEvaluationBlockNumbers, dataworker.blockRangeEndBlockBuffer),
         clients,
         bundle.blockNumber,
-        mainnetBundleEndBlock
+        clients.configStoreClient.getEnabledChains(
+          mainnetBundleEndBlock,
+          dataworker.chainIdListForBundleEvaluationBlockNumbers
+        )
       );
       const blockRangesImpliedByBundleEndBlocks = widestPossibleExpectedBlockRange.map((blockRange, index) => [
         blockRange[0],

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -60,6 +60,22 @@ describe("Dataworker block range-related utility methods", async function () {
     );
     expect(startingWidestBlocks).to.deep.equal(latestBlocks.map((endBlock) => [0, endBlock]));
 
+    // Sets end block to start block if chain is not on enabled chain list.
+    const disabledChainEndBlocks = await getWidestPossibleExpectedBlockRange(
+      chainIdListForBundleEvaluationBlockNumbers,
+      spokePoolClients,
+      defaultEndBlockBuffers,
+      dataworkerClients,
+      latestMainnetBlock,
+      chainIdListForBundleEvaluationBlockNumbers.slice(1)
+    );
+    expect(disabledChainEndBlocks).to.deep.equal(
+      latestBlocks.map((endBlock, i) => {
+        if (i === 0) return [0, 0];
+        else return [0, endBlock];
+      })
+    );
+
     // End block defaults to 0 if buffer is too large
     const largeBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(1000);
     const zeroRange = await getWidestPossibleExpectedBlockRange(

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -56,7 +56,7 @@ describe("Dataworker block range-related utility methods", async function () {
       defaultEndBlockBuffers,
       dataworkerClients,
       latestMainnetBlock,
-      latestMainnetBlock
+      chainIdListForBundleEvaluationBlockNumbers
     );
     expect(startingWidestBlocks).to.deep.equal(latestBlocks.map((endBlock) => [0, endBlock]));
 
@@ -68,7 +68,7 @@ describe("Dataworker block range-related utility methods", async function () {
       largeBuffers,
       dataworkerClients,
       latestMainnetBlock,
-      latestMainnetBlock
+      chainIdListForBundleEvaluationBlockNumbers
     );
     expect(zeroRange).to.deep.equal(latestBlocks.map((_) => [0, 0]));
   });


### PR DESCRIPTION
Also includes a refactor to pass in `enabledChains` into `getWidestPossibleBlockNumbers` which means we don't need to pass in `mainnetBundleEndBlock` to the function because its only used to get enabled chains

This will also make it easier to unit test `getWidestPossibleBlockNumbers`