### PR TITLE
fix: fix TTL resolution bug

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -140,10 +140,10 @@ class CacheProvider extends RateLimitedProvider {
       this.network.chainId
     }:eth_getLogs,`;
 
-    const _ttl = Number(process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL);
+    const _ttlVar = process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL;
+    const _ttl = Number(_ttlVar);
     if (isNaN(_ttl) || _ttl <= 0) {
-      const envVar = process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL;
-      throw new Error(`PROVIDER_CACHE_TTL (${envVar}) must be numeric and > 0`);
+      throw new Error(`PROVIDER_CACHE_TTL (${_ttlVar}) must be numeric and > 0`);
     }
     this.baseTTL = _ttl;
   }

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -140,11 +140,12 @@ class CacheProvider extends RateLimitedProvider {
       this.network.chainId
     }:eth_getLogs,`;
 
-    this.baseTTL = Number(process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL);
-    if (isNaN(this.baseTTL) || this.baseTTL <= 0) {
+    const _ttl = Number(process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL);
+    if (isNaN(_ttl) || _ttl <= 0) {
       const envVar = process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL;
       throw new Error(`PROVIDER_CACHE_TTL (${envVar}) must be numeric and > 0`);
     }
+    this.baseTTL = _ttl;
   }
   override async send(method: string, params: Array<any>): Promise<any> {
     if (this.redisClient && (await this.shouldCache(method, params))) {

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -15,12 +15,6 @@ import { Logger } from ".";
 
 const logger = Logger;
 
-const _ttl = Number(process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL);
-if (isNaN(_ttl) || _ttl <= 0) {
-  const envVar = process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL;
-  throw new Error(`PROVIDER_CACHE_TTL (${envVar}) must be numeric and > 0`);
-}
-
 // The async/queue library has a task-based interface for building a concurrent queue.
 // This is the type we pass to define a request "task".
 interface RateLimitTask {
@@ -126,6 +120,7 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
 class CacheProvider extends RateLimitedProvider {
   public readonly getLogsCachePrefix: string;
   public readonly maxReorgDistance: number;
+  public readonly baseTTL: number;
 
   constructor(
     providerCacheNamespace: string,
@@ -144,6 +139,12 @@ class CacheProvider extends RateLimitedProvider {
     this.getLogsCachePrefix = `${providerCacheNamespace},${new URL(this.connection.url).hostname},${
       this.network.chainId
     }:eth_getLogs,`;
+
+    this.baseTTL = Number(process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL);
+    if (isNaN(this.baseTTL) || this.baseTTL <= 0) {
+      const envVar = process.env.PROVIDER_CACHE_TTL ?? PROVIDER_CACHE_TTL;
+      throw new Error(`PROVIDER_CACHE_TTL (${envVar}) must be numeric and > 0`);
+    }
   }
   override async send(method: string, params: Array<any>): Promise<any> {
     if (this.redisClient && (await this.shouldCache(method, params))) {
@@ -161,7 +162,7 @@ class CacheProvider extends RateLimitedProvider {
       const result = await super.send(method, params);
 
       // Apply a random margin to spread expiry over a larger time window.
-      const ttl = _ttl + Math.ceil(lodash.random(-ttl_modifier, ttl_modifier, true) * _ttl);
+      const ttl = this.baseTTL + Math.ceil(lodash.random(-ttl_modifier, ttl_modifier, true) * this.baseTTL);
 
       // Commit result to redis.
       await setRedisKey(redisKey, JSON.stringify(result), this.redisClient, ttl);


### PR DESCRIPTION
This moves TTL resolution into the constructor of the cache provider so the default is defined by the time it runs.