### PR TITLE
improve(SpokePoolClient): Drop NODE_MAX_CONCURRENCY

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -402,11 +402,6 @@ export class SpokePoolClient {
 
   async update(eventsToQuery?: string[]) {
     if (this.configStoreClient !== null && !this.configStoreClient.isUpdated) throw new Error("RateModel not updated");
-    const { NODE_MAX_CONCURRENCY } = process.env;
-    // Default to a max concurrency of 1000 requests per node.
-    const nodeMaxConcurrency = Number(
-      process.env[`NODE_MAX_CONCURRENCY_${this.chainId}`] || NODE_MAX_CONCURRENCY || "1000"
-    );
 
     // Require that all Deposits meet the minimum specified number of confirmations.
     const [latestBlockNumber, currentTime] = await Promise.all([
@@ -511,10 +506,7 @@ export class SpokePoolClient {
 
       const dataForQuoteTime: { realizedLpFeePct: BigNumber; quoteBlock: number }[] = await Promise.map(
         depositEvents,
-        async (event) => {
-          return this.computeRealizedLpFeePct(event);
-        },
-        { concurrency: nodeMaxConcurrency }
+        async (event) => this.computeRealizedLpFeePct(event)
       );
 
       // Now add any newly fetched events from RPC.


### PR DESCRIPTION
Testing shows that this configuration has effectively no impact on performance. In practice,
it's limiting how many promises can be concurrently constructed and enqueued - not how
many parallel requests we will issue to the RPC provider. In practice, the limiting is more
effectively applied in the lower layers anyway (i.e. via provider caching/rate-limiting).