### PR TITLE
fix: Remove redundant explicitTypes config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,6 @@
 {
   "printWidth": 120,
   "bracketSpacing": true,
-  "explicitTypes": "preserve",
   "tabWidth": 2,
   "overrides": [
     {
@@ -9,8 +8,7 @@
       "options": {
         "tabWidth": 4,
         "useTabs": false,
-        "singleQuote": false,
-        "explicitTypes": "always"
+        "singleQuote": false
       }
     },
     {


### PR DESCRIPTION
When this option is defined, it spams the console with `Ignored unknown option [...]` messages during test. explicitTest was removed from prettier in September 2022; Dependabot recently upgraded us to ^1.1.3, which is from March 2023.

https://github.com/prettier-solidity/prettier-plugin-solidity/pull/730