### PR TITLE
feat: :bug: correct help cmd text

### DIFF
--- a/src/utils/Help.ts
+++ b/src/utils/Help.ts
@@ -4,9 +4,9 @@ export function usage(badInput: string | undefined = undefined): boolean {
 
   usageStr += `
     Usage:
-    \tts-node ./index.ts --help
-    \tts-node ./index.ts [-h] <--monitor|--relayer>      --wallet <${walletOpts}>
-    \tts-node ./index.tx [-h] <--dataworker|--finalizer> --wallet <${walletOpts}>
+    \tnode ./dist/index.js --help
+    \tnode ./dist/index.js [-h] <--monitor|--relayer>      --wallet <${walletOpts}>
+    \tnode ./dist/index.js [-h] <--dataworker|--finalizer> --wallet <${walletOpts}>
   `.slice(1); // Skip leading newline
 
   // eslint-disable-next-line no-console


### PR DESCRIPTION
I believe we're now using `node ./dist/index.js` instead of `ts-node ./index.ts`