### PR TITLE
fix: Support Bedrock finalizations

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@arbitrum/sdk": "^3.1.3",
     "@across-protocol/sdk-v2": "0.8.1",
     "@defi-wonderland/smock": "^2.3.4",
-    "@eth-optimism/sdk": "^2.0.2",
+    "@eth-optimism/sdk": "^2.1.0",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/abstract-signer": "^5.7.0",

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -56,7 +56,11 @@ export async function finalize(
   // Note: Could move this into a client in the future to manage # of calls and chunk calls based on
   // input byte length.
   const multicall2 = getMultisender(1, hubSigner);
-  const finalizationsToBatch: { callData: Multicall2Call[]; withdrawals: Withdrawal[]; optimismL1Proofs: Withdrawal[] } = {
+  const finalizationsToBatch: {
+    callData: Multicall2Call[];
+    withdrawals: Withdrawal[];
+    optimismL1Proofs: Withdrawal[];
+  } = {
     callData: [],
     withdrawals: [],
     optimismL1Proofs: [],
@@ -191,9 +195,7 @@ export async function finalize(
       finalizationsToBatch.optimismL1Proofs.forEach((withdrawal) => {
         logger.info({
           at: "Finalizer",
-          message: `Submitted L1 proof for Optimism and thereby initiating withdrawal for ${withdrawal.amount} of ${
-            withdrawal.l1TokenSymbol
-          } 🔜`,
+          message: `Submitted L1 proof for Optimism and thereby initiating withdrawal for ${withdrawal.amount} of ${withdrawal.l1TokenSymbol} 🔜`,
           transactionHash: etherscanLink(txn.transactionHash, 1),
         });
       });

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -17,6 +17,7 @@ import {
   multicallOptimismFinalizations,
   multicallPolygonFinalizations,
   multicallArbitrumFinalizations,
+  multicallOptimismL1Proofs,
 } from "./utils";
 import { SpokePoolClientsByChain } from "../interfaces";
 import { HubPoolClient } from "../clients";
@@ -55,9 +56,10 @@ export async function finalize(
   // Note: Could move this into a client in the future to manage # of calls and chunk calls based on
   // input byte length.
   const multicall2 = getMultisender(1, hubSigner);
-  const finalizationsToBatch: { callData: Multicall2Call[]; withdrawals: Withdrawal[] } = {
+  const finalizationsToBatch: { callData: Multicall2Call[]; withdrawals: Withdrawal[]; optimismL1Proofs: Withdrawal[] } = {
     callData: [],
     withdrawals: [],
+    optimismL1Proofs: [],
   };
   // For each chain, look up any TokensBridged events emitted by SpokePool client that we'll attempt to finalize
   // on L1.
@@ -124,20 +126,40 @@ export async function finalize(
       finalizationsToBatch.callData.push(...finalizations.callData);
       finalizationsToBatch.withdrawals.push(...finalizations.withdrawals);
     } else if (chainId === 10) {
-      // Skip events that are likely not past the seven day challenge period.
+      const crossChainMessenger = getOptimismClient(chainId, hubSigner) as optimismSDK.CrossChainMessenger;
       const firstBlockToFinalize = await getBlockForTimestamp(
         hubPoolClient.chainId,
         chainId,
         getCurrentTime() - optimisticRollupFinalizationWindow,
         getCurrentTime()
       );
+
+      // First submit proofs for any newly withdrawn tokens. You can submit proofs for any withdrawals that have been
+      // snapshotted on L1, so it takes roughly 1 hour from the withdrawal time. Skip events older than 7 days old.
+      logger.debug({
+        at: "Finalizer",
+        message: `Earliest TokensBridged block to attempt to submit proofs for ${getNetworkName(chainId)}`,
+        earliestBlockToProve: firstBlockToFinalize,
+      });
+      const recentTokensBridgedEvents = tokensBridged.filter((e) => e.blockNumber >= firstBlockToFinalize);
+      const proofs = await multicallOptimismL1Proofs(
+        chainId,
+        recentTokensBridgedEvents,
+        crossChainMessenger,
+        hubPoolClient,
+        logger
+      );
+      finalizationsToBatch.callData.push(...proofs.callData);
+      finalizationsToBatch.optimismL1Proofs.push(...proofs.withdrawals);
+
+      // Next finalize withdrawals that have passed challenge period.
+      // Skip events that are likely not past the seven day challenge period.
       logger.debug({
         at: "Finalizer",
         message: `Oldest TokensBridged block to attempt to finalize for ${getNetworkName(chainId)}`,
         firstBlockToFinalize,
       });
       const olderTokensBridgedEvents = tokensBridged.filter((e) => e.blockNumber < firstBlockToFinalize);
-      const crossChainMessenger = getOptimismClient(chainId, hubSigner) as optimismSDK.CrossChainMessenger;
       const finalizations = await multicallOptimismFinalizations(
         chainId,
         olderTokensBridgedEvents,
@@ -163,6 +185,15 @@ export async function finalize(
           message: `Finalized ${getNetworkName(withdrawal.l2ChainId)} withdrawal for ${withdrawal.amount} of ${
             withdrawal.l1TokenSymbol
           } 🪃`,
+          transactionHash: etherscanLink(txn.transactionHash, 1),
+        });
+      });
+      finalizationsToBatch.optimismL1Proofs.forEach((withdrawal) => {
+        logger.info({
+          at: "Finalizer",
+          message: `Submitted L1 proof for Optimism and thereby initiating withdrawal for ${withdrawal.amount} of ${
+            withdrawal.l1TokenSymbol
+          } 🔜`,
           transactionHash: etherscanLink(txn.transactionHash, 1),
         });
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,16 +373,15 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eth-optimism/contracts-bedrock@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts-bedrock/-/contracts-bedrock-0.13.2.tgz#4cdd4bfe7d905fa237719efdadab6bc228f49b0f"
-  integrity sha512-LMJzK0psPYEGDvvb+Qix8e1cK4+9J8tD9yXFqCt+On87warrTj8DZmLNh3G56DTLBrpz5/U6g62peEEsYha/4w==
+"@eth-optimism/contracts-bedrock@0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts-bedrock/-/contracts-bedrock-0.14.0.tgz#f93006416c8b114fb78d2e477dccd525aa651458"
+  integrity sha512-mvbSE2q2cyHUwg1jtHwR4JOQJcwdCVRAkmBdXCKUP0XsP48NT1J92bYileRdiUM5nLIESgNNmPA8L2J87mr62g==
   dependencies:
     "@eth-optimism/core-utils" "^0.12.0"
     "@openzeppelin/contracts" "4.7.3"
     "@openzeppelin/contracts-upgradeable" "4.7.3"
     ethers "^5.7.0"
-    hardhat "^2.9.6"
 
 "@eth-optimism/contracts-bedrock@0.8.3":
   version "0.8.3"
@@ -404,7 +403,16 @@
     "@ethersproject/abstract-provider" "^5.7.0"
     "@ethersproject/abstract-signer" "^5.7.0"
 
-"@eth-optimism/contracts@0.5.40", "@eth-optimism/contracts@^0.5.40", "@eth-optimism/contracts@^0.5.5":
+"@eth-optimism/contracts@0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.6.0.tgz#15ae76222a9b4d958a550cafb1960923af613a31"
+  integrity sha512-vQ04wfG9kMf1Fwy3FEMqH2QZbgS0gldKhcBeBUPfO8zu68L61VI97UDXmsMQXzTsEAxK8HnokW3/gosl4/NW3w==
+  dependencies:
+    "@eth-optimism/core-utils" "0.12.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+
+"@eth-optimism/contracts@^0.5.40", "@eth-optimism/contracts@^0.5.5":
   version "0.5.40"
   resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.5.40.tgz#d13a04a15ea947a69055e6fc74d87e215d4c936a"
   integrity sha512-MrzV0nvsymfO/fursTB7m/KunkPsCndltVgfdHaT1Aj5Vi6R/doKIGGkOofHX+8B6VMZpuZosKCMQ5lQuqjt8w==
@@ -482,13 +490,13 @@
     merkletreejs "^0.2.27"
     rlp "^2.2.7"
 
-"@eth-optimism/sdk@^2.0.2":
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-2.0.2.tgz#8a1ea67bc319448e6d3baa3f8bb19d4172686715"
-  integrity sha512-Um7tBmNENigoQtP3rt2VnAC3F/vCvkokw0PPS3Y01GcDtOiaZ74oGAoShJzAKb1om8Gh/8Ip/yPpT49dYkujeg==
+"@eth-optimism/sdk@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-2.1.0.tgz#8c679ddcf84144415746b73ed6e4eaaf07fb6350"
+  integrity sha512-XfRMsPNZRzdlNGARx3UIX88xaCBTJRzsZuKrRz2j8aqYkTpDOvdz87zYsmj+6Nl2tdOlgcxlhZPFCqdRtbiCaQ==
   dependencies:
-    "@eth-optimism/contracts" "0.5.40"
-    "@eth-optimism/contracts-bedrock" "0.13.2"
+    "@eth-optimism/contracts" "0.6.0"
+    "@eth-optimism/contracts-bedrock" "0.14.0"
     "@eth-optimism/core-utils" "0.12.0"
     lodash "^4.17.21"
     merkletreejs "^0.2.27"


### PR DESCRIPTION
https://community.optimism.io/docs/developers/bedrock/how-is-bedrock-different/#two-phase-withdrawals

Supports the new two phase withdrawal process:
- Submits proofs to L1 for recent Withdrawal events