### PR TITLE
fix(SpokePoolClient): Don't call eth_call on "latest"

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -260,7 +260,9 @@ export class SpokePoolClient {
   async binarySearchForBlockContainingDepositId(
     targetDepositId: number,
     initLow = this.spokePoolDeploymentBlock,
-    initHigh = this.latestBlockNumber
+    initHigh = this.latestBlockNumber-1 // Calling eth_call at 'latest' doesn't use quorum. Moreover, we 
+    // will never realistically be looking for the "latest" block using this function, so its safe to set
+    // this earlier than latest.
   ): Promise<number> {
     assert(initLow <= initHigh, "Binary search failed because low > high");
     let low = initLow;

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -260,7 +260,7 @@ export class SpokePoolClient {
   async binarySearchForBlockContainingDepositId(
     targetDepositId: number,
     initLow = this.spokePoolDeploymentBlock,
-    initHigh = this.latestBlockNumber-1 // Calling eth_call at 'latest' doesn't use quorum. Moreover, we 
+    initHigh = this.latestBlockNumber - 1 // Calling eth_call at 'latest' doesn't use quorum. Moreover, we
     // will never realistically be looking for the "latest" block using this function, so its safe to set
     // this earlier than latest.
   ): Promise<number> {


### PR DESCRIPTION
We noticed that eth_call doesn't seem to be using the quorum provider, and this is the likely suspect