### PR TITLE
fix: fix field comparison error

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -89,6 +89,9 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
   // back after we do the comparison with unignored keys. This is a faster algorithm than cloning an object but it has
   // some side effects such as the order of keys in the rpcResults object changing.
   const deleteIgnoredKeys = (ignoredKeys: string[], rpcResults: any) => {
+    if (!rpcResults) {
+      return;
+    }
     const ignoredMappings = {};
     for (const key of ignoredKeys) {
       ignoredMappings[key] = rpcResults[key];


### PR DESCRIPTION
This handles an issue where one of the rpc response passed into the compareRpcResults method is undefined or null and can't be accessed as an object. In this case, the method that checks for ignored fields first checks if the value is present before attempting to modify it.