### PR TITLE
refactor(SpokePoolClient): Simplify deposit lookup

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -19,6 +19,7 @@ import {
   flattenAndFilterUnfilledDepositsByOriginChain,
   updateUnfilledDepositsWithMatchedDeposit,
   getUniqueDepositsInRange,
+  queryHistoricalDepositForFill,
 } from "../utils";
 import { Clients } from "../common";
 import {
@@ -254,7 +255,8 @@ export class BundleDataClient {
         // Matched deposit for fill was not found in spoke client. This situation should be rare so let's
         // send some extra RPC requests to blocks older than the spoke client's initial event search config
         // to find the deposit if it exists.
-        const historicalDeposit = await originClient.queryHistoricalDepositForFill(fill);
+        const spokePoolClient = spokePoolClients[fill.originChainId];
+        const historicalDeposit = await queryHistoricalDepositForFill(spokePoolClient, fill);
         if (historicalDeposit) {
           addRefundForValidFill(fill, historicalDeposit, blockRangeForChain);
         } else {

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,111 +1,73 @@
-import {
-  getDeposit,
-  setDeposit,
-  getNetworkName,
-  getRedisDepositKey,
-  assert,
-  validateFillForDeposit,
-  getCurrentTime,
-  getRedis,
-} from "../utils";
-import { paginatedEventQuery, spreadEventWithBlockNumber } from "../utils";
-import { Deposit, DepositWithBlock, Fill, FundsDepositedEvent } from "../interfaces";
 import { clients } from "@across-protocol/sdk-v2";
+import { DepositWithBlock, FundsDepositedEvent } from "../interfaces";
+import { getNetworkName, paginatedEventQuery, spreadEventWithBlockNumber } from "../utils";
 
 export class SpokePoolClient extends clients.SpokePoolClient {
-  // Load a deposit for a fill if the fill's deposit ID is outside this client's search range.
-  // This can be used by the Dataworker to determine whether to give a relayer a refund for a fill
-  // of a deposit older or younger than its fixed lookback.
-  async queryHistoricalDepositForFill(fill: Fill): Promise<DepositWithBlock | undefined> {
-    const start = Date.now();
-    if (fill.originChainId !== this.chainId) {
-      throw new Error("fill.originChainId !== this.chainid");
-    }
+  async findDeposit(depositId: number, destinationChainId: number, depositor: string): Promise<DepositWithBlock> {
+    // Binary search for block where SpokePool.numberOfDeposits incremented to fill.depositId + 1.
+    // This way we can get the blocks before and after the deposit with deposit ID = fill.depositId
+    // and use those blocks to optimize the search for that deposit. Stop searches after a maximum
+    // # of searches to limit number of eth_call requests. Make an eth_getLogs call on the remaining block range
+    // (i.e. the [low, high] remaining from the binary search) to find the target deposit ID.
+    // @dev Limiting between 5-10 searches empirically performs best when there are ~300,000 deposits
+    // for a spoke pool and we're looking for a deposit <5 days older than HEAD.
+    const searchBounds = await this._getBlockRangeForDepositId(
+      depositId + 1,
+      this.deploymentBlock,
+      this.latestBlockNumber,
+      7
+    );
 
-    // We need to update client so we know the first and last deposit ID's queried for this spoke pool client, as well
-    // as the global first and last deposit ID's for this spoke pool.
-    if (!this.isUpdated) {
-      throw new Error("SpokePoolClient must be updated before querying historical deposits");
-    }
-    if (fill.depositId < this.firstDepositIdForSpokePool || fill.depositId > this.lastDepositIdForSpokePool) {
-      return undefined;
-    }
-    if (fill.depositId >= this.earliestDepositIdQueried && fill.depositId <= this.latestDepositIdQueried) {
-      return this.getDepositForFill(fill);
-    }
-
-    let deposit: DepositWithBlock, cachedDeposit: Deposit | undefined;
-    const redisClient = await getRedis(this.logger);
-    if (redisClient) {
-      cachedDeposit = await getDeposit(getRedisDepositKey(fill), redisClient);
-    }
-    if (cachedDeposit) {
-      deposit = cachedDeposit as DepositWithBlock;
-      // Assert that cache hasn't been corrupted.
-      assert(deposit.depositId === fill.depositId && deposit.originChainId === fill.originChainId);
-    } else {
-      // Binary search for block where SpokePool.numberOfDeposits incremented to fill.depositId + 1.
-      // This way we can get the blocks before and after the deposit with deposit ID = fill.depositId
-      // and use those blocks to optimize the search for that deposit. Stop searches after a maximum
-      // # of searches to limit number of eth_call requests. Make an eth_getLogs call on the remaining block range
-      // (i.e. the [low, high] remaining from the binary search) to find the target deposit ID.
-      // @dev Limiting between 5-10 searches empirically performs best when there are ~300,000 deposits
-      // for a spoke pool and we're looking for a deposit <5 days older than HEAD.
-      const searchBounds = await this._getBlockRangeForDepositId(
-        fill.depositId + 1,
-        this.deploymentBlock,
-        this.latestBlockNumber,
-        7
-      );
-      const query = await paginatedEventQuery(
-        this.spokePool,
-        this.spokePool.filters.FundsDeposited(
-          null,
-          null,
-          fill.destinationChainId,
-          null,
-          fill.depositId,
-          null,
-          null,
-          null,
-          fill.depositor,
-          null
-        ),
-        {
-          fromBlock: searchBounds.low,
-          toBlock: searchBounds.high,
-          maxBlockLookBack: this.eventSearchConfig.maxBlockLookBack,
-        }
-      );
-      const event = (query as FundsDepositedEvent[]).find((deposit) => deposit.args.depositId === fill.depositId);
-      if (event === undefined) {
-        const srcChain = getNetworkName(fill.originChainId);
-        const dstChain = getNetworkName(fill.destinationChainId);
-        throw new Error(
-          `Could not find deposit ${fill.depositId} for ${dstChain} fill` +
-            ` between ${srcChain} blocks [${searchBounds.low}, ${searchBounds.high}]`
-        );
+    const tStart = Date.now();
+    const query = await paginatedEventQuery(
+      this.spokePool,
+      this.spokePool.filters.FundsDeposited(
+        null,
+        null,
+        destinationChainId,
+        null,
+        depositId,
+        null,
+        null,
+        null,
+        depositor,
+        null
+      ),
+      {
+        fromBlock: searchBounds.low,
+        toBlock: searchBounds.high,
+        maxBlockLookBack: this.eventSearchConfig.maxBlockLookBack,
       }
-      const partialDeposit = spreadEventWithBlockNumber(event) as DepositWithBlock;
-      const { realizedLpFeePct, quoteBlock: quoteBlockNumber } = await this.computeRealizedLpFeePct(event); // Append the realizedLpFeePct.
-      // Append destination token and realized lp fee to deposit.
-      deposit = {
-        ...partialDeposit,
-        realizedLpFeePct,
-        destinationToken: this.getDestinationTokenForDeposit(partialDeposit),
-        quoteBlockNumber,
-      };
-      this.logger.debug({
-        at: "SpokePoolClient#queryHistoricalDepositForFill",
-        message: "Queried RPC for deposit outside SpokePoolClient's search range",
-        deposit,
-        elapsedMs: Date.now() - start,
-      });
-      if (redisClient) {
-        await setDeposit(deposit, getCurrentTime(), redisClient, 24 * 60 * 60);
-      }
-    }
+    );
+    const tStop = Date.now();
 
-    return validateFillForDeposit(fill, deposit) ? deposit : undefined;
+    const event = (query as FundsDepositedEvent[]).find((deposit) => deposit.args.depositId === depositId);
+    if (event === undefined) {
+      const srcChain = getNetworkName(this.chainId);
+      const dstChain = getNetworkName(destinationChainId);
+      throw new Error(
+        `Could not find deposit ${depositId} for ${dstChain} fill` +
+          ` between ${srcChain} blocks [${searchBounds.low}, ${searchBounds.high}]`
+      );
+    }
+    const partialDeposit = spreadEventWithBlockNumber(event) as DepositWithBlock;
+    const { realizedLpFeePct, quoteBlock: quoteBlockNumber } = await this.computeRealizedLpFeePct(event); // Append the realizedLpFeePct.
+
+    // Append destination token and realized lp fee to deposit.
+    const deposit: DepositWithBlock = {
+      ...partialDeposit,
+      realizedLpFeePct,
+      destinationToken: this.getDestinationTokenForDeposit(partialDeposit),
+      quoteBlockNumber,
+    };
+
+    this.logger.debug({
+      at: "SpokePoolClient#findDeposit",
+      message: "Located deposit outside of SpokePoolClient's search range",
+      deposit,
+      elapsedMs: tStop - tStart,
+    });
+
+    return deposit;
   }
 }

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -1,5 +1,15 @@
-import { SpokePoolClient } from "../clients";
+import {
+  assert,
+  getDeposit,
+  setDeposit,
+  getRedisDepositKey,
+  getCurrentTime,
+  getRedis,
+  isDefined,
+  validateFillForDeposit,
+} from "../utils";
 import { Deposit, DepositWithBlock, Fill, UnfilledDeposit, UnfilledDepositsForOriginChain } from "../interfaces";
+import { SpokePoolClient } from "../clients";
 import { assign, toBN, isFirstFillForDeposit } from "./";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 
@@ -92,4 +102,56 @@ export function getUniqueDepositsInRange(
 
 export function isDepositSpedUp(deposit: Deposit): boolean {
   return deposit.speedUpSignature !== undefined && deposit.newRelayerFeePct !== undefined;
+}
+
+// Load a deposit for a fill if the fill's deposit ID is outside this client's search range.
+// This can be used by the Dataworker to determine whether to give a relayer a refund for a fill
+// of a deposit older or younger than its fixed lookback.
+export async function queryHistoricalDepositForFill(
+  spokePoolClient: SpokePoolClient,
+  fill: Fill
+): Promise<DepositWithBlock | undefined> {
+  if (fill.originChainId !== spokePoolClient.chainId) {
+    throw new Error(`OriginChainId mismatch (${fill.originChainId} != ${spokePoolClient.chainId})`);
+  }
+
+  // We need to update client so we know the first and last deposit ID's queried for this spoke pool client, as well
+  // as the global first and last deposit ID's for this spoke pool.
+  if (!spokePoolClient.isUpdated) {
+    throw new Error("SpokePoolClient must be updated before querying historical deposits");
+  }
+
+  if (
+    fill.depositId < spokePoolClient.firstDepositIdForSpokePool ||
+    fill.depositId > spokePoolClient.lastDepositIdForSpokePool
+  ) {
+    return undefined;
+  }
+
+  if (
+    fill.depositId >= spokePoolClient.earliestDepositIdQueried &&
+    fill.depositId <= spokePoolClient.latestDepositIdQueried
+  ) {
+    return spokePoolClient.getDepositForFill(fill);
+  }
+
+  let deposit: DepositWithBlock, cachedDeposit: Deposit | undefined;
+  const redisClient = await getRedis(spokePoolClient.logger);
+  if (redisClient) {
+    cachedDeposit = await getDeposit(getRedisDepositKey(fill), redisClient);
+  }
+
+  if (isDefined(cachedDeposit)) {
+    deposit = cachedDeposit as DepositWithBlock;
+    // Assert that cache hasn't been corrupted.
+    assert(deposit.depositId === fill.depositId && deposit.originChainId === fill.originChainId);
+  } else {
+    deposit = await spokePoolClient.findDeposit(fill.depositId, fill.destinationChainId, fill.depositor);
+
+    if (redisClient) {
+      await setDeposit(deposit, getCurrentTime(), redisClient, 24 * 60 * 60);
+    }
+  }
+
+  return validateFillForDeposit(fill, deposit) ? deposit : undefined;
 }

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,5 +1,6 @@
 import { AcrossConfigStoreClient, HubPoolClient } from "../clients";
 import { Deposit, DepositWithBlock, Fill, FillsToRefund, FillWithBlock, SpokePoolClientsByChain } from "../interfaces";
+import { queryHistoricalDepositForFill } from "../utils";
 import {
   BigNumber,
   assign,
@@ -154,7 +155,7 @@ export async function getFillDataForSlowFillFromPreviousRootBundle(
   // allMatchingFills array, at the end of this block, allMatchingFills should contain all fills for the same
   // deposit as the input fill.
   if (!firstFillForSameDeposit) {
-    const depositForFill = await spokePoolClientsByChain[fill.originChainId].queryHistoricalDepositForFill(fill);
+    const depositForFill = await queryHistoricalDepositForFill(spokePoolClientsByChain[fill.originChainId], fill);
     const matchingFills = await spokePoolClientsByChain[fill.destinationChainId].queryHistoricalMatchingFills(
       fill,
       depositForFill,

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -708,7 +708,7 @@ describe("Dataworker: Load data used in all functions", async function () {
 
     // For queryHistoricalDepositForFill to work we need to have a deployment block set for the spoke pool client.
     const bundleData = await bundleDataClient.loadData(getDefaultBlockRange(0), spokePoolClients);
-    expect(spyLogIncludes(spy, -2, "Queried RPC for deposit")).is.true;
+    expect(spyLogIncludes(spy, -2, "Located deposit outside of SpokePoolClient's search range")).is.true;
     expect(bundleData.fillsToRefund).to.deep.equal({
       [destinationChainId]: {
         [erc20_2.address]: {


### PR DESCRIPTION
Split queryHistoricalDepositForFill() into two, factoring out the on-chain paginated lookup from the caching logic.

The on-chain paginated lookup (SpokePoolClient.findDeposit()) can probably be relocated to the parent SpokePoolClient class in the sdk-v2 repository as a result.

This is an enabler for future work to shuffle the relationship between the SpokePoolClient, HubPoolClient and ConfigStoreClient, which is needed for the pending UBA rollout.