### PR TITLE
improve(BundleDataClient): Log exact invalid fills

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -337,6 +337,7 @@ export class BundleDataClient {
         message: "Finished loading spoke pool data and found some invalid fills in range",
         blockRangesForChains,
         allInvalidFillsInRangeByDestinationChain: spokeEventsReadable.allInvalidFillsInRangeByDestinationChain,
+        allInvalidFills,
       });
 
     this.loadDataCache[key] = { fillsToRefund, deposits, unfilledDeposits, allValidFills };


### PR DESCRIPTION
Logging the details of the fills we deem invalid will make it a lot easier to investigate when they appear.