### PR TITLE
fix(disputer): Should evaluate pending block range from previous `bundleEndBlock` rather than previous `bundleEndBlock+1`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # Across V2 Relayer
 
-This code implements [UMIP-157](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-157.md) and interacts with these [smart contracts](https://github.com/across-protocol/contracts-v2). The contracts were audited [by OpenZeppelin](https://blog.openzeppelin.com/uma-across-v2-audit/). 
+This code implements [UMIP-157](https://github.com/UMAprotocol/UMIPs/blob/master/UMIPs/umip-157.md) and interacts with these [smart contracts](https://github.com/across-protocol/contracts-v2). The contracts were audited [by OpenZeppelin](https://blog.openzeppelin.com/uma-across-v2-audit/).
 
 # How to run a Relayer
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -601,7 +601,7 @@ export class Dataworker {
     );
 
     // Make sure that all end blocks are >= expected start blocks. Allow for situation where chain was halted
-    // and bundle end blocks hadn't advanced at time of proposal, meaning that the end blocks were equal to the 
+    // and bundle end blocks hadn't advanced at time of proposal, meaning that the end blocks were equal to the
     // previous end blocks. So, even if by the time the disputer runs, the chain has started advancing again, then
     // the proposed block is at most 1 behind the next expected block range.
     if (

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -606,7 +606,7 @@ export class Dataworker {
     // the proposed block is at most 1 behind the next expected block range.
     if (
       rootBundle.bundleEvaluationBlockNumbers.some(
-        (block, index) => block - 1 < widestPossibleExpectedBlockRange[index][0]
+        (block, index) => block + 1 < widestPossibleExpectedBlockRange[index][0]
       )
     ) {
       this.logger.debug({

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -600,9 +600,14 @@ export class Dataworker {
       this.blockRangeEndBlockBuffer
     );
 
-    // Make sure that all end blocks are >= expected start blocks.
+    // Make sure that all end blocks are >= expected start blocks. Allow for situation where chain was halted
+    // and bundle end blocks hadn't advanced at time of proposal, meaning that the end blocks were equal to the 
+    // previous end blocks. So, even if by the time the disputer runs, the chain has started advancing again, then
+    // the proposed block is at most 1 behind the next expected block range.
     if (
-      rootBundle.bundleEvaluationBlockNumbers.some((block, index) => block < widestPossibleExpectedBlockRange[index][0])
+      rootBundle.bundleEvaluationBlockNumbers.some(
+        (block, index) => block - 1 < widestPossibleExpectedBlockRange[index][0]
+      )
     ) {
       this.logger.debug({
         at: "Dataworker#validate",


### PR DESCRIPTION
Handles very unlikely edge case where proposer proposed when chain was halted but chain restarted during challenge window. In this case, the proposer might have proposed block range [100, 100] because the chain was halted at block 100, while disputer now thinks chain has advanced to block 150 and believes the "widest possible" block range is now [101, 150].
