### PR TITLE
refactor(ConfigStoreClient): Remove getUtilization override

### DIFF
--- a/src/clients/ConfigStoreClient.ts
+++ b/src/clients/ConfigStoreClient.ts
@@ -1,6 +1,6 @@
 import { clients } from "@across-protocol/sdk-v2";
-import { BigNumber, Contract } from "ethers";
-import { getRedis, shouldCache, getCurrentTime, setRedisKey, EventSearchConfig, MakeOptional, winston } from "../utils";
+import { Contract } from "ethers";
+import { EventSearchConfig, MakeOptional, winston } from "../utils";
 import { CHAIN_ID_LIST_INDICES, CONFIG_STORE_VERSION, DEFAULT_CONFIG_STORE_VERSION } from "../common";
 import { HubPoolClient } from "./HubPoolClient";
 
@@ -19,29 +19,5 @@ export class AcrossConfigStoreClient extends clients.AcrossConfigStoreClient {
       defaultConfigStoreVersion: DEFAULT_CONFIG_STORE_VERSION,
       configStoreVersion: CONFIG_STORE_VERSION,
     });
-  }
-
-  protected async getUtilization(
-    l1Token: string,
-    blockNumber: number,
-    amount: BigNumber,
-    timestamp: number
-  ): Promise<{ current: BigNumber; post: BigNumber }> {
-    const redisClient = await getRedis(this.logger);
-    if (!redisClient) {
-      return await this.hubPoolClient.getPostRelayPoolUtilization(l1Token, blockNumber, amount);
-    }
-    const key = `utilization_${l1Token}_${blockNumber}_${amount.toString()}`;
-    const result = await redisClient.get(key);
-    if (result === null) {
-      const { current, post } = await this.hubPoolClient.getPostRelayPoolUtilization(l1Token, blockNumber, amount);
-      if (shouldCache(getCurrentTime(), timestamp)) {
-        await setRedisKey(key, `${current.toString()},${post.toString()}`, redisClient, 60 * 60 * 24 * 90);
-      }
-      return { current, post };
-    } else {
-      const [current, post] = result.split(",").map(BigNumber.from);
-      return { current, post };
-    }
   }
 }


### PR DESCRIPTION
This method seems surprisingly unused by any other code in this repository!

It's proposed for removal because it introduces a dependency on the HubPoolClient, which seems like an inversion. Per a pending change to the HubPoolClient in the sdk-v2 repository, the HubPoolClient will instead become dependent on the ConfigStoreClient when validating the runningBalances member of the ExecutedRootBundle.

See https://github.com/across-protocol/sdk-v2/pull/213#discussion_r1197043597 for reference.