### PR TITLE
improve(MulticallerClient): Remove extra simulation

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -179,7 +179,6 @@ export class MultiCallerClient {
       await this.buildMultiCallBundles(_txns, this.chunkSize[chainId])
     );
 
-
     if (simulate) {
       let mrkdwn = "";
       txnRequests.forEach((txn, idx) => {

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -179,35 +179,15 @@ export class MultiCallerClient {
       await this.buildMultiCallBundles(_txns, this.chunkSize[chainId])
     );
 
-    // Simulate the final bundle that will be sent via Multicall3 or Multicaller. This is an extra sanity check
-    // that gives us confidence even if any of the individual transactions are allowed to fail in individual
-    // simulations. The batched transactions should always succeed in simulation.
-    const batchSimResults = await this.txnClient.simulate(txnRequests);
-    batchSimResults.forEach((result) => {
-      this.logger[result.succeed ? "debug" : "error"]({
-        at: "MultiCallerClient#executeChainTxnQueue",
-        message: result.succeed
-          ? `Successfully simulated ${networkName} transaction batch!`
-          : `Failed to simulate ${networkName} transaction batch!`,
-        batchTxn: {
-          ...result.transaction,
-          contract: result.transaction.contract.address,
-        },
-      });
-      if (!result.succeed) {
-        throw new Error("Failed to simulate transaction batch!");
-      }
-    });
 
     if (simulate) {
       let mrkdwn = "";
-      const successfulTxns = _valueTxns.concat(_txns);
-      successfulTxns.forEach((txn, idx) => {
+      txnRequests.forEach((txn, idx) => {
         mrkdwn += `  *${idx + 1}. ${txn.message || "No message"}: ${txn.mrkdwn || "No markdown"}\n`;
       });
       this.logger.info({
         at: "MultiCallerClient#executeTxnQueue",
-        message: `${successfulTxns.length}/${nTxns} ${networkName} transaction simulation(s) succeeded!`,
+        message: `${txnRequests.length}/${nTxns} ${networkName} transaction simulation(s) succeeded!`,
         mrkdwn,
       });
       this.logger.info({ at: "MulticallerClient#executeTxnQueue", message: "Exiting simulation mode 🎮" });


### PR DESCRIPTION
This PR removes a simulation of the batch sent to `Multicall3`. This was originally included because technically its possible that individually transactions will succeed when batched together, they can revert.

This extra simulation has downsides:
- Extra RPC request to simulate transaction ends up leading to slow down in transactions being mined which opens up to ultimate failures like nonce-reuse and front-running
- More logic

With some upsides:
- Catches case where batch fails while individual txns succeed

Ultimately, the dataworker and relayer functions using this code should never be batching together transactions that would fail in a batch but succeed individually, so I think its safe to remove to mitigate the downsides above. Moreover, if the batch fails, we'll hear about it anyways.

The motivation for this PR was an error log that showed the batch failed simulation, which suggests that the individual txn suceeded, but the batch failed. This error did not persist, meaning that the `fillRelay` reverted after succeeding the individual simulation but was probably front-run by the time of the batch txn.