### PR TITLE
refactor: :recycle: enable strict on `finalizer` directory

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -201,7 +201,14 @@ export async function finalize(
   }
 }
 
-export async function constructFinalizerClients(_logger: winston.Logger, config, baseSigner: Wallet) {
+export async function constructFinalizerClients(
+  _logger: winston.Logger,
+  config: FinalizerConfig,
+  baseSigner: Wallet
+): Promise<{
+  commonClients: Clients;
+  spokePoolClients: SpokePoolClientsByChain;
+}> {
   const commonClients = await constructClients(_logger, config, baseSigner);
   await updateFinalizerClients(commonClients);
 

--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -39,6 +39,7 @@ export async function finalizeArbitrum(message: L2ToL1MessageWriter): Promise<Mu
   const l2Provider = getCachedProvider(CHAIN_ID, true);
   const proof = await message.getOutboxProof(l2Provider);
   const outbox = new Contract((await getL2Network(l2Provider)).ethBridge.outbox, outboxAbi);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const eventData = (message as any).nitroWriter.event; // nitroWriter is a private property on the
   // L2ToL1MessageWriter class, which we need to form the calldata so unfortunately we must cast to `any`.
   const callData = await outbox.populateTransaction.executeTransaction(

--- a/src/finalizer/utils/polygon.ts
+++ b/src/finalizer/utils/polygon.ts
@@ -32,7 +32,7 @@ export interface PolygonTokensBridged extends TokensBridged {
   payload: string;
 }
 
-export async function getPosClient(mainnetSigner: Wallet) {
+export async function getPosClient(mainnetSigner: Wallet): Promise<POSClient> {
   // Following from https://maticnetwork.github.io/matic.js/docs/pos
   use(Web3ClientPlugin);
   setProofApi("https://apis.matic.network/");
@@ -59,7 +59,7 @@ export async function getFinalizableTransactions(
   logger: winston.Logger,
   tokensBridged: TokensBridged[],
   posClient: POSClient
-) {
+): Promise<PolygonTokensBridged[]> {
   // First look up which L2 transactions were checkpointed to mainnet.
   const isCheckpointed = await Promise.all(
     tokensBridged.map((event) => posClient.exitUtil.isCheckPointed(event.transactionHash))
@@ -150,6 +150,7 @@ export async function multicallPolygonFinalizations(
   const callData = await Promise.all(finalizableMessages.map((event) => finalizePolygon(posClient, event)));
   const tokensInFinalizableMessages = getL2TokensToFinalize(
     finalizableMessages.map((polygonTokensBridged) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { payload, ...tokensBridged } = polygonTokensBridged;
       return tokensBridged;
     })
@@ -198,7 +199,7 @@ export async function retrieveTokenFromMainnetTokenBridger(
   };
 }
 
-export function getL2TokensToFinalize(events: TokensBridged[]) {
+export function getL2TokensToFinalize(events: TokensBridged[]): string[] {
   const l2TokenCountInBridgeEvents = events.reduce((l2TokenDictionary, event) => {
     l2TokenDictionary[event.l2TokenAddress] = true;
     return l2TokenDictionary;


### PR DESCRIPTION
This change corrects for eslint and typescript strict in the finalizer directory