### PR TITLE
chore(package): Bump minimum nodejs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "AGPL-3.0-only",
   "private": true,
   "engines": {
-    "node": ">=12.9.0"
+    "node": ">=16.18.0"
   },
   "dependencies": {
     "@across-protocol/contracts-v2": "2.2.1",


### PR DESCRIPTION
In practice, relayer-v2 won't run on node 12.x, and supporting older versions makes it difficult to support the relayer because some users see weird issues on older versions.