### PR TITLE
improve: Log deposit txn hashes for unprofitable deposits

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -2,7 +2,7 @@ import { Provider } from "@ethersproject/abstract-provider";
 import * as constants from "../common/Constants";
 import { assert, BigNumber, formatFeePct, max, winston, toBNWei, toBN, assign } from "../utils";
 import { HubPoolClient } from ".";
-import { Deposit, L1Token, SpokePoolClientsByChain } from "../interfaces";
+import { Deposit, DepositWithBlock, L1Token, SpokePoolClientsByChain } from "../interfaces";
 import { priceClient, relayFeeCalculator } from "@across-protocol/sdk-v2";
 import { constants as sdkConstants } from "@across-protocol/sdk-v2";
 const { TOKEN_SYMBOLS_MAP, CHAIN_IDs } = sdkConstants;
@@ -67,7 +67,7 @@ export class ProfitClient {
   private readonly priceClient;
   protected minRelayerFees: { [route: string]: BigNumber } = {};
   protected tokenPrices: { [l1Token: string]: BigNumber } = {};
-  private unprofitableFills: { [chainId: number]: { deposit: Deposit; fillAmount: BigNumber }[] } = {};
+  private unprofitableFills: { [chainId: number]: { deposit: DepositWithBlock; fillAmount: BigNumber }[] } = {};
 
   // Track total gas costs of a relay on each chain.
   protected totalGasCosts: { [chainId: number]: BigNumber } = {};
@@ -160,7 +160,7 @@ export class ProfitClient {
     };
   }
 
