### PR TITLE
improve(multicallerclient): Log multicaller execution failures

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -133,7 +133,7 @@ export class MultiCallerClient {
       this.logger.error({
         at: "MultiCallerClient#executeTxnQueues",
         message: `Failed to execute ${failedChains.length} transaction(s) on chain(s) ${failedChains.join(", ")}`,
-        error: txnHashes,
+        error: failedChains.map((chainId) => txnHashes[chainId].result),
       });
       throw new Error(
         `Failed to execute ${failedChains.length} transaction(s) on chain(s) ${failedChains.join(

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -136,8 +136,9 @@ export class MultiCallerClient {
         errors: failedTxns,
       });
       throw new Error(
-        `Failed to execute ${failedChains.length} transaction(s) on chain(s) ${failedChains.join(", ")}`,
-        failedTxns
+        `Failed to execute ${failedChains.length} transaction(s) on chain(s) ${failedChains.join(
+          ", "
+        )}: ${JSON.stringify(failedTxns)}`
       );
     }
     // Recombine the results into a single object that match the legacy implementation.

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -133,7 +133,7 @@ export class MultiCallerClient {
       this.logger.error({
         at: "MultiCallerClient#executeTxnQueues",
         message: `Failed to execute ${failedChains.length} transaction(s) on chain(s) ${failedChains.join(", ")}`,
-        errors: txnHashes,
+        error: txnHashes,
       });
       throw new Error(
         `Failed to execute ${failedChains.length} transaction(s) on chain(s) ${failedChains.join(


### PR DESCRIPTION
This  PR tries to filter out any errors that occur when a transaction is successfully simulated but then fails when it is mined. This can happen for the relayer commonly if they get front-run by another 
relay, which is expected behavior
