### PR TITLE
improve: Fetch gas price when sending gas token

### DIFF
--- a/scripts/sendTokens.ts
+++ b/scripts/sendTokens.ts
@@ -1,4 +1,4 @@
-import { ethers, getSigner, getProvider, ERC20, ZERO_ADDRESS, toBN } from "../src/utils";
+import { ethers, getSigner, getProvider, ERC20, ZERO_ADDRESS, toBN, getGasPrice } from "../src/utils";
 import { askYesNoQuestion } from "./utils";
 import minimist from "minimist";
 const args = minimist(process.argv.slice(2), {
@@ -44,7 +44,8 @@ export async function run(): Promise<void> {
       return;
     }
     console.log("sending...");
-    const tx = await connectedSigner.sendTransaction({ to: recipient, value: toBN(args.amount) });
+    const gas = await getGasPrice(connectedSigner.provider);
+    const tx = await connectedSigner.sendTransaction({ to: recipient, value: toBN(args.amount), ...gas });
     const receipt = await tx.wait();
     console.log("Transaction hash:", receipt.transactionHash);
   }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -21,6 +21,7 @@ import {
   ethers,
   etherscanLink,
   etherscanLinks,
+  getGasPrice,
   getNativeTokenSymbol,
   getNetworkName,
   getUnfilledDeposits,
@@ -425,9 +426,10 @@ export class Monitor {
               });
             } else {
               // Note: We don't multicall sending ETH as its not a contract call.
+              const gas = await getGasPrice(this.clients.spokePoolClients[chainId].spokePool.provider);
               const tx = await (
                 await this.clients.spokePoolClients[chainId].spokePool.signer
-              ).sendTransaction({ to: account, value: deficit });
+              ).sendTransaction({ to: account, value: deficit, ...gas });
               const receipt = await tx.wait();
               this.logger.info({
                 at: "Monitor#refillBalances",


### PR DESCRIPTION
- This specifically fixes a bug often seen on chains like Matic where the ethers automatic gas price setting usually doesn't work
- Motivation for this was to add MATIC config to monitor's refillBalances logic
