### PR TITLE
improve: Refuse to execute SlowFill leaves for deposits with messages

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -332,17 +332,7 @@ export class BundleDataClient {
 
     // For each deposit with a matched fill, figure out the unfilled amount that we need to slow relay. We will filter
     // out any deposits that are fully filled.
-    const _unfilledDeposits = flattenAndFilterUnfilledDepositsByOriginChain(unfilledDepositsForOriginChain);
-    if (_unfilledDeposits.some((x) => x.deposit.message !== "0x")) {
-      this.logger.warn({
-        at: "BundleDataClient#loadData",
-        message: "Some unfilled deposits have non-zero message fields. Refusing to create slow fill roots for them",
-        unfilledDeposits: _unfilledDeposits.filter((x) => x.deposit.message !== "0x"),
-      });
-    }
-    const unfilledDeposits = flattenAndFilterUnfilledDepositsByOriginChain(unfilledDepositsForOriginChain).filter(
-      (x) => x.deposit.message === "0x"
-    );
+    const unfilledDeposits = flattenAndFilterUnfilledDepositsByOriginChain(unfilledDepositsForOriginChain);
 
     const spokeEventsReadable = prettyPrintSpokePoolEvents(
       blockRangesForChains,

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -332,7 +332,17 @@ export class BundleDataClient {
 
     // For each deposit with a matched fill, figure out the unfilled amount that we need to slow relay. We will filter
     // out any deposits that are fully filled.
-    const unfilledDeposits = flattenAndFilterUnfilledDepositsByOriginChain(unfilledDepositsForOriginChain);
+    const _unfilledDeposits = flattenAndFilterUnfilledDepositsByOriginChain(unfilledDepositsForOriginChain);
+    if (_unfilledDeposits.some((x) => x.deposit.message !== "0x")) {
+      this.logger.warn({
+        at: "BundleDataClient#loadData",
+        message: "Some unfilled deposits have non-zero message fields. Refusing to create slow fill roots for them",
+        unfilledDeposits: _unfilledDeposits.filter((x) => x.deposit.message !== "0x"),
+      });
+    }
+    const unfilledDeposits = flattenAndFilterUnfilledDepositsByOriginChain(unfilledDepositsForOriginChain).filter(
+      (x) => x.deposit.message === "0x"
+    );
 
     const spokeEventsReadable = prettyPrintSpokePoolEvents(
       blockRangesForChains,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -991,10 +991,6 @@ export class Dataworker {
     submitExecution: boolean,
     rootBundleId?: number
   ): Promise<void> {
-    if (_leaves.length === 0) {
-      return;
-    }
-
     // Ignore slow fill leaves for deposits with messages as these messages might be very expensive to execute.
     // The original depositor can always execute these and pay for the gas themselves.
     const leaves = _leaves.filter((leaf) => {
@@ -1009,6 +1005,10 @@ export class Dataworker {
         return true;
       }
     });
+
+    if (leaves.length === 0) {
+      return;
+    }
 
     const chainId = client.chainId;
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -999,7 +999,7 @@ export class Dataworker {
     // The original depositor can always execute these and pay for the gas themselves.
     const leaves = _leaves.filter((leaf) => {
       if (leaf.relayData.message !== "0x") {
-        this.logger.warn({
+        this.logger.error({
           at: "Dataworker#_executeSlowFillLeaf",
           message: "Ignoring slow fill leaf with message",
           leaf,


### PR DESCRIPTION
Protects dataworker from executing fill for deposit with very expensive message