-  getUnprofitableFills(): { [chainId: number]: { deposit: Deposit; fillAmount: BigNumber }[] } {
+  getUnprofitableFills(): { [chainId: number]: { deposit: DepositWithBlock; fillAmount: BigNumber }[] } {
     return this.unprofitableFills;
   }
 
@@ -304,7 +304,7 @@ export class ProfitClient {
     return fill.fillProfitable;
   }
 
-  captureUnprofitableFill(deposit: Deposit, fillAmount: BigNumber): void {
+  captureUnprofitableFill(deposit: DepositWithBlock, fillAmount: BigNumber): void {
     this.logger.debug({ at: "ProfitClient", message: "Handling unprofitable fill", deposit, fillAmount });
     assign(this.unprofitableFills, [deposit.originChainId], [{ deposit, fillAmount }]);
   }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -401,11 +401,11 @@ export class Relayer {
         const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForDeposit(deposit);
         const formatFunction = createFormatFunction(2, 4, false, decimals);
         const gasFormatFunction = createFormatFunction(2, 10, false, 18);
+        const depositEtherscanLink = etherscanLink(deposit.transactionHash, deposit.originChainId);
         depositMrkdwn +=
-          `- DepositId ${deposit.depositId} (tx: ${etherscanLink(
-            deposit.transactionHash,
-            deposit.originChainId
-          )}) of amount ${formatFunction(deposit.amount.toString())} ${symbol}` +
+          `- DepositId ${deposit.depositId} (tx: ${depositEtherscanLink}) of amount ${formatFunction(
+            deposit.amount.toString()
+          )} ${symbol}` +
           ` with a relayerFeePct ${formatFeePct(deposit.relayerFeePct)}% and gas cost ${gasFormatFunction(gasCost)}` +
           ` from ${getNetworkName(deposit.originChainId)} to ${getNetworkName(deposit.destinationChainId)}` +
           ` and an unfilled amount of ${formatFunction(fillAmount.toString())} ${symbol} is unprofitable!\n`;

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -10,7 +10,7 @@ import {
 } from "../utils";
 import { createFormatFunction, etherscanLink, formatFeePct, toBN, toBNWei } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
-import { Deposit } from "../interfaces";
+import { Deposit, DepositWithBlock } from "../interfaces";
 import { RelayerConfig } from "./RelayerConfig";
 import { CONFIG_STORE_VERSION } from "../common";
 
@@ -389,7 +389,9 @@ export class Relayer {
     Object.keys(unprofitableDeposits).forEach((chainId) => {
       let depositMrkdwn = "";
       Object.keys(unprofitableDeposits[chainId]).forEach((depositId) => {
-        const { deposit, fillAmount } = unprofitableDeposits[chainId][depositId];
+        const unprofitableDeposit = unprofitableDeposits[chainId][depositId];
+        const deposit: DepositWithBlock = unprofitableDeposit.deposit;
+        const fillAmount: BigNumber = unprofitableDeposit.fillAmount;
         // Skip notifying if the unprofitable fill happened too long ago to avoid spamming.
         if (deposit.quoteTimestamp + UNPROFITABLE_DEPOSIT_NOTICE_PERIOD < getCurrentTime()) {
           return;
@@ -400,10 +402,10 @@ export class Relayer {
         const formatFunction = createFormatFunction(2, 4, false, decimals);
         const gasFormatFunction = createFormatFunction(2, 10, false, 18);
         depositMrkdwn +=
-          `- DepositId ${deposit.depositId} of amount ${formatFunction(deposit.amount)} ${symbol}` +
+          `- DepositId ${deposit.depositId} (tx: ${etherscanLink(deposit.transactionHash, deposit.originChainId)}) of amount ${formatFunction(deposit.amount.toString())} ${symbol}` +
           ` with a relayerFeePct ${formatFeePct(deposit.relayerFeePct)}% and gas cost ${gasFormatFunction(gasCost)}` +
           ` from ${getNetworkName(deposit.originChainId)} to ${getNetworkName(deposit.destinationChainId)}` +
-          ` and an unfilled amount of ${formatFunction(fillAmount)} ${symbol} is unprofitable!\n`;
+          ` and an unfilled amount of ${formatFunction(fillAmount.toString())} ${symbol} is unprofitable!\n`;
       });
 
       if (depositMrkdwn) {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -402,7 +402,10 @@ export class Relayer {
         const formatFunction = createFormatFunction(2, 4, false, decimals);
         const gasFormatFunction = createFormatFunction(2, 10, false, 18);
         depositMrkdwn +=
-          `- DepositId ${deposit.depositId} (tx: ${etherscanLink(deposit.transactionHash, deposit.originChainId)}) of amount ${formatFunction(deposit.amount.toString())} ${symbol}` +
+          `- DepositId ${deposit.depositId} (tx: ${etherscanLink(
+            deposit.transactionHash,
+            deposit.originChainId
+          )}) of amount ${formatFunction(deposit.amount.toString())} ${symbol}` +
           ` with a relayerFeePct ${formatFeePct(deposit.relayerFeePct)}% and gas cost ${gasFormatFunction(gasCost)}` +
           ` from ${getNetworkName(deposit.originChainId)} to ${getNetworkName(deposit.destinationChainId)}` +
           ` and an unfilled amount of ${formatFunction(fillAmount.toString())} ${symbol} is unprofitable!\n`;

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -9,7 +9,7 @@ import {
   destinationChainId,
 } from "./utils";
 import { MockHubPoolClient, MockProfitClient } from "./mocks";
-import { Deposit, L1Token } from "../src/interfaces";
+import { Deposit, DepositWithBlock, L1Token } from "../src/interfaces";
 import { FillProfit, GAS_TOKEN_BY_CHAIN_ID, SpokePoolClient, MATIC, USDC, WBTC, WETH } from "../src/clients";
 
 const chainIds: number[] = [1, 10, 137, 288, 42161];
@@ -361,7 +361,7 @@ describe("ProfitClient: Consider relay profit", async function () {
   });
 
   it("Captures unprofitable fills", async function () {
-    const deposit = { relayerFeePct: toBNWei("0.003"), originChainId: 1, depositId: 42 } as Deposit;
+    const deposit = { relayerFeePct: toBNWei("0.003"), originChainId: 1, depositId: 42 } as DepositWithBlock;
     profitClient.captureUnprofitableFill(deposit, toBNWei(1));
     expect(profitClient.getUnprofitableFills()).to.deep.equal({ 1: [{ deposit, fillAmount: toBNWei(1) }] });
   });


### PR DESCRIPTION
In  practice we find it would be helpful to link directly to deposit transaction hashes in order to debug why a deposit was sent with unprofitable parameters
