### PR TITLE
improve(monitor): Change log level for unknown relayer to `warn` from `error`

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -175,7 +175,7 @@ export class Monitor {
         const mrkdwn =
           `An unknown relayer ${etherscanLink(fill.relayer, chainId)}` +
           ` filled a deposit on ${getNetworkName(chainId)}\ntx: ${etherscanLink(fill.transactionHash, chainId)}`;
-        this.logger.error({ at: "Monitor", message: "Unknown relayer 🛺", mrkdwn });
+        this.logger.warn({ at: "Monitor", message: "Unknown relayer 🛺", mrkdwn });
       }
     }
   }


### PR DESCRIPTION
This alert was a lot more important when Across first started and we did not expect _any_ third-party relayers. Now that these are very much expected, we should still be alerted on them but at a lower severity log level.