### PR TITLE
fix(UBA): Restore tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@arbitrum/sdk": "^3.1.2",
     "@defi-wonderland/smock": "^2.3.4",
     "@eth-optimism/sdk": "^2.0.1",
+    "@ethersproject/abi": "^5.7.0",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/abstract-signer": "^5.7.0",
     "@google-cloud/kms": "^3.5.0",

--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -357,7 +357,7 @@ export class AcrossConfigStoreClient {
         blockNumber: event.blockNumber,
         transactionIndex: event.transactionIndex,
         logIndex: event.logIndex,
-        ...spreadEvent(event),
+        ...spreadEvent(event.args),
       };
 
       if (args.key === utf8ToHex(GLOBAL_CONFIG_STORE_KEYS.MAX_RELAYER_REPAYMENT_LEAF_SIZE)) {

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -492,7 +492,7 @@ export class HubPoolClient {
     // For each enabled Lp token fetch the token symbol and decimals from the token contract. Note this logic will
     // only run iff a new token has been enabled. Will only append iff the info is not there already.
     // Filter out any duplicate addresses. This might happen due to enabling, disabling and re-enabling a token.
-    const uniqueL1Tokens = [...new Set(l1TokensLpEvents.map((event) => spreadEvent(event).l1Token))];
+    const uniqueL1Tokens = [...new Set(l1TokensLpEvents.map((event) => spreadEvent(event.args).l1Token))];
     const [tokenInfo, lpTokenInfo] = await Promise.all([
       Promise.all(uniqueL1Tokens.map((l1Token: string) => this.fetchTokenInfoFromContract(l1Token))),
       Promise.all(uniqueL1Tokens.map(async (l1Token: string) => await this.hubPool.pooledTokens(l1Token))),

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -694,21 +694,14 @@ export class SpokePoolClient {
       }
       for (const event of fillEvents) {
         const fill = spreadEventWithBlockNumber(event) as FillWithBlock;
-        /**
-         * struct RelayExecutionInfo {
-         *   address recipient;
-         *   bytes message;
-         *   int64 relayerFeePct;
-         *   bool isSlowRelay;
-         *   int256 payoutAdjustmentPct;
-         * }
-         */
+        // speadEventWithBlockNumber() doesn't recurse down into Objects within event.args.
+        // Unpack updatableRelayData here and perform the necessary type conversions.
         fill.updatableRelayData = {
-          recipient: fill.updatableRelayData[0],
-          message: fill.updatableRelayData[1],
-          relayerFeePct: toBN(fill.updatableRelayData[2]),
-          isSlowRelay: fill.updatableRelayData[3],
-          payoutAdjustmentPct: toBN(fill.updatableRelayData[4]),
+          recipient: fill.updatableRelayData.recipient,
+          message: fill.updatableRelayData.message,
+          relayerFeePct: toBN(fill.updatableRelayData.relayerFeePct),
+          isSlowRelay: fill.updatableRelayData.isSlowRelay,
+          payoutAdjustmentPct: toBN(fill.updatableRelayData.payoutAdjustmentPct),
         };
         assign(this.fills, [fill.originChainId], [fill]);
         assign(this.depositHashesToFills, [this.getDepositHash(fill)], [fill]);

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -694,14 +694,15 @@ export class SpokePoolClient {
       }
       for (const event of fillEvents) {
         const fill = spreadEventWithBlockNumber(event) as FillWithBlock;
+        const { recipient, message, relayerFeePct, isSlowRelay, payoutAdjustmentPct } = fill.updatableRelayData;
         // speadEventWithBlockNumber() doesn't recurse down into Objects within event.args.
         // Unpack updatableRelayData here and perform the necessary type conversions.
         fill.updatableRelayData = {
-          recipient: fill.updatableRelayData.recipient,
-          message: fill.updatableRelayData.message,
-          relayerFeePct: toBN(fill.updatableRelayData.relayerFeePct),
-          isSlowRelay: fill.updatableRelayData.isSlowRelay,
-          payoutAdjustmentPct: toBN(fill.updatableRelayData.payoutAdjustmentPct),
+          recipient,
+          message,
+          isSlowRelay,
+          relayerFeePct: toBN(relayerFeePct),
+          payoutAdjustmentPct: toBN(payoutAdjustmentPct),
         };
         assign(this.fills, [fill.originChainId], [fill]);
         assign(this.depositHashesToFills, [this.getDepositHash(fill)], [fill]);

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -672,7 +672,7 @@ export class SpokePoolClient {
       const speedUpEvents = queryResults[eventsToQuery.indexOf("RequestedSpeedUpDeposit")];
 
       for (const event of speedUpEvents) {
-        const speedUp: SpeedUp = { ...spreadEvent(event), originChainId: this.chainId };
+        const speedUp: SpeedUp = { ...spreadEvent(event.args), originChainId: this.chainId };
         assign(this.speedUps, [speedUp.depositor, speedUp.depositId], [speedUp]);
       }
 
@@ -696,14 +696,6 @@ export class SpokePoolClient {
         const fill = spreadEventWithBlockNumber(event) as FillWithBlock;
         // speadEventWithBlockNumber() doesn't recurse down into Objects within event.args.
         // Unpack updatableRelayData here and perform the necessary type conversions.
-        const { recipient, message, relayerFeePct, isSlowRelay, payoutAdjustmentPct } = fill.updatableRelayData;
-        fill.updatableRelayData = {
-          recipient,
-          message,
-          isSlowRelay,
-          relayerFeePct: toBN(relayerFeePct),
-          payoutAdjustmentPct: toBN(payoutAdjustmentPct),
-        };
         assign(this.fills, [fill.originChainId], [fill]);
         assign(this.depositHashesToFills, [this.getDepositHash(fill)], [fill]);
       }
@@ -729,7 +721,7 @@ export class SpokePoolClient {
       const enableDepositsEvents = queryResults[eventsToQuery.indexOf("EnabledDepositRoute")];
 
       for (const event of enableDepositsEvents) {
-        const enableDeposit = spreadEvent(event);
+        const enableDeposit = spreadEvent(event.args);
         assign(
           this.depositRoutes,
           [enableDeposit.originToken, enableDeposit.destinationChainId],

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -694,9 +694,9 @@ export class SpokePoolClient {
       }
       for (const event of fillEvents) {
         const fill = spreadEventWithBlockNumber(event) as FillWithBlock;
-        const { recipient, message, relayerFeePct, isSlowRelay, payoutAdjustmentPct } = fill.updatableRelayData;
         // speadEventWithBlockNumber() doesn't recurse down into Objects within event.args.
         // Unpack updatableRelayData here and perform the necessary type conversions.
+        const { recipient, message, relayerFeePct, isSlowRelay, payoutAdjustmentPct } = fill.updatableRelayData;
         fill.updatableRelayData = {
           recipient,
           message,

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -694,8 +694,6 @@ export class SpokePoolClient {
       }
       for (const event of fillEvents) {
         const fill = spreadEventWithBlockNumber(event) as FillWithBlock;
-        // speadEventWithBlockNumber() doesn't recurse down into Objects within event.args.
-        // Unpack updatableRelayData here and perform the necessary type conversions.
         assign(this.fills, [fill.originChainId], [fill]);
         assign(this.depositHashesToFills, [this.getDepositHash(fill)], [fill]);
       }

--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -123,7 +123,7 @@ export class ArbitrumAdapter extends BaseAdapter {
         const l1Token = validTokens[Math.floor(index / 2)];
         // l1Token is not an indexed field on Aribtrum gateway's deposit events, so these events are for all tokens.
         // Therefore, we need to filter unrelated deposits of other tokens.
-        const filteredEvents = result.filter((event) => spreadEvent(event)["l1Token"] === l1Token);
+        const filteredEvents = result.filter((event) => spreadEvent(event.args)["l1Token"] === l1Token);
         const events = filteredEvents.map((event) => {
           // TODO: typing here is a little janky. To get these right, we'll probably need to rework how we're sorting
           // these different types of events into the array to get stronger guarantees when extracting them.

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -14,27 +14,26 @@ export function spreadEvent(args: Result): any {
   const returnedObject: any = {};
   keys.forEach((key: string) => {
     switch (typeof args[key]) {
-    case "boolean": // fallthrough
-    case "number":
-    case "string":
-      returnedObject[key] = args[key];
-      break;
-    case "object":
-      if (Array.isArray(args[key])) {
-        if (Object.keys(args[key].filter((key: string) => isNaN(+key))).length > 0) {
-          // Record/Array hybrid...
-          returnedObject[key] = spreadEvent(args[key]);
+      case "boolean": // fallthrough
+      case "number":
+      case "string":
+        returnedObject[key] = args[key];
+        break;
+      case "object":
+        if (Array.isArray(args[key])) {
+          if (Object.keys(args[key].filter((key: string) => isNaN(+key))).length > 0) {
+            // Record/Array hybrid...
+            returnedObject[key] = spreadEvent(args[key]);
+          } else {
+            // Just an array
+            returnedObject[key] = args[key];
+          }
         } else {
-          // Just an array
           returnedObject[key] = args[key];
         }
-      } else {
-        returnedObject[key] = args[key];
-      }
-      break;
+        break;
     }
   });
-
 
   // ID information, if included in an event, should be cast to a number rather than a BigNumber.
   if (returnedObject.groupIndex) {

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -21,13 +21,10 @@ export function spreadEvent(args: Result): any {
         break;
       case "object":
         if (Array.isArray(args[key])) {
-          if (Object.keys(args[key].filter((key: string) => isNaN(+key))).length > 0) {
-            // Record/Array hybrid...
-            returnedObject[key] = spreadEvent(args[key]);
-          } else {
-            // Just an array
-            returnedObject[key] = args[key];
-          }
+          returnedObject[key] =
+            Object.keys(args[key].filter((key: string) => isNaN(+key))).length > 0
+              ? spreadEvent(args[key]) // Record/array hybrid...
+              : args[key]; // Just an array
         } else {
           returnedObject[key] = args[key];
         }

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -1,7 +1,7 @@
+import { Result } from "@ethersproject/abi";
 import { delay } from "@uma/financial-templates-lib";
 import { SortableEvent } from "../interfaces";
 import { Contract, Event, EventFilter, Promise } from "./";
-import { Result } from "@ethersproject/abi";
 
 const maxRetries = 3;
 const retrySleepTime = 10;

--- a/test/UBA.SpokePoolClient.ts
+++ b/test/UBA.SpokePoolClient.ts
@@ -46,7 +46,7 @@ describe("UBA: SpokePool Events", async function () {
     await spokePoolClient.update();
   });
 
-  it.skip("Correctly orders UBA flows", async function () {
+  it("Correctly orders UBA flows", async function () {
     const nTxns = spokePoolClient.minBlockRange;
     expect(nTxns).to.be.above(5);
 
@@ -131,7 +131,7 @@ describe("UBA: SpokePool Events", async function () {
     });
   });
 
-  it.skip("Correctly includes initial partial fills", async function () {
+  it("Correctly includes initial partial fills", async function () {
     const nTxns = spokePoolClient.minBlockRange;
     expect(nTxns).to.be.above(5);
 
@@ -170,7 +170,7 @@ describe("UBA: SpokePool Events", async function () {
     expect(ubaFlows).to.deep.equal(fills);
   });
 
-  it.skip("Correctly filters subsequent partial fills", async function () {
+  it("Correctly filters subsequent partial fills", async function () {
     const nDeposits = 5;
 
     const fullFills: Event[] = [];
@@ -220,7 +220,7 @@ describe("UBA: SpokePool Events", async function () {
     });
   });
 
-  it.skip("Correctly filters slow fills", async function () {
+  it("Correctly filters slow fills", async function () {
     // Inject slow and instant fill events.
     const events: Event[] = [];
     for (let idx = 0; idx < spokePoolClient.minBlockRange; ++idx) {
@@ -229,9 +229,11 @@ describe("UBA: SpokePool Events", async function () {
       [true, false].forEach((isSlowRelay) => {
         const fill = spokePoolClient.generateFill({
           relayer,
-          isSlowRelay,
           blockNumber,
           transactionIndex,
+          updatableRelayData: {
+            isSlowRelay,
+          },
         } as FillWithBlock);
 
         spokePoolClient.addEvent(fill);
@@ -252,7 +254,7 @@ describe("UBA: SpokePool Events", async function () {
         assert.fail("UBA outflow is not a fill");
       }
 
-      expect((ubaFlow as FillWithBlock).isSlowRelay).to.be.false;
+      expect((ubaFlow as FillWithBlock).updatableRelayData.isSlowRelay).to.be.false;
     });
   });
 });


### PR DESCRIPTION
The Ethers Event 'args' field is an unusual Array/Object hybrid, so we can dereference its members directly, rather than using their array indices. However, EventUtils doesn't handle recursion down into args members that are themselves Objects, so add that capability in.

This broader event unpacking functionality seems ripe for some re-work in order to address some previously discussed type that's necessary to appease the various type checkers.

Fixes ACX-1057