### PR TITLE
improve(Dataworker): Dynamic HubPool chainId

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -348,7 +348,7 @@ export class BundleDataClient {
     if (logData) {
       const mainnetRange = getBlockRangeForChain(
         blockRangesForChains,
-        1,
+        this.clients.hubPoolClient.chainId,
         this.chainIdListForBundleEvaluationBlockNumbers
       );
       this.logger.debug({

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -466,7 +466,7 @@ export class Dataworker {
     ) {
       throw new Error("HubPoolClient not updated");
     }
-    const hubPoolChainId = (await this.clients.hubPoolClient.hubPool.provider.getNetwork()).chainId;
+    const hubPoolChainId = this.clients.hubPoolClient.chainId;
 
     // Exit early if a bundle is not pending.
     const pendingRootBundle = this.clients.hubPoolClient.getPendingRootBundle();
@@ -1152,7 +1152,7 @@ export class Dataworker {
     ) {
       throw new Error("HubPoolClient not updated");
     }
-    const hubPoolChainId = (await this.clients.hubPoolClient.hubPool.provider.getNetwork()).chainId;
+    const hubPoolChainId = this.clients.hubPoolClient.chainId;
 
     // Exit early if a bundle is not pending.
     const pendingRootBundle = this.clients.hubPoolClient.getPendingRootBundle();
@@ -1182,7 +1182,7 @@ export class Dataworker {
 
     const mainnetBundleEndBlockForPendingRootBundle = getBlockForChain(
       pendingRootBundle.bundleEvaluationBlockNumbers,
-      this.clients.hubPoolClient.chainId,
+      hubPoolChainId,
       this.chainIdListForBundleEvaluationBlockNumbers
     );
     const widestPossibleExpectedBlockRange = this._getWidestPossibleBlockRangeForNextBundle(

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -132,7 +132,7 @@ export class Dataworker {
       blockRangesForChains,
       this.clients.hubPoolClient.chainId,
       this.chainIdListForBundleEvaluationBlockNumbers
-    )[this.clients.hubPoolClient.chainId];
+    )[1];
 
     const { fillsToRefund } = await this.clients.bundleDataClient.loadData(blockRangesForChains, spokePoolClients);
     const maxRefundCount = this.maxRefundCountOverride
@@ -164,7 +164,7 @@ export class Dataworker {
       blockRangesForChains,
       this.clients.hubPoolClient.chainId,
       this.chainIdListForBundleEvaluationBlockNumbers
-    )[this.clients.hubPoolClient.chainId];
+    )[1];
     const allValidFillsInRange = getFillsInRange(
       allValidFills,
       blockRangesForChains,
@@ -289,7 +289,7 @@ export class Dataworker {
     // to construct the potential next bundle block range.
     const blockRangesForProposal = this._getWidestPossibleBlockRangeForNextBundle(
       spokePoolClients,
-      this.clients.hubPoolClient.latestBlockNumber - this.blockRangeEndBlockBuffer[hubPoolChainId]
+      this.clients.hubPoolClient.latestBlockNumber - this.blockRangeEndBlockBuffer[1]
     );
 
     // Exit early if spoke pool clients don't have early enough event data to satisfy block ranges for the
@@ -319,7 +319,7 @@ export class Dataworker {
       blockRangesForProposal,
       hubPoolChainId,
       this.chainIdListForBundleEvaluationBlockNumbers
-    )[hubPoolChainId];
+    )[1];
 
     // Create roots using constructed block ranges.
     const timerStart = Date.now();
@@ -707,7 +707,7 @@ export class Dataworker {
       blockRangesImpliedByBundleEndBlocks,
       hubPoolChainId,
       this.chainIdListForBundleEvaluationBlockNumbers
-    )[hubPoolChainId];
+    )[1];
     // If config store version isn't up to date, return early. This is a simple rule that is perhaps too aggressive
     // but the proposer role is a specialized one and the user should always be using updated software.
     if (!this.clients.configStoreClient.hasLatestConfigStoreVersion) {
@@ -1559,7 +1559,7 @@ export class Dataworker {
           blockNumberRanges,
           hubPoolChainId,
           this.chainIdListForBundleEvaluationBlockNumbers
-        )[hubPoolChainId];
+        )[1];
         const mainnetEndBlockTimestamp = (
           await this.clients.hubPoolClient.hubPool.provider.getBlock(endBlockForMainnet)
         ).timestamp;

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -102,7 +102,7 @@ export function getImpliedBundleBlockRanges(
   const enabledChains = configStoreClient.getEnabledChains(
     getBlockForChain(
       rootBundle.bundleEvaluationBlockNumbers.map((x) => x.toNumber()),
-      1,
+      hubPoolClient.chainId,
       chainIdListForBundleEvaluationBlockNumbers
     ),
     chainIdListForBundleEvaluationBlockNumbers

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -177,7 +177,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
 
   const mainnetBundleEndBlock = getBlockForChain(
     rootBundle.bundleEvaluationBlockNumbers,
-    1,
+    clients.hubPoolClient.chainId,
     dataworker.chainIdListForBundleEvaluationBlockNumbers
   );
 

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -99,7 +99,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
       }
       for (let i = 0; i < leaf.l1Tokens.length; i++) {
         const l1Token = leaf.l1Tokens[i];
-        const tokenInfo = clients.hubPoolClient.getTokenInfo(1, l1Token);
+        const tokenInfo = clients.hubPoolClient.getTokenInfo(clients.hubPoolClient.chainId, l1Token);
         if (!excesses[leaf.chainId]) {
           excesses[leaf.chainId] = {};
         }
@@ -399,7 +399,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
       // Reconstruct bundle block range for bundle.
       const mainnetBundleEndBlock = getBlockForChain(
         bundle.bundleEvaluationBlockNumbers.map((x) => x.toNumber()),
-        1,
+        clients.hubPoolClient.chainId,
         dataworker.chainIdListForBundleEvaluationBlockNumbers
       );
       const widestPossibleExpectedBlockRange = getWidestPossibleExpectedBlockRange(

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -41,7 +41,7 @@ export function getRefundInformationFromFill(
   // Save fill data and associate with repayment chain and L2 token refund should be denominated in.
   const endBlockForMainnet = getBlockRangeForChain(
     blockRangesForChains,
-    1,
+    hubPoolClient.chainId,
     chainIdListForBundleEvaluationBlockNumbers
   )[1];
   const l1TokenCounterpart = hubPoolClient.getL1TokenCounterpartAtBlock(

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -5,7 +5,7 @@ import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 import { DataworkerClients } from "../src/dataworker/DataworkerClientHelper";
 import { HubPoolClient, SpokePoolClient } from "../src/clients";
 import { getWidestPossibleExpectedBlockRange } from "../src/dataworker/PoolRebalanceUtils";
-import { CHAIN_ID_TEST_LIST, originChainId, toBN } from "./constants";
+import { originChainId, toBN } from "./constants";
 import { blockRangesAreInvalidForSpokeClients, getEndBlockBuffers } from "../src/dataworker/DataworkerUtils";
 import { getDeployedBlockNumber } from "@across-protocol/contracts-v2";
 
@@ -38,7 +38,7 @@ describe("Dataworker block range-related utility methods", async function () {
   });
   it("PoolRebalanceUtils.getWidestPossibleExpectedBlockRange", async function () {
     // End blocks equal to latest spoke client block, start block for first bundle equal to 0:
-    const chainIdListForBundleEvaluationBlockNumbers = CHAIN_ID_TEST_LIST;
+    const chainIdListForBundleEvaluationBlockNumbers = Object.keys(spokePoolClients).map((_chainId) => Number(_chainId)) ;
     const defaultEndBlockBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(1);
     const latestBlocks = await Promise.all(
       chainIdListForBundleEvaluationBlockNumbers.map(async (chainId: number, index) =>
@@ -94,19 +94,21 @@ describe("Dataworker block range-related utility methods", async function () {
     expect(zeroRange).to.deep.equal(latestBlocks.map(() => [0, 0]));
   });
   it("DataworkerUtils.blockRangesAreInvalidForSpokeClients", async function () {
+    const chainId = hubPoolClient.chainId;
+
     // Only use public chain IDs because getDeploymentBlockNumber will only work for real chain ID's. This is a hack
     // and getDeploymentBlockNumber should be changed to work in test environments.
-    const _spokePoolClients = { [1]: spokePoolClients[1] };
-    const chainIds = [1];
+    const _spokePoolClients = { [chainId]: spokePoolClients[chainId] };
+    const chainIds = [chainId];
 
     // Look if bundle range from block is before the latest invalid
     // bundle start block. If so, then the range is invalid.
 
-    const mainnetDeploymentBlock = spokePoolClients[1].deploymentBlock;
+    const mainnetDeploymentBlock = spokePoolClients[chainId].deploymentBlock;
     if (mainnetDeploymentBlock === 0) {
       throw new Error("Mainnet SpokePoolClient has not been updated");
     }
-    if (spokePoolClients[1].latestBlockNumber === 0) {
+    if (spokePoolClients[chainId].latestBlockNumber === 0) {
       throw new Error(`Chain ${spokePoolClients[1].chainId} SpokePoolClient has not been updated`);
     } else if (spokePoolClients[originChainId].latestBlockNumber === 0) {
       throw new Error(`Chain ${originChainId} SpokePoolClient has not been updated`);
@@ -124,18 +126,18 @@ describe("Dataworker block range-related utility methods", async function () {
     expect(
       blockRangesAreInvalidForSpokeClients(
         _spokePoolClients,
-        [[mainnetDeploymentBlock + 3, spokePoolClients[1].latestBlockNumber]],
+        [[mainnetDeploymentBlock + 3, spokePoolClients[chainId].latestBlockNumber]],
         chainIds,
-        { [1]: mainnetDeploymentBlock + 2 }
+        { [chainId]: mainnetDeploymentBlock + 2 }
       )
     ).to.equal(false);
     // Set block range toBlock > client's last block queried. Clients can no longer validate this block range.
     expect(
       blockRangesAreInvalidForSpokeClients(
         _spokePoolClients,
-        [[mainnetDeploymentBlock + 3, spokePoolClients[1].latestBlockNumber + 3]],
+        [[mainnetDeploymentBlock + 3, spokePoolClients[chainId].latestBlockNumber + 3]],
         chainIds,
-        { [1]: mainnetDeploymentBlock + 2 }
+        { [chainId]: mainnetDeploymentBlock + 2 }
       )
     ).to.equal(true);
     // Bundle block range toBlocks is less than
@@ -143,33 +145,33 @@ describe("Dataworker block range-related utility methods", async function () {
     expect(
       blockRangesAreInvalidForSpokeClients(
         _spokePoolClients,
-        [[mainnetDeploymentBlock + 1, spokePoolClients[1].latestBlockNumber]],
+        [[mainnetDeploymentBlock + 1, spokePoolClients[chainId].latestBlockNumber]],
         chainIds,
-        { [1]: mainnetDeploymentBlock + 2 }
+        { [chainId]: mainnetDeploymentBlock + 2 }
       )
     ).to.equal(true);
     // Works even if the condition is true for one chain.
     const optimismDeploymentBlock = getDeployedBlockNumber("SpokePool", 10);
     expect(
       blockRangesAreInvalidForSpokeClients(
-        { [1]: spokePoolClients[1], [10]: spokePoolClients[originChainId] },
+        { [chainId]: spokePoolClients[chainId], [10]: spokePoolClients[originChainId] },
         [
-          [mainnetDeploymentBlock + 1, spokePoolClients[1].latestBlockNumber],
+          [mainnetDeploymentBlock + 1, spokePoolClients[chainId].latestBlockNumber],
           [optimismDeploymentBlock + 3, spokePoolClients[originChainId].latestBlockNumber],
         ],
-        [1, 10],
-        { [1]: mainnetDeploymentBlock + 2, [10]: optimismDeploymentBlock + 2 }
+        [chainId, 10],
+        { [chainId]: mainnetDeploymentBlock + 2, [10]: optimismDeploymentBlock + 2 }
       )
     ).to.equal(true);
     expect(
       blockRangesAreInvalidForSpokeClients(
-        { [1]: spokePoolClients[1], [10]: spokePoolClients[originChainId] },
+        { [chainId]: spokePoolClients[chainId], [10]: spokePoolClients[originChainId] },
         [
-          [mainnetDeploymentBlock + 3, spokePoolClients[1].latestBlockNumber],
+          [mainnetDeploymentBlock + 3, spokePoolClients[chainId].latestBlockNumber],
           [optimismDeploymentBlock + 3, spokePoolClients[originChainId].latestBlockNumber],
         ],
-        [1, 10],
-        { [1]: mainnetDeploymentBlock + 2, [10]: optimismDeploymentBlock + 2 }
+        [chainId, 10],
+        { [chainId]: mainnetDeploymentBlock + 2, [10]: optimismDeploymentBlock + 2 }
       )
     ).to.equal(false);
 
@@ -177,13 +179,13 @@ describe("Dataworker block range-related utility methods", async function () {
     // the latest invalid start block. This means that the dataworker will refuse to validate any bundles with clients
     // that don't have early enough data for the first bundle, which started at the deployment block height.
     expect(
-      blockRangesAreInvalidForSpokeClients(_spokePoolClients, [[0, spokePoolClients[1].latestBlockNumber]], chainIds, {
-        [1]: mainnetDeploymentBlock + 2,
+      blockRangesAreInvalidForSpokeClients(_spokePoolClients, [[0, spokePoolClients[chainId].latestBlockNumber]], chainIds, {
+        [chainId]: mainnetDeploymentBlock + 2,
       })
     ).to.equal(true);
     expect(
-      blockRangesAreInvalidForSpokeClients(_spokePoolClients, [[0, spokePoolClients[1].latestBlockNumber]], chainIds, {
-        [1]: mainnetDeploymentBlock - 1,
+      blockRangesAreInvalidForSpokeClients(_spokePoolClients, [[0, spokePoolClients[chainId].latestBlockNumber]], chainIds, {
+        [chainId]: mainnetDeploymentBlock - 1,
       })
     ).to.equal(false);
   });

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -38,7 +38,9 @@ describe("Dataworker block range-related utility methods", async function () {
   });
   it("PoolRebalanceUtils.getWidestPossibleExpectedBlockRange", async function () {
     // End blocks equal to latest spoke client block, start block for first bundle equal to 0:
-    const chainIdListForBundleEvaluationBlockNumbers = Object.keys(spokePoolClients).map((_chainId) => Number(_chainId)) ;
+    const chainIdListForBundleEvaluationBlockNumbers = Object.keys(spokePoolClients).map((_chainId) =>
+      Number(_chainId)
+    );
     const defaultEndBlockBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(1);
     const latestBlocks = await Promise.all(
       chainIdListForBundleEvaluationBlockNumbers.map(async (chainId: number, index) =>
@@ -179,14 +181,24 @@ describe("Dataworker block range-related utility methods", async function () {
     // the latest invalid start block. This means that the dataworker will refuse to validate any bundles with clients
     // that don't have early enough data for the first bundle, which started at the deployment block height.
     expect(
-      blockRangesAreInvalidForSpokeClients(_spokePoolClients, [[0, spokePoolClients[chainId].latestBlockNumber]], chainIds, {
-        [chainId]: mainnetDeploymentBlock + 2,
-      })
+      blockRangesAreInvalidForSpokeClients(
+        _spokePoolClients,
+        [[0, spokePoolClients[chainId].latestBlockNumber]],
+        chainIds,
+        {
+          [chainId]: mainnetDeploymentBlock + 2,
+        }
+      )
     ).to.equal(true);
     expect(
-      blockRangesAreInvalidForSpokeClients(_spokePoolClients, [[0, spokePoolClients[chainId].latestBlockNumber]], chainIds, {
-        [chainId]: mainnetDeploymentBlock - 1,
-      })
+      blockRangesAreInvalidForSpokeClients(
+        _spokePoolClients,
+        [[0, spokePoolClients[chainId].latestBlockNumber]],
+        chainIds,
+        {
+          [chainId]: mainnetDeploymentBlock - 1,
+        }
+      )
     ).to.equal(false);
   });
 });

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -46,12 +46,11 @@ describe("Dataworker: Execute pool rebalances", async function () {
       MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF,
       DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD,
       0,
-      destinationChainId,
+      destinationChainId
     ));
   });
   it("Simple lifecycle", async function () {
     await updateAllClients();
-
 
     // Send a deposit and a fill so that dataworker builds simple roots.
     const deposit = await buildDeposit(

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -12,6 +12,9 @@ import { Dataworker } from "../src/dataworker/Dataworker";
 import { spokePoolClientsToProviders } from "../src/common";
 import { BalanceAllocator } from "../src/clients/BalanceAllocator";
 
+// Set to arbitrum to test that the dataworker sends ETH to the HubPool to test L1 --> Arbitrum message transfers.
+const destinationChainId = 42161;
+
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract;
 let l1Token_1: Contract, hubPool: Contract;
 let depositor: SignerWithAddress;
@@ -43,15 +46,12 @@ describe("Dataworker: Execute pool rebalances", async function () {
       MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF,
       DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD,
       0,
-      42161
+      destinationChainId,
     ));
   });
   it("Simple lifecycle", async function () {
     await updateAllClients();
 
-    // Set to arbitrum so we can test that the dataworker sends ETH to the HubPool to test L1 --> Arbitrum message
-    // transfers.
-    const destinationChainId = 42161;
 
     // Send a deposit and a fill so that dataworker builds simple roots.
     const deposit = await buildDeposit(
@@ -70,7 +70,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
 
     const providers = {
       ...spokePoolClientsToProviders(spokePoolClients),
-      [(await hubPool.provider.getNetwork()).chainId]: hubPool.provider,
+      [hubPoolClient.chainId]: hubPool.provider,
     };
 
     await dataworkerInstance.proposeRootBundle(spokePoolClients);

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -3,7 +3,7 @@ import { SignerWithAddress, expect, ethers, Contract, buildDeposit } from "./uti
 import { HubPoolClient, SpokePoolClient, MultiCallerClient } from "../src/clients";
 import { amountToDeposit, destinationChainId, BUNDLE_END_BLOCK_BUFFER, createRandomBytes32 } from "./constants";
 import { MAX_REFUNDS_PER_RELAYER_REFUND_LEAF, MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF } from "./constants";
-import { CHAIN_ID_TEST_LIST, DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD } from "./constants";
+import { DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD } from "./constants";
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 import { MAX_UINT_VAL, EMPTY_MERKLE_ROOT, utf8ToHex } from "../src/utils";
 
@@ -70,7 +70,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     }
     await updateAllClients();
     const latestBlock2 = await hubPool.provider.getBlockNumber();
-    const blockRange2 = CHAIN_ID_TEST_LIST.map(() => [0, latestBlock2]);
+    const blockRange2 = Object.keys(spokePoolClients).map(() => [0, latestBlock2]);
 
     // Construct expected roots before we propose new root so that last log contains logs about submitted txn.
     const expectedPoolRebalanceRoot2 = await dataworkerInstance.buildPoolRebalanceRoot(blockRange2, spokePoolClients);
@@ -137,7 +137,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await hubPool.emergencyDeleteProposal();
     await updateAllClients();
     const latestBlock4 = await hubPool.provider.getBlockNumber();
-    const blockRange4 = CHAIN_ID_TEST_LIST.map(() => [latestBlock2 + 1, latestBlock4]);
+    const blockRange4 = Object.keys(spokePoolClients).map(() => [latestBlock2 + 1, latestBlock4]);
     const expectedPoolRebalanceRoot4 = await dataworkerInstance.buildPoolRebalanceRoot(blockRange4, spokePoolClients);
     const expectedRelayerRefundRoot4 = await dataworkerInstance.buildRelayerRefundRoot(
       blockRange4,
@@ -148,7 +148,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     const expectedSlowRelayRefundRoot4 = await dataworkerInstance.buildSlowRelayRoot(blockRange4, spokePoolClients);
 
     await hubPool.proposeRootBundle(
-      Array(CHAIN_ID_TEST_LIST.length).fill(await hubPool.provider.getBlockNumber()),
+      Array(Object.keys(spokePoolClients).length).fill(await hubPool.provider.getBlockNumber()),
       expectedPoolRebalanceRoot4.leaves.length,
       expectedPoolRebalanceRoot4.tree.getHexRoot(),
       expectedRelayerRefundRoot4.tree.getHexRoot(),
@@ -166,7 +166,7 @@ describe("Dataworker: Validate pending root bundle", async function () {
     await hubPool.emergencyDeleteProposal();
     await updateAllClients();
     await hubPool.proposeRootBundle(
-      Array(CHAIN_ID_TEST_LIST.length).fill(0),
+      Array(Object.keys(spokePoolClients).length).fill(0),
       expectedPoolRebalanceRoot4.leaves.length,
       expectedPoolRebalanceRoot4.tree.getHexRoot(),
       expectedRelayerRefundRoot4.tree.getHexRoot(),
@@ -222,7 +222,8 @@ describe("Dataworker: Validate pending root bundle", async function () {
     // Bundle range length doesn't match expected chain ID list.
     await updateAllClients();
     await hubPool.proposeRootBundle(
-      Array(CHAIN_ID_TEST_LIST.length).fill(1).concat(1), // Add an extra chain.
+      // @todo: XXX Confirm the intent of this!
+      Array(Object.keys(spokePoolClients).length).fill(1).concat(1), // Add an extra chain.
       expectedPoolRebalanceRoot4.leaves.length,
       expectedPoolRebalanceRoot4.tree.getHexRoot(),
       expectedRelayerRefundRoot4.tree.getHexRoot(),
@@ -334,8 +335,8 @@ describe("Dataworker: Validate pending root bundle", async function () {
 
     const latestBlock = await hubPool.provider.getBlockNumber();
     await hubPool.connect(dataworker).proposeRootBundle(
-      CHAIN_ID_TEST_LIST.map(() => latestBlock),
-      CHAIN_ID_TEST_LIST.length,
+      Object.keys(spokePoolClients).map(() => latestBlock),
+      Object.keys(spokePoolClients).length,
       createRandomBytes32(),
       createRandomBytes32(),
       createRandomBytes32()

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -42,7 +42,7 @@ let updateAllClients: () => Promise<void>;
 
 const { spy, spyLogger } = createSpyLogger();
 
-const TEST_NETWORK_NAMES = ["Hardhat1", "Hardhat2", "Unknown", ALL_CHAINS_NAME];
+const TEST_NETWORK_NAMES = ["Hardhat1", "Hardhat2", "unknown", ALL_CHAINS_NAME];
 
 let defaultMonitorEnvVars;
 
@@ -71,7 +71,7 @@ describe("Monitor", async function () {
       0
     ));
 
-    const configuredNetworks = [1, repaymentChainId, originChainId, destinationChainId];
+    const configuredNetworks = [hubPoolClient.chainId, repaymentChainId, originChainId, destinationChainId];
 
     defaultMonitorEnvVars = {
       STARTING_BLOCK_NUMBER: "0",
@@ -92,7 +92,7 @@ describe("Monitor", async function () {
     // Set the config store version to 0 to match the default version in the ConfigStoreClient.
     process.env.CONFIG_STORE_VERSION = "0";
 
-    const chainIds = [1, repaymentChainId, originChainId, destinationChainId];
+    const chainIds = configuredNetworks;
     bundleDataClient = new BundleDataClient(
       spyLogger,
       {

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -157,7 +157,13 @@ export async function setupDataworker(
   );
 
   const configStoreClient = new MockConfigStoreClient(spyLogger, configStore);
-  const hubPoolClient = new clients.HubPoolClient(spyLogger, hubPool, configStoreClient);
+  const hubPoolClient = new clients.HubPoolClient(
+    spyLogger,
+    hubPool,
+    configStoreClient,
+    hubPoolDeploymentBlock,
+    hubPoolChainId
+  );
   const multiCallerClient = new MockedMultiCallerClient(spyLogger); // leave out the gasEstimator for now.
 
   const [spokePoolClient_1, spokePoolClient_2, spokePoolClient_3, spokePoolClient_4] =

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -13,8 +13,7 @@ import * as clients from "../../src/clients";
 import {
   amountToLp,
   destinationChainId as defaultDestinationChainId,
-  originChainId as defaultOriginChainid,
-  CHAIN_ID_TEST_LIST,
+  originChainId as defaultOriginChainId,
   repaymentChainId,
   MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF,
   MAX_REFUNDS_PER_RELAYER_REFUND_LEAF,
@@ -57,7 +56,7 @@ export async function setupDataworker(
   defaultPoolRebalanceTokenTransferThreshold: BigNumber,
   defaultEndBlockBuffer: number,
   destinationChainId = defaultDestinationChainId,
-  originChainId = defaultOriginChainid,
+  originChainId = defaultOriginChainId,
   lookbackForAllChains?: number
 ): Promise<{
   hubPool: Contract;
@@ -96,8 +95,8 @@ export async function setupDataworker(
   const { spokePool: spokePool_3 } = await deploySpokePoolWithToken(repaymentChainId, hubPoolChainId);
   const { spokePool: spokePool_4 } = await deploySpokePoolWithToken(hubPoolChainId, repaymentChainId);
   const spokePoolDeploymentBlocks = {
-    [defaultOriginChainid]: await spokePool_1.provider.getBlockNumber(),
-    [defaultDestinationChainId]: await spokePool_2.provider.getBlockNumber(),
+    [originChainId]: await spokePool_1.provider.getBlockNumber(),
+    [destinationChainId]: await spokePool_2.provider.getBlockNumber(),
     [repaymentChainId]: await spokePool_3.provider.getBlockNumber(),
     [hubPoolChainId]: await spokePool_4.provider.getBlockNumber(),
   };
@@ -165,7 +164,7 @@ export async function setupDataworker(
   const [spokePoolClient_1, spokePoolClient_2, spokePoolClient_3, spokePoolClient_4] =
     await _constructSpokePoolClientsWithLookback(
       [spokePool_1, spokePool_2, spokePool_3, spokePool_4],
-      [defaultOriginChainid, defaultDestinationChainId, repaymentChainId, hubPoolChainId],
+      [originChainId, destinationChainId, repaymentChainId, hubPoolChainId],
       spyLogger,
       relayer,
       configStoreClient,
@@ -312,7 +311,7 @@ export async function setupFastDataworker(
     DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD,
     0,
     defaultDestinationChainId,
-    defaultOriginChainid,
+    defaultOriginChainId,
     lookbackForAllChains
   );
 }

--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -88,33 +88,23 @@ export async function setupDataworker(
   dataworkerClients: DataworkerClients;
   updateAllClients: () => Promise<void>;
 }> {
-  // Replace origin chainId and destination chain id in the chainIdList.
-  const testChainIdList = CHAIN_ID_TEST_LIST.map((chainId) => {
-    switch (chainId) {
-      case defaultDestinationChainId:
-        return destinationChainId;
-      case defaultOriginChainid:
-        return originChainId;
-      default:
-        return chainId;
-    }
-  });
-
   const [owner, depositor, relayer, dataworker] = await ethers.getSigners();
+  const hubPoolChainId = await owner.getChainId();
 
   const { spokePool: spokePool_1, erc20: erc20_1 } = await deploySpokePoolWithToken(originChainId, destinationChainId);
   const { spokePool: spokePool_2, erc20: erc20_2 } = await deploySpokePoolWithToken(destinationChainId, originChainId);
-  const { spokePool: spokePool_3 } = await deploySpokePoolWithToken(repaymentChainId, 1);
-  const { spokePool: spokePool_4 } = await deploySpokePoolWithToken(1, repaymentChainId);
+  const { spokePool: spokePool_3 } = await deploySpokePoolWithToken(repaymentChainId, hubPoolChainId);
+  const { spokePool: spokePool_4 } = await deploySpokePoolWithToken(hubPoolChainId, repaymentChainId);
   const spokePoolDeploymentBlocks = {
     [defaultOriginChainid]: await spokePool_1.provider.getBlockNumber(),
     [defaultDestinationChainId]: await spokePool_2.provider.getBlockNumber(),
     [repaymentChainId]: await spokePool_3.provider.getBlockNumber(),
-    [1]: await spokePool_4.provider.getBlockNumber(),
+    [hubPoolChainId]: await spokePool_4.provider.getBlockNumber(),
   };
+  const testChainIdList = Object.keys(spokePoolDeploymentBlocks).map((_chainId) => Number(_chainId));
 
   const umaEcosystem = await setupUmaEcosystem(owner);
-  const { hubPool, l1Token_1, l1Token_2 } = await deployAndConfigureHubPool(
+  const { hubPool, hubPoolDeploymentBlock, l1Token_1, l1Token_2 } = await deployAndConfigureHubPool(
     owner,
     [
       { l2ChainId: destinationChainId, spokePool: spokePool_2 },
@@ -122,7 +112,7 @@ export async function setupDataworker(
       // Following spoke pool destinations should not be used in tests but need to be set for dataworker to fetch
       // spoke pools for those chains in proposeRootBundle
       { l2ChainId: repaymentChainId, spokePool: spokePool_3 },
-      { l2ChainId: 1, spokePool: spokePool_4 },
+      { l2ChainId: hubPoolChainId, spokePool: spokePool_4 },
     ],
     umaEcosystem.finder.address,
     umaEcosystem.timer.address
@@ -131,8 +121,6 @@ export async function setupDataworker(
   // Enable deposit routes for second L2 tokens so relays can be sent between spoke pool 1 <--> 2.
   await enableRoutes(spokePool_1, [{ originToken: erc20_2.address, destinationChainId: destinationChainId }]);
   await enableRoutes(spokePool_2, [{ originToken: erc20_1.address, destinationChainId: originChainId }]);
-
-  const hubPoolChainId = (await hubPool.provider.getNetwork()).chainId;
 
   // For each chain, enable routes to both erc20's so that we can fill relays
   await enableRoutesOnHubPool(hubPool, [
@@ -169,7 +157,7 @@ export async function setupDataworker(
     defaultPoolRebalanceTokenTransferThreshold
   );
 
-  const hubPoolClient = new clients.HubPoolClient(spyLogger, hubPool);
+  const hubPoolClient = new clients.HubPoolClient(spyLogger, hubPool, hubPoolDeploymentBlock, hubPoolChainId);
   const configStoreClient = new MockConfigStoreClient(spyLogger, configStore, hubPoolClient);
 
   const multiCallerClient = new MockedMultiCallerClient(spyLogger); // leave out the gasEstimator for now.
@@ -177,7 +165,7 @@ export async function setupDataworker(
   const [spokePoolClient_1, spokePoolClient_2, spokePoolClient_3, spokePoolClient_4] =
     await _constructSpokePoolClientsWithLookback(
       [spokePool_1, spokePool_2, spokePool_3, spokePool_4],
-      [defaultOriginChainid, defaultDestinationChainId, repaymentChainId, 1],
+      [defaultOriginChainid, defaultDestinationChainId, repaymentChainId, hubPoolChainId],
       spyLogger,
       relayer,
       configStoreClient,
@@ -193,7 +181,7 @@ export async function setupDataworker(
     [originChainId]: spokePoolClient_1,
     [destinationChainId]: spokePoolClient_2,
     [repaymentChainId]: spokePoolClient_3,
-    1: spokePoolClient_4,
+    [hubPoolChainId]: spokePoolClient_4,
   };
   const profitClient = new clients.ProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
   const bundleDataClient = new BundleDataClient(

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -110,7 +110,7 @@ export function createSpyLogger() {
 
 export async function deploySpokePoolWithToken(fromChainId = 0, toChainId = 0, enableRoute = true) {
   const { timer, weth, erc20, spokePool, unwhitelistedErc20, destErc20 } = await utils.deploySpokePool(utils.ethers);
-  const deploymentBlock = await spokePool.provider.getBlockNumber();
+  const receipt = await spokePool.deployTransaction.wait();
 
   await spokePool.setChainId(fromChainId == 0 ? utils.originChainId : fromChainId);
 
@@ -120,7 +120,7 @@ export async function deploySpokePoolWithToken(fromChainId = 0, toChainId = 0, e
       { originToken: weth.address, destinationChainId: toChainId == 0 ? utils.destinationChainId : toChainId },
     ]);
   }
-  return { timer, weth, erc20, spokePool, unwhitelistedErc20, destErc20, deploymentBlock };
+  return { timer, weth, erc20, spokePool, unwhitelistedErc20, destErc20, deploymentBlock: receipt.blockNumber };
 }
 
 export async function deployConfigStore(
@@ -163,6 +163,7 @@ export async function deployAndConfigureHubPool(
   const hubPool = await (
     await utils.getContractFactory("HubPool", signer)
   ).deploy(lpTokenFactory.address, finderAddress, zeroAddress, timerAddress);
+  const receipt = await hubPool.deployTransaction.wait();
 
   const mockAdapter = await (await utils.getContractFactory("Mock_Adapter", signer)).deploy();
 
@@ -175,7 +176,7 @@ export async function deployAndConfigureHubPool(
   const l1Token_2 = await (await utils.getContractFactory("ExpandedERC20", signer)).deploy("Rando L1", "L1", 18);
   await l1Token_2.addMember(TokenRolesEnum.MINTER, signer.address);
 
-  return { hubPool, mockAdapter, l1Token_1, l1Token_2 };
+  return { hubPool, mockAdapter, l1Token_1, l1Token_2, hubPoolDeploymentBlock: receipt.blockNumber };
 }
 
 export async function deployNewToken(owner) {


### PR DESCRIPTION
Removes the so-far identified constraints that would prohibit running with a HubPool
deployed to a network with a chainId other than 1.

Fixes ACX-1152