### PR TITLE
fix: fix multiple bugs in BalanceAllocator

### DIFF
--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -1,8 +1,8 @@
-import { BigNumber, ERC20, ethers, ZERO_ADDRESS } from "../utils";
+import { BigNumber, ERC20, ethers, ZERO_ADDRESS, min } from "../utils";
 import lodash from "lodash";
 
 // This type is used to map used and current balances of different users.
-interface BalanceMap {
+export interface BalanceMap {
   [chainId: number]: {
     [token: string]: {
       [holder: string]: BigNumber;
@@ -22,12 +22,8 @@ export class BalanceAllocator {
   async requestBalanceAllocations(
     requests: { chainId: number; tokens: string[]; holder: string; amount: BigNumber }[]
   ): Promise<boolean> {
-    // Validate that all input tokens are unique.
-    const tokens = requests.map(({ tokens }) => tokens.map((token) => token.toLowerCase())).flat();
-    if (!lodash.uniq(tokens)) throw new Error("BalanceAllocator::requestBalanceAllocations input tokens not unique!");
-
     // Do all async work up-front to avoid atomicity problems with updating used.
-    const requestsWithbalances = await Promise.all(
+    const requestsWithBalances = await Promise.all(
       requests.map(async (request) => {
         const balances = Object.fromEntries(
           await Promise.all(
@@ -48,27 +44,42 @@ export class BalanceAllocator {
       })
     );
 
-    // Determine if the entire group will be successful.
-    const success = requestsWithbalances.every(({ chainId, tokens, holder, amount, balances }) => {
-      const availableBalance = tokens.reduce(
-        (acc, token) => acc.add(balances[token].sub(this.getUsed(chainId, token, holder))),
-        BigNumber.from(0)
-      );
-      return availableBalance.gte(amount);
-    });
+    // Construct a map of available balances for all requests, taking into account used and balances.
+    const availableBalances: BalanceMap = {};
+    for (const request of requestsWithBalances) {
+      if (!availableBalances[request.chainId]) availableBalances[request.chainId] = {};
+      for (const token of request.tokens) {
+        if (!availableBalances[request.chainId][token]) availableBalances[request.chainId][token] = {};
+        availableBalances[request.chainId][token][request.holder] = request.balances[token].sub(
+          this.getUsed(request.chainId, token, request.holder)
+        );
+      }
+    }
+
+    // Determine if the entire group will be successful by subtracting the amount from the available balance as we go.
+    for (const request of requestsWithBalances) {
+      const remainingAmount = request.tokens.reduce((acc, token) => {
+        const availableBalance = availableBalances[request.chainId][token][request.holder];
+        const amountToDeduct = min(acc, availableBalance);
+        if (amountToDeduct.gt(0))
+          availableBalances[request.chainId][token][request.holder] = availableBalance.sub(amountToDeduct);
+        return acc.sub(amountToDeduct);
+      }, request.amount);
+      // If there is a remaining amount, the entire group will fail, so return false.
+      if (remainingAmount.gt(0)) return false;
+    }
 
     // If the entire group is successful commit to using these tokens.
-    if (success)
-      requestsWithbalances.forEach(({ chainId, tokens, holder, balances, amount }) =>
-        tokens.forEach((token) => {
-          const used = amount.gt(balances[token]) ? balances[token] : amount;
-          this.addUsed(chainId, token, holder, used);
-          amount = amount.sub(used);
-        })
-      );
+    requestsWithBalances.forEach(({ chainId, tokens, holder, balances, amount }) =>
+      tokens.forEach((token) => {
+        const used = min(amount, balances[token].sub(this.getUsed(chainId, token, holder)));
+        this.addUsed(chainId, token, holder, used);
+        amount = amount.sub(used);
+      })
+    );
 
     // Return success.
-    return success;
+    return true;
   }
 
   async requestBalanceAllocation(
@@ -82,15 +93,15 @@ export class BalanceAllocator {
 
   async getBalance(chainId: number, token: string, holder: string) {
     if (!this.balances?.[chainId]?.[token]?.[holder]) {
-      const balance =
-        token === ZERO_ADDRESS
-          ? await this.providers[chainId].getBalance(holder)
-          : await ERC20.connect(token, this.providers[chainId]).balanceOf(holder);
-
-      // Note: cannot use assign because it breaks the BigNumber object.
-      if (!this.balances[chainId]) this.balances[chainId] = {};
-      if (!this.balances[chainId][token]) this.balances[chainId][token] = {};
-      this.balances[chainId][token][holder] = balance;
+      const balance = await this._queryBalance(chainId, token, holder);
+      // To avoid inconsitencies, we recheck the balances value after the query.
+      // If it exists, skip the assignment so the value doesn't change after being set.
+      if (!this.balances?.[chainId]?.[token]?.[holder]) {
+        // Note: cannot use assign because it breaks the BigNumber object.
+        if (!this.balances[chainId]) this.balances[chainId] = {};
+        if (!this.balances[chainId][token]) this.balances[chainId][token] = {};
+        this.balances[chainId][token][holder] = balance;
+      }
     }
     return this.balances[chainId][token][holder];
   }
@@ -116,5 +127,12 @@ export class BalanceAllocator {
 
   clearBalances() {
     this.balances = {};
+  }
+
+  // This method is primarily here to be overriden for testing purposes.
+  protected async _queryBalance(chainId: number, token: string, holder: string): Promise<BigNumber> {
+    return token === ZERO_ADDRESS
+      ? await this.providers[chainId].getBalance(holder)
+      : await ERC20.connect(token, this.providers[chainId]).balanceOf(holder);
   }
 }

--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -98,7 +98,7 @@ export class BalanceAllocator {
       // If it exists, skip the assignment so the value doesn't change after being set.
       if (!this.balances?.[chainId]?.[token]?.[holder]) {
         // Note: cannot use assign because it breaks the BigNumber object.
-        if (!this.balances[chainId]) this.balances[chainId] = {};
+        this.balances[chainId] ??= {};
         if (!this.balances[chainId][token]) this.balances[chainId][token] = {};
         this.balances[chainId][token][holder] = balance;
       }

--- a/src/utils/BigNumberUtils.ts
+++ b/src/utils/BigNumberUtils.ts
@@ -3,3 +3,7 @@ import { BigNumber } from ".";
 export function max(a: BigNumber, b: BigNumber): BigNumber {
   return a.gt(b) ? a : b;
 }
+
+export function min(a: BigNumber, b: BigNumber): BigNumber {
+  return a.gt(b) ? b : a;
+}

--- a/test/BalanceAllocator.ts
+++ b/test/BalanceAllocator.ts
@@ -1,0 +1,103 @@
+import { BalanceAllocator, BalanceMap } from "../src/clients/BalanceAllocator";
+import { BigNumber, ethers } from "../src/utils";
+import { randomAddress, chai } from "./utils";
+const { expect } = chai;
+
+class TestBalanceAllocator extends BalanceAllocator {
+  constructor() {
+    super({});
+  }
+
+  mockBalances: BalanceMap = {};
+  setMockBalances(chainId: number, token: string, holder: string, balance?: BigNumber) {
+    // Note: cannot use assign because it breaks the BigNumber object.
+    if (!this.mockBalances[chainId]) this.mockBalances[chainId] = {};
+    if (!this.mockBalances[chainId][token]) this.mockBalances[chainId][token] = {};
+    if (!balance) delete this.mockBalances[chainId][token][holder];
+    else this.mockBalances[chainId][token][holder] = balance;
+  }
+
+  protected _queryBalance(chainId: number, token: string, holder: string): Promise<BigNumber> {
+    if (!this.mockBalances[chainId]?.[token]?.[holder]) throw new Error("No balance!");
+    return Promise.resolve(this.mockBalances[chainId][token][holder]);
+  }
+}
+
+describe("BalanceAllocator", async function () {
+  let balanceAllocator: TestBalanceAllocator;
+  const testToken1 = randomAddress();
+  const testToken2 = randomAddress();
+
+  const testAccount1 = randomAddress();
+  const testAccount2 = randomAddress();
+
+  beforeEach(async function () {
+    balanceAllocator = new TestBalanceAllocator();
+  });
+
+  it("Correct initial state", async function () {
+    balanceAllocator.setMockBalances(1, testToken1, testAccount1, BigNumber.from(100));
+    expect(await balanceAllocator.getBalance(1, testToken1, testAccount1)).to.equal(BigNumber.from(100));
+    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(0));
+  });
+
+  it("Add used", async function () {
+    balanceAllocator.addUsed(1, testToken1, testAccount1, BigNumber.from(100));
+    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(100));
+  });
+
+  it("Simple request", async function () {
+    balanceAllocator.setMockBalances(1, testToken1, testAccount1, BigNumber.from(100));
+    expect(await balanceAllocator.requestBalanceAllocation(1, [testToken1], testAccount1, BigNumber.from(50))).to.be
+      .true;
+    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(50));
+  });
+
+  it("Multiple requests, multiple tokens, succeeds", async function () {
+    balanceAllocator.setMockBalances(1, testToken1, testAccount1, BigNumber.from(100));
+    balanceAllocator.setMockBalances(1, testToken2, testAccount1, BigNumber.from(100));
+    expect(
+      await balanceAllocator.requestBalanceAllocations([
+        { chainId: 1, tokens: [testToken1], holder: testAccount1, amount: BigNumber.from(50) },
+        { chainId: 1, tokens: [testToken2], holder: testAccount1, amount: BigNumber.from(50) },
+      ])
+    ).to.be.true;
+    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(50));
+    expect(balanceAllocator.getUsed(1, testToken2, testAccount1)).to.equal(BigNumber.from(50));
+  });
+
+  it("Combined request, same token, succeeds", async function () {
+    balanceAllocator.setMockBalances(1, testToken1, testAccount1, BigNumber.from(100));
+    expect(
+      await balanceAllocator.requestBalanceAllocations([
+        { chainId: 1, tokens: [testToken1], holder: testAccount1, amount: BigNumber.from(50) },
+        { chainId: 1, tokens: [testToken1], holder: testAccount1, amount: BigNumber.from(50) },
+      ])
+    ).to.be.true;
+    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(100));
+  });
+
+  it("Combined request, same token, fails", async function () {
+    balanceAllocator.setMockBalances(1, testToken1, testAccount1, BigNumber.from(99));
+    expect(
+      await balanceAllocator.requestBalanceAllocations([
+        { chainId: 1, tokens: [testToken1], holder: testAccount1, amount: BigNumber.from(50) },
+        { chainId: 1, tokens: [testToken1], holder: testAccount1, amount: BigNumber.from(50) },
+      ])
+    ).to.be.false;
+    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(0));
+  });
+
+  it("Combined request, multiple tokens per request, succeeds", async function () {
+    balanceAllocator.setMockBalances(1, testToken1, testAccount1, BigNumber.from(99));
+    balanceAllocator.setMockBalances(1, testToken2, testAccount1, BigNumber.from(99));
+    expect(
+      await balanceAllocator.requestBalanceAllocations([
+        { chainId: 1, tokens: [testToken1, testToken2], holder: testAccount1, amount: BigNumber.from(50) },
+        { chainId: 1, tokens: [testToken1, testToken2], holder: testAccount1, amount: BigNumber.from(50) },
+      ])
+    ).to.be.true;
+    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(99));
+    expect(balanceAllocator.getUsed(1, testToken2, testAccount1)).to.equal(BigNumber.from(1));
+  });
+});


### PR DESCRIPTION
There are a few bugs in the BalanceAllocator.

1. If you send a request containing two requested allocations for the same token, it will not account for the first allocation impacting the second.
2. If you send a request with multiple tokens and it needed to use multiple tokens to fulfil it, it would ignore the previously used amount when deciding how to increment used.

These two scenarios are the last two tests added in the test file. I verified that these failed in the previous version, but succeed after these changes.