### PR TITLE
improve: Quieter logs for deposits over limit

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -172,9 +172,12 @@ export class Relayer {
           at: "Relayer",
           message: "😱 Skipping deposit with greater unfilled amount than API suggested limit",
           limit: this.clients.acrossApiClient.getLimit(l1Token.address),
-          unfilledAmount: unfilledAmount.toString(),
           l1Token: l1Token.address,
-          deposit,
+          depositId: deposit.depositId,
+          amount: deposit.amount,
+          unfilledAmount: unfilledAmount.toString(),
+          originChainId: deposit.originChainId,
+          transactionHash: deposit.transactionHash,
         });
         continue;
       }


### PR DESCRIPTION
This should include the bare minimum that we need to find the deposit. Additionally,
logging the deposit amount vs. unfilledAmount makes it easy to quickly see whether
a slow fill has been initiated.