### PR TITLE
fix(fixture): Fix chainIds in Dataworker fixture

### DIFF
--- a/test/fixtures/Dataworker.Fixture.ts
+++ b/test/fixtures/Dataworker.Fixture.ts
@@ -13,7 +13,7 @@ import * as clients from "../../src/clients";
 import {
   amountToLp,
   destinationChainId as defaultDestinationChainId,
-  originChainId as defaultOriginChainid,
+  originChainId as defaultOriginChainId,
   CHAIN_ID_TEST_LIST,
   repaymentChainId,
   MAX_L1_TOKENS_PER_POOL_REBALANCE_LEAF,
@@ -57,7 +57,7 @@ export async function setupDataworker(
   defaultPoolRebalanceTokenTransferThreshold: BigNumber,
   defaultEndBlockBuffer: number,
   destinationChainId = defaultDestinationChainId,
-  originChainId = defaultOriginChainid,
+  originChainId = defaultOriginChainId,
   lookbackForAllChains?: number
 ): Promise<{
   hubPool: Contract;
@@ -93,7 +93,7 @@ export async function setupDataworker(
     switch (chainId) {
       case defaultDestinationChainId:
         return destinationChainId;
-      case defaultOriginChainid:
+      case defaultOriginChainId:
         return originChainId;
       default:
         return chainId;
@@ -107,8 +107,8 @@ export async function setupDataworker(
   const { spokePool: spokePool_3 } = await deploySpokePoolWithToken(repaymentChainId, 1);
   const { spokePool: spokePool_4 } = await deploySpokePoolWithToken(1, repaymentChainId);
   const spokePoolDeploymentBlocks = {
-    [defaultOriginChainid]: await spokePool_1.provider.getBlockNumber(),
-    [defaultDestinationChainId]: await spokePool_2.provider.getBlockNumber(),
+    [originChainId]: await spokePool_1.provider.getBlockNumber(),
+    [destinationChainId]: await spokePool_2.provider.getBlockNumber(),
     [repaymentChainId]: await spokePool_3.provider.getBlockNumber(),
     [1]: await spokePool_4.provider.getBlockNumber(),
   };
@@ -177,7 +177,7 @@ export async function setupDataworker(
   const [spokePoolClient_1, spokePoolClient_2, spokePoolClient_3, spokePoolClient_4] =
     await _constructSpokePoolClientsWithLookback(
       [spokePool_1, spokePool_2, spokePool_3, spokePool_4],
-      [defaultOriginChainid, defaultDestinationChainId, repaymentChainId, 1],
+      [originChainId, destinationChainId, repaymentChainId, 1],
       spyLogger,
       relayer,
       configStoreClient,
@@ -324,7 +324,7 @@ export async function setupFastDataworker(
     DEFAULT_POOL_BALANCE_TOKEN_TRANSFER_THRESHOLD,
     0,
     defaultDestinationChainId,
-    defaultOriginChainid,
+    defaultOriginChainId,
     lookbackForAllChains
   );
 }


### PR DESCRIPTION
Driveby fix:
 - Use the correct chainIds after SpokePool deployment.
 - Correct minor typo (originChainid => originChainId).