### PR TITLE
fix: Make entire package a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "engines": {
     "node": ">=12.9.0"
   },
+  "type": "module",
   "dependencies": {
     "@across-protocol/contracts-v2": "2.2.1",
     "@across-protocol/sdk-v2": "0.5.3",


### PR DESCRIPTION
Addresses the [err](https://stackoverflow.com/questions/58211880/uncaught-syntaxerror-cannot-use-import-statement-outside-a-module-when-import)