### PR TITLE
improve(TransactionUtils): Retry txn on REPLACEMENT_UNDERPRICED

### DIFF
--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -53,6 +53,7 @@ export async function runTransaction(
       retriesRemaining > 0 &&
       (error?.code === "NONCE_EXPIRED" ||
         error?.code === "INSUFFICIENT_FUNDS" ||
+        error?.code === "REPLACEMENT_UNDERPRICED" ||
         error?.message.includes("intrinsic gas too low"))
     ) {
       // If error is due to a nonce collision or gas underpricement then re-submit to fetch latest params.


### PR DESCRIPTION
This likely happens when there is a collision between multiple relayer instances.