### PR TITLE
chore(across-v2.5): Make CHAIN_ID_LIST_INDICES user-configurable

### DIFF
--- a/scripts/disableDepositRoutes.ts
+++ b/scripts/disableDepositRoutes.ts
@@ -1,12 +1,6 @@
 /* eslint-disable no-process-exit */
 import { getSigner, winston, Logger } from "../src/utils";
-import {
-  CHAIN_ID_LIST_INDICES,
-  CommonConfig,
-  constructClients,
-  constructSpokePoolClientsWithStartBlocks,
-  updateClients,
-} from "../src/common";
+import { CommonConfig, constructClients, constructSpokePoolClientsWithStartBlocks, updateClients } from "../src/common";
 
 import minimist from "minimist";
 const args = minimist(process.argv.slice(2), {
@@ -31,7 +25,7 @@ export async function run(logger: winston.Logger): Promise<void> {
     baseSigner,
     {}, // Default setting fromBlocks = deployment blocks
     {}, // Default setting toBlocks = latest
-    CHAIN_ID_LIST_INDICES
+    config.chainIdListIndices
   );
   await Promise.all(Object.values(spokePoolClients).map((client) => client.update(["EnabledDepositRoute"])));
 
@@ -50,7 +44,7 @@ export async function run(logger: winston.Logger): Promise<void> {
     originToken: string;
     depositsEnabled: boolean;
   }[] = [];
-  for (const chainId of CHAIN_ID_LIST_INDICES) {
+  for (const chainId of config.chainIdListIndices) {
     const depositRoutesForChain = spokePoolClients[chainId].getDepositRoutes();
     for (const originToken of Object.keys(depositRoutesForChain)) {
       // If chainId is the one we want to disable, disable every route to every other chain from it.

--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -1,7 +1,6 @@
 import { winston, BigNumber, getL2TokenAddresses } from "../utils";
 import axios, { AxiosError } from "axios";
 import { HubPoolClient } from "./HubPoolClient";
-import { CHAIN_ID_LIST_INDICES } from "../common";
 import { constants } from "@across-protocol/sdk-v2";
 import { SpokePoolClientsByChain } from "../interfaces";
 import _ from "lodash";
@@ -67,7 +66,7 @@ export class AcrossApiClient {
           return (
             mainnetSpokePoolClient.isDepositRouteEnabled(l1Token, Number(chainId)) &&
             Number(chainId) !== CHAIN_IDs.MAINNET &&
-            CHAIN_ID_LIST_INDICES.includes(Number(chainId))
+            Object.keys(this.spokePoolClients).includes(chainId)
           );
         });
         // No valid deposit routes from mainnet for this token. We won't record a limit for it.

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -67,7 +67,8 @@ export class AcrossConfigStoreClient {
     readonly logger: winston.Logger,
     readonly configStore: Contract,
     readonly hubPoolClient: HubPoolClient,
-    readonly eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 }
+    readonly eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 },
+    readonly enabledChainIds: number[] = CHAIN_ID_LIST_INDICES
   ) {
     this.firstBlockToSearch = eventSearchConfig.fromBlock;
     this.blockFinder = new BlockFinder(this.configStore.provider.getBlock.bind(this.configStore.provider));
@@ -190,7 +191,7 @@ export class AcrossConfigStoreClient {
   getEnabledChainsInBlockRange(
     fromBlock: number,
     toBlock = Number.MAX_SAFE_INTEGER,
-    allPossibleChains = CHAIN_ID_LIST_INDICES
+    allPossibleChains = this.enabledChainIds
   ): number[] {
     if (toBlock < fromBlock) {
       throw new Error(`Invalid block range: fromBlock ${fromBlock} > toBlock ${toBlock}`);
@@ -220,7 +221,7 @@ export class AcrossConfigStoreClient {
       .sort((a, b) => a - b);
   }
 
-  getEnabledChains(block = Number.MAX_SAFE_INTEGER, allPossibleChains = CHAIN_ID_LIST_INDICES): number[] {
+  getEnabledChains(block = Number.MAX_SAFE_INTEGER, allPossibleChains = this.enabledChainIds): number[] {
     // Get most recent disabled chain list before the block specified.
     const currentlyDisabledChains = this.getDisabledChainsForBlock(block);
     return allPossibleChains.filter((chainId) => !currentlyDisabledChains.includes(chainId));

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -253,7 +253,8 @@ export async function constructClients(
     logger,
     configStore,
     hubPoolClient,
-    rateModelClientSearchSettings
+    rateModelClientSearchSettings,
+    config.chainIdListIndices
   );
 
   const multiCallerClient = new MultiCallerClient(logger, config.multiCallChunkSize, hubSigner);

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -18,6 +18,7 @@ export class CommonConfig {
   readonly multiCallChunkSize: { [chainId: number]: number };
   readonly version: string;
   readonly blockRangeEndBlockBuffer: { [chainId: number]: number };
+  readonly chainIdListIndices: number[];
 
   constructor(env: ProcessEnv) {
     const {
@@ -30,8 +31,13 @@ export class CommonConfig {
       SEND_TRANSACTIONS,
       BUNDLE_REFUND_LOOKBACK,
       SPOKE_POOL_CHAINS_OVERRIDE,
+      CHAIN_ID_LIST_OVERRIDE,
       ACROSS_BOT_VERSION,
     } = env;
+
+    this.chainIdListIndices = CHAIN_ID_LIST_OVERRIDE
+      ? JSON.parse(CHAIN_ID_LIST_OVERRIDE)
+      : Constants.CHAIN_ID_LIST_INDICES;
 
     this.version = ACROSS_BOT_VERSION ?? "unknown";
 
@@ -39,7 +45,7 @@ export class CommonConfig {
       ? JSON.parse(BLOCK_RANGE_END_BLOCK_BUFFER)
       : Constants.BUNDLE_END_BLOCK_BUFFERS;
     if (Object.keys(this.blockRangeEndBlockBuffer).length > 0) {
-      for (const chainId of Constants.CHAIN_ID_LIST_INDICES) {
+      for (const chainId of this.chainIdListIndices) {
         assert(
           Object.keys(this.blockRangeEndBlockBuffer).includes(chainId.toString()),
           "BLOCK_RANGE_END_BLOCK_BUFFER missing networks"
@@ -53,7 +59,7 @@ export class CommonConfig {
     this.spokePoolChainsOverride = SPOKE_POOL_CHAINS_OVERRIDE ? JSON.parse(SPOKE_POOL_CHAINS_OVERRIDE) : [];
     this.maxBlockLookBack = MAX_BLOCK_LOOK_BACK ? JSON.parse(MAX_BLOCK_LOOK_BACK) : {};
     if (Object.keys(this.maxBlockLookBack).length > 0) {
-      for (const chainId of Constants.CHAIN_ID_LIST_INDICES) {
+      for (const chainId of this.chainIdListIndices) {
         assert(Object.keys(this.maxBlockLookBack).includes(chainId.toString()), "MAX_BLOCK_LOOK_BACK missing networks");
       }
     } else {
@@ -65,7 +71,7 @@ export class CommonConfig {
 
     // Multicall chunk size precedence: Environment, chain-specific config, global default.
     this.multiCallChunkSize = Object.fromEntries(
-      Constants.CHAIN_ID_LIST_INDICES.map((_chainId) => {
+      this.chainIdListIndices.map((_chainId) => {
         const chainId = Number(_chainId);
         // prettier-ignore
         const chunkSize = Number(

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -1,7 +1,6 @@
 import winston from "winston";
 import { DataworkerConfig } from "./DataworkerConfig";
 import {
-  CHAIN_ID_LIST_INDICES,
   Clients,
   constructClients,
   constructSpokePoolClientsWithStartBlocks,
@@ -36,7 +35,7 @@ export async function constructDataworkerClients(
     logger,
     commonClients,
     {},
-    CHAIN_ID_LIST_INDICES,
+    config.chainIdListIndices,
     config.blockRangeEndBlockBuffer
   );
 

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -1,6 +1,5 @@
 import { CommonConfig, ProcessEnv } from "../common";
 import { BigNumber, assert, toBNWei } from "../utils";
-import * as Constants from "../common/Constants";
 
 export class DataworkerConfig extends CommonConfig {
   readonly maxPoolRebalanceLeafSizeOverride: number;
@@ -85,7 +84,7 @@ export class DataworkerConfig extends CommonConfig {
     this.sendingDisputesEnabled = SEND_DISPUTES === "true";
     this.sendingProposalsEnabled = SEND_PROPOSALS === "true";
     this.sendingExecutionsEnabled = SEND_EXECUTIONS === "true";
-    this.finalizerChains = FINALIZER_CHAINS ? JSON.parse(FINALIZER_CHAINS) : Constants.CHAIN_ID_LIST_INDICES;
+    this.finalizerChains = FINALIZER_CHAINS ? JSON.parse(FINALIZER_CHAINS) : this.chainIdListIndices;
     this.finalizerEnabled = FINALIZER_ENABLED === "true";
 
     // `dataworkerFastLookbackCount` affects how far we fetch events from, modifying the search config's 'fromBlock'.

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -1,6 +1,5 @@
 import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, disconnectRedisClient } from "../utils";
 import { spokePoolClientsToProviders } from "../common";
-import * as Constants from "../common";
 import { Dataworker } from "./Dataworker";
 import { DataworkerConfig } from "./DataworkerConfig";
 import {
@@ -28,7 +27,7 @@ export async function createDataworker(
   const dataworker = new Dataworker(
     _logger,
     clients,
-    Constants.CHAIN_ID_LIST_INDICES,
+    config.chainIdListIndices,
     config.maxRelayerRepaymentLeafSizeOverride,
     config.maxPoolRebalanceLeafSizeOverride,
     config.tokenTransferThresholdOverride,

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -8,7 +8,6 @@ import {
   updateSpokePoolClients,
   constructClients,
   constructSpokePoolClientsWithLookback,
-  CHAIN_ID_LIST_INDICES,
 } from "../common";
 import { SpokePoolClientsByChain } from "../interfaces";
 
@@ -42,7 +41,7 @@ export async function constructMonitorClients(
     logger,
     commonClients,
     spokePoolClients,
-    CHAIN_ID_LIST_INDICES,
+    config.chainIdListIndices,
     config.blockRangeEndBlockBuffer
   );
 

--- a/src/monitor/MonitorConfig.ts
+++ b/src/monitor/MonitorConfig.ts
@@ -1,4 +1,4 @@
-import { CommonConfig, ProcessEnv, CHAIN_ID_LIST_INDICES } from "../common";
+import { CommonConfig, ProcessEnv } from "../common";
 import { ethers, ZERO_ADDRESS } from "../utils";
 
 // Set modes to true that you want to enable in the AcrossMonitor bot.
@@ -163,7 +163,7 @@ export class MonitorConfig extends CommonConfig {
       );
     }
 
-    CHAIN_ID_LIST_INDICES.forEach((chainId) => {
+    this.chainIdListIndices.forEach((chainId) => {
       this.spokePoolsBlocks[chainId] = {
         startingBlock: process.env[`STARTING_BLOCK_NUMBER_${chainId}`]
           ? Number(process.env[`STARTING_BLOCK_NUMBER_${chainId}`])

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -3,7 +3,7 @@ import { Wallet } from "../utils";
 import { TokenClient, ProfitClient, BundleDataClient, InventoryClient, AcrossApiClient } from "../clients";
 import { AdapterManager, CrossChainTransferClient } from "../clients/bridges";
 import { RelayerConfig } from "./RelayerConfig";
-import { CHAIN_ID_LIST_INDICES, Clients, constructClients, updateClients, updateSpokePoolClients } from "../common";
+import { Clients, constructClients, updateClients, updateSpokePoolClients } from "../common";
 import { SpokePoolClientsByChain } from "../interfaces";
 import { constructSpokePoolClientsWithLookback } from "../common";
 
@@ -44,7 +44,7 @@ export async function constructRelayerClients(
 
   // If `relayerDestinationChains` is a non-empty array, then copy its value, otherwise default to all chains.
   const enabledChainIds = (
-    config.relayerDestinationChains.length > 0 ? config.relayerDestinationChains : CHAIN_ID_LIST_INDICES
+    config.relayerDestinationChains.length > 0 ? config.relayerDestinationChains : config.chainIdListIndices
   ).filter((chainId) => Object.keys(spokePoolClients).includes(chainId.toString()));
   const profitClient = new ProfitClient(
     logger,
@@ -65,7 +65,7 @@ export async function constructRelayerClients(
     logger,
     commonClients,
     spokePoolClients,
-    CHAIN_ID_LIST_INDICES,
+    config.chainIdListIndices,
     config.blockRangeEndBlockBuffer
   );
   const crossChainTransferClient = new CrossChainTransferClient(logger, enabledChainIds, adapterManager);

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -93,7 +93,7 @@ export class RelayerConfig extends CommonConfig {
     (this.minDepositConfirmations = MIN_DEPOSIT_CONFIRMATIONS
       ? JSON.parse(MIN_DEPOSIT_CONFIRMATIONS)
       : Constants.MIN_DEPOSIT_CONFIRMATIONS),
-      Constants.CHAIN_ID_LIST_INDICES.forEach((chainId) => {
+      this.chainIdListIndices.forEach((chainId) => {
         Object.keys(this.minDepositConfirmations).forEach((threshold) => {
           const nBlocks: number = this.minDepositConfirmations[threshold][chainId];
           assert(


### PR DESCRIPTION
Pulled across from Nick's across-2.5 branch. This change permits the supported chains to be overridden by the environment. It has no impact unless overridden by the environment, so it should be safe to go into prod.

Co-authored-by: nicholaspai <9457025+nicholaspai@users.noreply.github.com>