### PR TITLE
feat: Let bot runner set `toBlockOverride` to construct clients for deprecated SpokePools

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -48,7 +48,7 @@ export async function constructSpokePoolClientsWithLookback(
   config: CommonConfig,
   baseSigner: Wallet,
   initialLookBackOverride: number,
-  hubPoolChainId: number,
+  hubPoolChainId: number
 ): Promise<SpokePoolClientsByChain> {
   // Construct spoke pool clients for all chains that were enabled at least once in the block range.
   // Caller can optionally override the disabled chains list, which is useful for executing leaves or validating

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -48,7 +48,7 @@ export async function constructSpokePoolClientsWithLookback(
   config: CommonConfig,
   baseSigner: Wallet,
   initialLookBackOverride: number,
-  hubPoolChainId: number
+  hubPoolChainId: number,
 ): Promise<SpokePoolClientsByChain> {
   // Construct spoke pool clients for all chains that were enabled at least once in the block range.
   // Caller can optionally override the disabled chains list, which is useful for executing leaves or validating
@@ -90,14 +90,14 @@ export async function constructSpokePoolClientsWithLookback(
     )
   );
 
-  // @dev: Set toBlocks = {} to construct spoke pool clients that query until the latest blocks.
+  // @dev: If toBlocks = {} then  construct spoke pool clients that query until the latest blocks.
   return await constructSpokePoolClientsWithStartBlocks(
     logger,
     configStoreClient,
     config,
     baseSigner,
     fromBlocks,
-    {},
+    config.toBlockOverride,
     enabledChains
   );
 }

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -18,6 +18,7 @@ export class CommonConfig {
   readonly multiCallChunkSize: { [chainId: number]: number };
   readonly version: string;
   readonly blockRangeEndBlockBuffer: { [chainId: number]: number };
+  readonly toBlockOverride: Record<number, number> = {};
 
   constructor(env: ProcessEnv) {
     const {
@@ -46,6 +47,15 @@ export class CommonConfig {
         );
       }
     }
+
+    for (const chainId of Constants.CHAIN_ID_LIST_INDICES) {
+      if (env[`TO_BLOCK_OVERRIDE_${chainId}`] !== undefined) {
+        const toBlock = Number(env[`TO_BLOCK_OVERRIDE_${chainId}`]);
+        assert(toBlock > 0, `TO_BLOCK_OVERRIDE_${chainId} must be greater than 0`);
+        this.toBlockOverride[chainId] = toBlock;
+      }
+    }
+
     // `maxRelayerLookBack` is how far we fetch events from, modifying the search config's 'fromBlock'
     this.maxRelayerLookBack = Number(MAX_RELAYER_DEPOSIT_LOOK_BACK ?? Constants.MAX_RELAYER_DEPOSIT_LOOK_BACK);
     this.hubPoolChainId = Number(HUB_CHAIN_ID ?? 1);


### PR DESCRIPTION
This can be used for example to make sure that the `finalizer` continues to finalize events for deprecated spoke pools by setting `TO_BLOCK_OVERRIDE_1=<block-before-spoke-pool-was-deprecated>`.

This is because the function `constructSpokePoolClientsWithLookback` used to create `SpokePoolClient`'s  looks up the enabled SpokePools as of the `toBlock` for chainId=1. Currently the `toBlocks` default to "latest", so this PR allow these to be overridden.