### PR TITLE
improve: Handle case where chain has stopped advancing

### DIFF
--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -425,34 +425,43 @@ export function getWidestPossibleExpectedBlockRange(
   latestMainnetBlock: number,
   enabledChains: number[]
 ): number[][] {
+  // We subtract a buffer from the end blocks to reduce the chance that network providers
+  // for different bot runs produce different contract state because of variability near the HEAD of the network.
+  // Reducing the latest block that we query also gives partially filled deposits slightly more buffer for relayers
+  // to fully fill the deposit and reduces the chance that the data worker includes a slow fill payment that gets
+  // filled during the challenge period.
+  const latestPossibleBundleEndBlockNumbers = chainIdListForBundleEvaluationBlockNumbers.map(
+    (chainId: number, index) =>
+      spokeClients[chainId] && Math.max(spokeClients[chainId].latestBlockNumber - endBlockBuffers[index], 0)
+  );
   return chainIdListForBundleEvaluationBlockNumbers.map((chainId: number, index) => {
+    const lastEndBlockForChain = clients.hubPoolClient.getLatestBundleEndBlockForChain(
+      chainIdListForBundleEvaluationBlockNumbers,
+      latestMainnetBlock,
+      chainId
+    );
+
     // If chain is disabled, re-use the latest bundle end block for the chain as both the start
     // and end block.
     if (!enabledChains.includes(chainId)) {
-      const lastEndBlockForDisabledChain = clients.hubPoolClient.getLatestBundleEndBlockForChain(
-        chainIdListForBundleEvaluationBlockNumbers,
-        latestMainnetBlock,
-        chainId
-      );
-      return [lastEndBlockForDisabledChain, lastEndBlockForDisabledChain];
+      return [lastEndBlockForChain, lastEndBlockForChain];
     } else {
-      // We subtract a buffer from the end blocks to reduce the chance that network providers
-      // for different bot runs produce different contract state because of variability near the HEAD of the network.
-      // Reducing the latest block that we query also gives partially filled deposits slightly more buffer for relayers
-      // to fully fill the deposit and reduces the chance that the data worker includes a slow fill payment that gets
-      // filled during the challenge period.
-      const latestPossibleBundleEndBlockNumbers = chainIdListForBundleEvaluationBlockNumbers.map(
-        (chainId: number, index) =>
-          spokeClients[chainId] && Math.max(spokeClients[chainId].latestBlockNumber - endBlockBuffers[index], 0)
-      );
-      return [
-        clients.hubPoolClient.getNextBundleStartBlockNumber(
-          chainIdListForBundleEvaluationBlockNumbers,
-          latestMainnetBlock,
-          chainId
-        ),
-        latestPossibleBundleEndBlockNumbers[index],
-      ];
+      // If the latest block hasn't advanced enough from the previous proposed end block, then re-use it. It will
+      // be regarded as disabled by the Dataworker clients. Otherwise, add 1 to the previous proposed end block.
+      if (lastEndBlockForChain >= latestPossibleBundleEndBlockNumbers[index]) {
+        return [lastEndBlockForChain, lastEndBlockForChain];
+      } else {
+        // Chain has advanced far enough including the buffer, return range from previous proposed end block + 1 to
+        // latest block for chain minus buffer.
+        return [
+          clients.hubPoolClient.getNextBundleStartBlockNumber(
+            chainIdListForBundleEvaluationBlockNumbers,
+            latestMainnetBlock,
+            chainId
+          ),
+          latestPossibleBundleEndBlockNumbers[index],
+        ];
+      }
     }
   });
 }

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -449,6 +449,8 @@ export function getWidestPossibleExpectedBlockRange(
       // If the latest block hasn't advanced enough from the previous proposed end block, then re-use it. It will
       // be regarded as disabled by the Dataworker clients. Otherwise, add 1 to the previous proposed end block.
       if (lastEndBlockForChain >= latestPossibleBundleEndBlockNumbers[index]) {
+        // @dev: Without this check, then `getNextBundleStartBlockNumber` could return `latestBlock+1` even when the
+        // latest block for the chain hasn't advanced, resulting in an invalid range being produced.
         return [lastEndBlockForChain, lastEndBlockForChain];
       } else {
         // Chain has advanced far enough including the buffer, return range from previous proposed end block + 1 to

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -425,8 +425,7 @@ export function getWidestPossibleExpectedBlockRange(
   latestMainnetBlock: number,
   enabledChains: number[]
 ): number[][] {
-  // We subtract a buffer from the end blocks to reduce the chance that network providers
-  // for different bot runs produce different contract state because of variability near the HEAD of the network.
+  // We impose a buffer on the head of the chain to increase the probability that the received blocks are final.
   // Reducing the latest block that we query also gives partially filled deposits slightly more buffer for relayers
   // to fully fill the deposit and reduces the chance that the data worker includes a slow fill payment that gets
   // filled during the challenge period.

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -8,6 +8,7 @@ import { getWidestPossibleExpectedBlockRange } from "../src/dataworker/PoolRebal
 import { originChainId, toBN } from "./constants";
 import { blockRangesAreInvalidForSpokeClients, getEndBlockBuffers } from "../src/dataworker/DataworkerUtils";
 import { getDeployedBlockNumber } from "@across-protocol/contracts-v2";
+import { MockHubPoolClient } from "./mocks";
 
 let dataworkerClients: DataworkerClients;
 let spokePoolClients: { [chainId: number]: SpokePoolClient };
@@ -95,6 +96,50 @@ describe("Dataworker block range-related utility methods", async function () {
     );
     expect(zeroRange).to.deep.equal(latestBlocks.map(() => [0, 0]));
   });
+  it("PoolRebalanceUtils.getWidestPossibleExpectedBlockRange: chain is paused", async function() {
+    const mockHubPoolClient = new MockHubPoolClient(
+      hubPoolClient
+    )
+
+    const chainIdListForBundleEvaluationBlockNumbers = Object.keys(spokePoolClients).map((_chainId) =>
+      Number(_chainId)
+    );
+    
+
+    // Set bundle end blocks equal to spoke pool clients latest blocks to simulate a chain being paused:
+    // - Buffers are 0: 
+    let defaultEndBlockBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(0);
+    chainIdListForBundleEvaluationBlockNumbers.forEach((_chainId) => {
+      mockHubPoolClient.setLatestBundleEndBlockForChain(_chainId, spokePoolClients[_chainId].latestBlockNumber);
+  });
+    expect(getWidestPossibleExpectedBlockRange(
+      chainIdListForBundleEvaluationBlockNumbers,
+      spokePoolClients,
+      defaultEndBlockBuffers,
+      {
+        ...dataworkerClients,
+        hubPoolClient: mockHubPoolClient
+      },
+      0,
+      chainIdListForBundleEvaluationBlockNumbers
+    )).to.deep.equal(chainIdListForBundleEvaluationBlockNumbers.map((_chainId) => [spokePoolClients[_chainId].latestBlockNumber, spokePoolClients[_chainId].latestBlockNumber]));
+
+
+    // - Works with Buffers > 0 such that the latest blocks minus buffers are < latest bundle end blocks.
+    defaultEndBlockBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(10);
+    expect(getWidestPossibleExpectedBlockRange(
+      chainIdListForBundleEvaluationBlockNumbers,
+      spokePoolClients,
+      defaultEndBlockBuffers,
+      {
+        ...dataworkerClients,
+        hubPoolClient: mockHubPoolClient
+      },
+      0,
+      chainIdListForBundleEvaluationBlockNumbers
+    )).to.deep.equal(chainIdListForBundleEvaluationBlockNumbers.map((_chainId) => [spokePoolClients[_chainId].latestBlockNumber, spokePoolClients[_chainId].latestBlockNumber]));
+
+  })
   it("DataworkerUtils.blockRangesAreInvalidForSpokeClients", async function () {
     const chainId = hubPoolClient.chainId;
 

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -97,7 +97,13 @@ describe("Dataworker block range-related utility methods", async function () {
     expect(zeroRange).to.deep.equal(latestBlocks.map(() => [0, 0]));
   });
   it("PoolRebalanceUtils.getWidestPossibleExpectedBlockRange: chain is paused", async function () {
-    const mockHubPoolClient = new MockHubPoolClient(hubPoolClient);
+    const mockHubPoolClient = new MockHubPoolClient(
+      hubPoolClient.logger,
+      hubPoolClient.hubPool,
+      dataworkerClients.configStoreClient,
+      hubPoolClient.deploymentBlock,
+      hubPoolClient.chainId
+    );
 
     const chainIdListForBundleEvaluationBlockNumbers = Object.keys(spokePoolClients).map((_chainId) =>
       Number(_chainId)

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -96,50 +96,59 @@ describe("Dataworker block range-related utility methods", async function () {
     );
     expect(zeroRange).to.deep.equal(latestBlocks.map(() => [0, 0]));
   });
-  it("PoolRebalanceUtils.getWidestPossibleExpectedBlockRange: chain is paused", async function() {
-    const mockHubPoolClient = new MockHubPoolClient(
-      hubPoolClient
-    )
+  it("PoolRebalanceUtils.getWidestPossibleExpectedBlockRange: chain is paused", async function () {
+    const mockHubPoolClient = new MockHubPoolClient(hubPoolClient);
 
     const chainIdListForBundleEvaluationBlockNumbers = Object.keys(spokePoolClients).map((_chainId) =>
       Number(_chainId)
     );
-    
 
     // Set bundle end blocks equal to spoke pool clients latest blocks to simulate a chain being paused:
-    // - Buffers are 0: 
+    // - Buffers are 0:
     let defaultEndBlockBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(0);
     chainIdListForBundleEvaluationBlockNumbers.forEach((_chainId) => {
       mockHubPoolClient.setLatestBundleEndBlockForChain(_chainId, spokePoolClients[_chainId].latestBlockNumber);
-  });
-    expect(getWidestPossibleExpectedBlockRange(
-      chainIdListForBundleEvaluationBlockNumbers,
-      spokePoolClients,
-      defaultEndBlockBuffers,
-      {
-        ...dataworkerClients,
-        hubPoolClient: mockHubPoolClient
-      },
-      0,
-      chainIdListForBundleEvaluationBlockNumbers
-    )).to.deep.equal(chainIdListForBundleEvaluationBlockNumbers.map((_chainId) => [spokePoolClients[_chainId].latestBlockNumber, spokePoolClients[_chainId].latestBlockNumber]));
-
+    });
+    expect(
+      getWidestPossibleExpectedBlockRange(
+        chainIdListForBundleEvaluationBlockNumbers,
+        spokePoolClients,
+        defaultEndBlockBuffers,
+        {
+          ...dataworkerClients,
+          hubPoolClient: mockHubPoolClient,
+        },
+        0,
+        chainIdListForBundleEvaluationBlockNumbers
+      )
+    ).to.deep.equal(
+      chainIdListForBundleEvaluationBlockNumbers.map((_chainId) => [
+        spokePoolClients[_chainId].latestBlockNumber,
+        spokePoolClients[_chainId].latestBlockNumber,
+      ])
+    );
 
     // - Works with Buffers > 0 such that the latest blocks minus buffers are < latest bundle end blocks.
     defaultEndBlockBuffers = Array(chainIdListForBundleEvaluationBlockNumbers.length).fill(10);
-    expect(getWidestPossibleExpectedBlockRange(
-      chainIdListForBundleEvaluationBlockNumbers,
-      spokePoolClients,
-      defaultEndBlockBuffers,
-      {
-        ...dataworkerClients,
-        hubPoolClient: mockHubPoolClient
-      },
-      0,
-      chainIdListForBundleEvaluationBlockNumbers
-    )).to.deep.equal(chainIdListForBundleEvaluationBlockNumbers.map((_chainId) => [spokePoolClients[_chainId].latestBlockNumber, spokePoolClients[_chainId].latestBlockNumber]));
-
-  })
+    expect(
+      getWidestPossibleExpectedBlockRange(
+        chainIdListForBundleEvaluationBlockNumbers,
+        spokePoolClients,
+        defaultEndBlockBuffers,
+        {
+          ...dataworkerClients,
+          hubPoolClient: mockHubPoolClient,
+        },
+        0,
+        chainIdListForBundleEvaluationBlockNumbers
+      )
+    ).to.deep.equal(
+      chainIdListForBundleEvaluationBlockNumbers.map((_chainId) => [
+        spokePoolClients[_chainId].latestBlockNumber,
+        spokePoolClients[_chainId].latestBlockNumber,
+      ])
+    );
+  });
   it("DataworkerUtils.blockRangesAreInvalidForSpokeClients", async function () {
     const chainId = hubPoolClient.chainId;
 

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -7,17 +7,15 @@ export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
   public chainId: number;
 
   // For convenience, allow caller to base this Mock after already constructed HubPoolClient.
-  constructor(
-    hubPoolClient: clients.HubPoolClient
-    ) {
+  constructor(hubPoolClient: clients.HubPoolClient) {
     super(hubPoolClient.logger, hubPoolClient.hubPool, hubPoolClient.configStoreClient, hubPoolClient.deploymentBlock);
     this.chainId = hubPoolClient.chainId;
-    }
+  }
 
-    setLatestBundleEndBlockForChain(chainId: number, latestBundleEndBlock: number): void {
-        this.latestBundleEndBlocks[chainId] = latestBundleEndBlock;
-    }
-    getLatestBundleEndBlockForChain(_chainIdList: number[], _latestMainnetBlock: number, chainId: number): number {
-        return this.latestBundleEndBlocks[chainId] ?? 0;
-    }
+  setLatestBundleEndBlockForChain(chainId: number, latestBundleEndBlock: number): void {
+    this.latestBundleEndBlocks[chainId] = latestBundleEndBlock;
+  }
+  getLatestBundleEndBlockForChain(_chainIdList: number[], _latestMainnetBlock: number, chainId: number): number {
+    return this.latestBundleEndBlocks[chainId] ?? 0;
+  }
 }

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -1,15 +1,22 @@
 import { clients } from "@across-protocol/sdk-v2";
+import { Contract, winston } from "../utils";
+import { ConfigStoreClient } from "../../src/clients";
 
-// Adds mocked functions to HubPoolClient to facilitate Dataworker unit testing.
+// Adds functions to MockHubPoolClient to facilitate Dataworker unit testing.
 export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
   public latestBundleEndBlocks: { [chainId: number]: number } = {};
 
   public chainId: number;
 
-  // For convenience, allow caller to base this Mock after already constructed HubPoolClient.
-  constructor(hubPoolClient: clients.HubPoolClient) {
-    super(hubPoolClient.logger, hubPoolClient.hubPool, hubPoolClient.configStoreClient, hubPoolClient.deploymentBlock);
-    this.chainId = hubPoolClient.chainId;
+  constructor(
+    logger: winston.Logger,
+    hubPool: Contract,
+    configStoreClient: ConfigStoreClient,
+    deploymentBlock = 0,
+    chainId = 1
+  ) {
+    super(logger, hubPool, configStoreClient, deploymentBlock);
+    this.chainId = chainId;
   }
 
   setLatestBundleEndBlockForChain(chainId: number, latestBundleEndBlock: number): void {

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -1,0 +1,23 @@
+import { clients } from "@across-protocol/sdk-v2";
+
+// Adds mocked functions to HubPoolClient to facilitate Dataworker unit testing.
+export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
+  public latestBundleEndBlocks: { [chainId: number]: number } = {};
+
+  public chainId: number;
+
+  // For convenience, allow caller to base this Mock after already constructed HubPoolClient.
+  constructor(
+    hubPoolClient: clients.HubPoolClient
+    ) {
+    super(hubPoolClient.logger, hubPoolClient.hubPool, hubPoolClient.configStoreClient, hubPoolClient.deploymentBlock);
+    this.chainId = hubPoolClient.chainId;
+    }
+
+    setLatestBundleEndBlockForChain(chainId: number, latestBundleEndBlock: number): void {
+        this.latestBundleEndBlocks[chainId] = latestBundleEndBlock;
+    }
+    getLatestBundleEndBlockForChain(_chainIdList: number[], _latestMainnetBlock: number, chainId: number): number {
+        return this.latestBundleEndBlocks[chainId] ?? 0;
+    }
+}

--- a/test/mocks/index.ts
+++ b/test/mocks/index.ts
@@ -1,9 +1,9 @@
 import { clients } from "@across-protocol/sdk-v2";
 
-export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {}
 export class MockSpokePoolClient extends clients.mocks.MockSpokePoolClient {}
 
 export * from "./MockConfigStoreClient";
+export * from "./MockHubPoolClient";
 export * from "./MockBundleDataClient";
 export * from "./MockProfitClient";
 export * from "./MockAdapterManager";


### PR DESCRIPTION
Adds one additional check to function that returns next bundle block range to propose to handle case where the `latest` block has stopped advancing.