### PR TITLE
Remove logging of quorum (accepted) RPC response

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -342,7 +342,6 @@ class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
         message: "Some providers mismatched with the quorum result or failed 🚸",
         method,
         params,
-        quorumResult,
         quorumProviders,
         mismatchedProviders,
         erroringProviders: errors.map(([provider, errorText]) => formatProviderError(provider, errorText)),


### PR DESCRIPTION
Logging the complete accepted response tends to be very spammy.