### PR TITLE
fix: Handle executor for first root bundle ID

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -163,7 +163,9 @@ export class SpokePoolClient {
   }
 
   getLatestRootBundleId(): number {
-    return this.rootBundleRelays[this.rootBundleRelays.length - 1]?.rootBundleId ?? 0;
+    return this.rootBundleRelays.length > 0
+      ? this.rootBundleRelays[this.rootBundleRelays.length - 1]?.rootBundleId + 1
+      : 0;
   }
 
   getRelayerRefundExecutions(): RelayerRefundExecutionWithBlock[] {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1224,7 +1224,7 @@ export class Dataworker {
       // will be relayed after executing the above pool rebalance root. However, since we batch together all
       // transactions, the root bundle won't have been relayed yet. So, we need to infer it by adding 1 to the last
       // relayed root bundle. This assumes that all previous root bundles have been relayed already.
-      const nextRootBundleIdForMainnet = spokePoolClients[1].getLatestRootBundleId() + 1;
+      const nextRootBundleIdForMainnet = spokePoolClients[1].getLatestRootBundleId();
 
       // Now, execute refund and slow fill leaves for Mainnet using new funds. These methods will return early if there
       // are no relevant leaves to execute.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1221,9 +1221,7 @@ export class Dataworker {
       );
 
       // We need to know the next root bundle ID for the mainnet spoke pool in order to execute leaves for roots that
-      // will be relayed after executing the above pool rebalance root. However, since we batch together all
-      // transactions, the root bundle won't have been relayed yet. So, we need to infer it by adding 1 to the last
-      // relayed root bundle. This assumes that all previous root bundles have been relayed already.
+      // will be relayed after executing the above pool rebalance root.
       const nextRootBundleIdForMainnet = spokePoolClients[1].getLatestRootBundleId();
 
       // Now, execute refund and slow fill leaves for Mainnet using new funds. These methods will return early if there


### PR DESCRIPTION
Doesn't handle case where there are no root bundles yet
