### PR TITLE
refactor(SpokePoolClient): Simplify validateFillForDeposit usage

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -218,14 +218,11 @@ export class SpokePoolClient {
 
   getDepositForFill(fill: Fill): DepositWithBlock | undefined {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { blockNumber, ...fillCopy } = fill as FillWithBlock; // Ignore blockNumber when validating the fill.
     const depositWithMatchingDepositId = this.depositHashes[this.getDepositHash(fill)];
     if (depositWithMatchingDepositId === undefined) {
       return undefined;
     }
-    return this.validateFillForDeposit(fillCopy, depositWithMatchingDepositId)
-      ? depositWithMatchingDepositId
-      : undefined;
+    return this.validateFillForDeposit(fill, depositWithMatchingDepositId) ? depositWithMatchingDepositId : undefined;
   }
 
   getValidUnfilledAmountForDeposit(deposit: Deposit): {
@@ -436,9 +433,7 @@ export class SpokePoolClient {
       }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { blockNumber, ...fillCopy } = fill as FillWithBlock; // Ignore blockNumber when validating the fill
-    return this.validateFillForDeposit(fillCopy, deposit) ? deposit : undefined;
+    return this.validateFillForDeposit(fill, deposit) ? deposit : undefined;
   }
 
   async queryHistoricalMatchingFills(fill: Fill, deposit: Deposit, toBlock: number): Promise<FillWithBlock[]> {


### PR DESCRIPTION
The function validateFillForDeposit never evaluates the blockNumber member, so there's no need drop that member from the input object. This removes two lint suppressions.