### PR TITLE
fix(relayer): Don't construct API client with disabled destination chains

### DIFF
--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -34,10 +34,18 @@ export async function constructRelayerClients(
     config.maxRelayerLookBack
   );
 
+  // We only use the API client to load /limits for chains so we should remove any chains that are not included in the
+  // destination chain list.
+  const destinationSpokePoolClients = Object.fromEntries(
+    Object.keys(spokePoolClients)
+      .filter((chainId) => config.relayerDestinationChains.includes(Number(chainId)))
+      .map((chainId) => [chainId, spokePoolClients[chainId]])
+  );
+
   const acrossApiClient = new AcrossApiClient(
     logger,
     commonClients.hubPoolClient,
-    spokePoolClients,
+    destinationSpokePoolClients,
     config.relayerTokens
   );
   const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);


### PR DESCRIPTION
There is no need to call /limits on disabled destination chains