### PR TITLE
improve(MockSpokePoolClient): Fixes & simplifications

### DIFF
--- a/test/SpokePoolClient.RefundRequests.ts
+++ b/test/SpokePoolClient.RefundRequests.ts
@@ -19,6 +19,8 @@ let relayer: SignerWithAddress;
 let deploymentBlock: number;
 let spokePoolClient: MockSpokePoolClient;
 
+const event = "RefundRequested";
+
 describe("SpokePoolClient: Refund Requests", async function () {
   beforeEach(async function () {
     [relayer] = await ethers.getSigners();
@@ -39,10 +41,11 @@ describe("SpokePoolClient: Refund Requests", async function () {
     for (let _idx = 0; _idx < 5; ++_idx) {
       const requestArgs: EthersEventTemplate = {
         address: relayer.address,
+        event,
         topics: [relayer.address, originChainId.toString(), ""],
-        args: [],
+        args: {},
       };
-      const testEvent = spokePoolClient.generateRefundRequest(requestArgs);
+      const testEvent = spokePoolClient.generateEvent(requestArgs);
       spokePoolClient.addEvent(testEvent);
       refundRequestEvents.push(spreadEventWithBlockNumber(testEvent) as RefundRequestWithBlock);
     }
@@ -66,12 +69,13 @@ describe("SpokePoolClient: Refund Requests", async function () {
     for (let blockNumber = latestBlockNumber + 1; blockNumber <= minExpectedBlockNumber; ++blockNumber) {
       // Barebones Event - only absolutely necessary fields are populated.
       const requestArgs: EthersEventTemplate = {
-        blockNumber,
         address: relayer.address,
+        event,
         topics: [relayer.address, originChainId.toString(), ""],
-        args: [],
+        args: {},
+        blockNumber,
       };
-      const testEvent = spokePoolClient.generateRefundRequest(requestArgs);
+      const testEvent = spokePoolClient.generateEvent(requestArgs);
       spokePoolClient.addEvent(testEvent);
       refundRequestEvents.push(spreadEventWithBlockNumber(testEvent) as RefundRequestWithBlock);
     }

--- a/test/mocks/MockSpokePoolClient.ts
+++ b/test/mocks/MockSpokePoolClient.ts
@@ -64,8 +64,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
 
     // Ensure an array for every requested event exists, in the requested order.
     // All requested event types must be populated in the array (even if empty).
-    const events: Event[][] = [];
-    eventsToQuery.forEach((_eventName, idx) => (events[idx] ??= []));
+    const events: Event[][] = eventsToQuery.map(() => []);
     this.events.flat().forEach((event) => {
       const idx = eventsToQuery.indexOf(event.event as string);
       if (idx !== -1) {

--- a/test/mocks/MockSpokePoolClient.ts
+++ b/test/mocks/MockSpokePoolClient.ts
@@ -1,13 +1,13 @@
 import { random } from "lodash";
 import { SpokePoolClient, SpokePoolUpdate } from "../../src/clients";
-import { Event } from "../../src/utils";
+import { BigNumberish, Event } from "../../src/utils";
 import { Contract, ethers, winston } from "../utils";
 
 export type EthersEventTemplate = {
   address: string;
   event: string;
   topics: string[];
-  args: Record<string,any>;
+  args: Record<string, BigNumberish | string>;
   data?: string;
   blockNumber?: number;
   transactionIndex?: number;
@@ -30,11 +30,11 @@ export class MockSpokePoolClient extends SpokePoolClient {
     this.latestBlockNumber = deploymentBlock;
   }
 
-  addEvent(event: Event) {
+  addEvent(event: Event): void {
     this.events.push(event);
   }
 
-  setDepositIds(_depositIds: number[]) {
+  setDepositIds(_depositIds: number[]): void {
     this.depositIdAtBlock = [];
     if (_depositIds.length === 0) {
       return;
@@ -98,7 +98,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     FundsDeposited: "uint256,uint256,uint256,int64,uint32,uint32,address,address,address,bytes",
     FilledRelay: "uint256,uint256,uint256,int64,uint32,uint32,address,address,address,bytes",
     RefundRequested: "address,address,uint256,uint256,uint256,int64,uint32,uint256,uint256",
-  }
+  };
 
   // Event topic. Not strictly required, but they make generated events more recognisable.
   // @todo: Source these from contracts-v2, when available.
@@ -106,7 +106,7 @@ export class MockSpokePoolClient extends SpokePoolClient {
     FundsDeposited: "XXX",
     FilledRelay: "XXX",
     RefundRequested: "XXX",
-  }
+  };
 
   generateEvent(inputs: EthersEventTemplate): Event {
     const { address, event, topics, data, args } = inputs;


### PR DESCRIPTION
 - The ethers Event type is a weird hybrid of an array _and_ an Object with k/v pairs. Internally in relayer-v2 EventUtils, we ignore the array members and focus on the named k/v pairs. Therefore, switch the args type from an array to an Object. This enables the named args to be properly extracted and transformed into a proper "...WithBlock" object.

 - Consolidate MockSpokePoolClient event generation, such that the event name is passed in as part of the EthersEventTemplate. This makes it easier to use and reduces repetitive code fragments.

 - Minor optimisation to the way events are fed into the base SpokePoolClient during mocked _update().

 - Increase randomness in transactionHash generation.