### PR TITLE
fix(SpokePoolClient): Don't reorder on getDeposits()

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -114,7 +114,7 @@ export class SpokePoolClient {
   }
 
   getDeposits(): DepositWithBlock[] {
-    return sortEventsAscendingInPlace(Object.values(this.deposits).flat());
+    return Object.values(this.deposits).flat();
   }
 
   getTokensBridged(): TokensBridged[] {


### PR DESCRIPTION
getDeposits() internally sorts deposit events according to blockNumber. The deposit blockNumber is however the block number corresponding to the quoteTimestamp, not the block number of the deposit transaction. This is a quirk that seems unique to FundsDeposited events.

This method is only used in test, but the re-ordering is incompatible with the new UBA design, where the ordering of SpokePool transactions takes precedence.