### PR TITLE
fix: :bug: improve logging support for failed multicall txns

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -114,8 +114,7 @@ export class MultiCallerClient {
     // only log the results once, so we need to collate the results into a single object.
     const failedChains = Object.entries(txnHashes)
       .filter(([, { isError }]) => isError)
-      .map(([chainId]) => chainId)
-      .filter((chainId, idx, arr) => arr.indexOf(chainId) === idx);
+      .map(([chainId]) => chainId);
 
     if (failedChains.length > 0) {
       // Log the results.


### PR DESCRIPTION
This change adds a logging and exit condition to the multicaller txn execution. In the event that the transactions fail, the new logic will collate failed txn states and produce an error log. Additionall this fn will propagate the error and lead to an eventual (caught) stack unwind to prevent any further logic