### PR TITLE
fix: Ensure ordering of client updates

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -261,7 +261,8 @@ export async function constructClients(
 }
 
 export async function updateClients(clients: Clients): Promise<void> {
-  await Promise.all([clients.hubPoolClient.update(), clients.configStoreClient.update()]);
+  await clients.configStoreClient.update();
+  await clients.hubPoolClient.update();
 }
 
 export function spokePoolClientsToProviders(spokePoolClients: { [chainId: number]: SpokePoolClient }): {


### PR DESCRIPTION
The HubPoolClient must now be updated _after_ the ConfigStoreClient.