### PR TITLE
fix: Temporarily filter out optimism with L2 txns with multiple withdrawals

### DIFF
--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -90,13 +90,13 @@ export async function getOptimismFinalizableMessages(
   const crossChainMessages = await getCrossChainMessages(chainId, tokensBridged, crossChainMessenger);
   // Temporarily filter out messages with multiple withdrawals until eth-optimism sdk can handle them:
   // https://github.com/ethereum-optimism/optimism/issues/5983
-  const messagesWithMultipleWithdrawals = crossChainMessages.filter(
+  const messagesWithSingleWithdrawals = crossChainMessages.filter(
     (message, i) =>
       !crossChainMessages.some(
         (otherMessage, j) => i !== j && otherMessage.event.transactionHash === message.event.transactionHash
       )
   );
-  const messageStatuses = await getMessageStatuses(chainId, messagesWithMultipleWithdrawals, crossChainMessenger);
+  const messageStatuses = await getMessageStatuses(chainId, messagesWithSingleWithdrawals, crossChainMessenger);
   logger.debug({
     at: "OptimismFinalizer",
     message: "Optimism message statuses",

--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -88,7 +88,15 @@ export async function getOptimismFinalizableMessages(
   crossChainMessenger: OVM_CROSS_CHAIN_MESSENGER
 ): Promise<CrossChainMessageWithStatus[]> {
   const crossChainMessages = await getCrossChainMessages(chainId, tokensBridged, crossChainMessenger);
-  const messageStatuses = await getMessageStatuses(chainId, crossChainMessages, crossChainMessenger);
+  // Temporarily filter out messages with multiple withdrawals until eth-optimism sdk can handle them:
+  // https://github.com/ethereum-optimism/optimism/issues/5983
+  const messagesWithMultipleWithdrawals = crossChainMessages.filter(
+    (message, i) =>
+      !crossChainMessages.some(
+        (otherMessage, j) => i !== j && otherMessage.event.transactionHash === message.event.transactionHash
+      )
+  );
+  const messageStatuses = await getMessageStatuses(chainId, messagesWithMultipleWithdrawals, crossChainMessenger);
   logger.debug({
     at: "OptimismFinalizer",
     message: "Optimism message statuses",


### PR DESCRIPTION
eth-optimism SDK can't handle them. I've raised an issue with their team [here](https://github.com/ethereum-optimism/optimism/issues/5983)