### PR TITLE
fix(package): Explicitly define HARDHAT_CONFIG

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "clean": "dir=\"./node_modules\"; mv \"${dir}\" \"${dir}_\" 2>/dev/null && rm -r \"${dir}_\" &",
     "reinstall": "yarn clean && yarn install && yarn build",
     "update": "git pull && yarn reinstall && yarn version --non-interactive && git show --quiet",
-    "relay": "node ./dist/index.js --relayer"
+    "relay": "HARDHAT_CONFIG=./dist/hardhat.config.js node ./dist/index.js --relayer"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-ethers": "^2.2.2",


### PR DESCRIPTION
This workaround is necessary after a recent regression. It's a bandaid, pending a proper fix.