### PR TITLE
fix: Correct log message

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -471,7 +471,7 @@ export class HubPoolClient {
       maxBlockLookBack: this.eventSearchConfig.maxBlockLookBack,
     };
     if (searchConfig.fromBlock > searchConfig.toBlock) {
-      this.logger.warn("Invalid update() searchConfig.", { searchConfig });
+      this.logger.warn({ at: "HubPoolClient#_update", message: "Invalid update() searchConfig.", searchConfig });
       return { success: false };
     }
 


### PR DESCRIPTION
This log message was mostly copy/pasted from the SpokePoolClient, but the SpokePoolClient implements a wrapper for logger that handles the message structuring.