### PR TITLE
fix(Monitor): Correct slow fill alerting logic

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -168,7 +168,7 @@ export class Monitor {
       );
       for (const fill of fills) {
         // Skip notifications for known relay caller addresses.
-        if (this.monitorConfig.whitelistedRelayers.includes(fill.relayer) && !fill.updatableRelayData.isSlowRelay) {
+        if (this.monitorConfig.whitelistedRelayers.includes(fill.relayer) || fill.updatableRelayData.isSlowRelay) {
           continue;
         }
 

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -167,7 +167,7 @@ export class Monitor {
         this.spokePoolsBlocks[chainId].endingBlock
       );
       for (const fill of fills) {
-        // Skip notifications for known relay caller addresses.
+        // Skip notifications for known relay caller addresses, or slow fills.
         if (this.monitorConfig.whitelistedRelayers.includes(fill.relayer) || fill.updatableRelayData.isSlowRelay) {
           continue;
         }


### PR DESCRIPTION
The conditional logic was broken since its initial introduction a few weeks ago. The intention is that slow relays should not trigger alerts.