### PR TITLE
improve(finalizer): Use Retry provider in Optimism finalizer

### DIFF
--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -2,7 +2,7 @@ import * as optimismSDK from "@eth-optimism/sdk";
 import { Withdrawal } from "..";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { L1Token, TokensBridged } from "../../interfaces";
-import { convertFromWei, ethers, getNodeUrlList, groupObjectCountsByProp, Wallet, winston } from "../../utils";
+import { convertFromWei, getCachedProvider, groupObjectCountsByProp, Wallet, winston } from "../../utils";
 import { Multicall2Call } from "../../common";
 
 type OVM_CHAIN_ID = 10;
@@ -12,8 +12,8 @@ export function getOptimismClient(chainId: OVM_CHAIN_ID, hubSigner: Wallet): OVM
   return new optimismSDK.CrossChainMessenger({
     l1ChainId: 1,
     l2ChainId: chainId,
-    l1SignerOrProvider: hubSigner.connect(new ethers.providers.JsonRpcProvider(getNodeUrlList(1)[0])),
-    l2SignerOrProvider: hubSigner.connect(new ethers.providers.JsonRpcProvider(getNodeUrlList(chainId)[0])),
+    l1SignerOrProvider: hubSigner.connect(getCachedProvider(1, true)),
+    l2SignerOrProvider: hubSigner.connect(getCachedProvider(10, true)),
   });
 }
 


### PR DESCRIPTION
I've noticed that we suffer from intermittent timeout errors when querying the Optimism [cross domain messenger on 
L1](https://etherscan.io/address/0x25ace71c97b33cc4729cf772ae268934f7ab5fa1#readProxyContract). The optimism finalizer code is the only one where we don't use the cache+retry provider, and instead use a 
vanilla JSONRpcProvider. I think using the more robust bespoke provider should mitigate these issues.

The reason why I originally used this vanilla provider was to make TS compile.

 Signed-off-by: nicholaspai <npai.nyc@gmail.com>
