### PR TITLE
fix(finalizer): Use fork of @eth-optimism/sdk that supports withdrawing multiple messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@arbitrum/sdk": "^3.1.3",
     "@across-protocol/sdk-v2": "0.8.2",
     "@defi-wonderland/smock": "^2.3.4",
+    "@eth-optimism/sdk": "^2.1.0",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/abstract-signer": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@across-protocol/contracts-v2": "2.3.0",
     "@arbitrum/sdk": "^3.1.3",
+    "@across-protocol/optimism-sdk": "2.1.3",
     "@across-protocol/sdk-v2": "0.8.2",
     "@defi-wonderland/smock": "^2.3.4",
     "@eth-optimism/sdk": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@arbitrum/sdk": "^3.1.3",
     "@across-protocol/sdk-v2": "0.8.2",
     "@defi-wonderland/smock": "^2.3.4",
-    "@eth-optimism/sdk": "^2.1.0",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/abstract-signer": "^5.7.0",

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -31,7 +31,7 @@ import {
   FINALIZER_TOKENBRIDGE_LOOKBACK,
   Multicall2Call,
 } from "../common";
-import * as optimismSDK from "@eth-optimism/sdk";
+import * as optimismSDK from "@across-protocol/optimism-sdk";
 config();
 let logger: winston.Logger;
 

--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -107,13 +107,13 @@ export async function getOptimismFinalizableMessages(
   ).filter((m) => m !== undefined);
   // Temporarily filter out messages with multiple withdrawals until eth-optimism sdk can handle them:
   // https://github.com/ethereum-optimism/optimism/issues/5983
-  const messagesWithSingleWithdrawals = bedrockMessages.filter(
+  const messagesWithMultipleWithdrawals = crossChainMessages.filter(
     (message, i) =>
       !crossChainMessages.some(
         (otherMessage, j) => i !== j && otherMessage.event.transactionHash === message.event.transactionHash
       )
   );
-  const messageStatuses = await getMessageStatuses(chainId, messagesWithSingleWithdrawals, crossChainMessenger);
+  const messageStatuses = await getMessageStatuses(chainId, messagesWithMultipleWithdrawals, crossChainMessenger);
   logger.debug({
     at: "OptimismFinalizer",
     message: "Optimism message statuses",

--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -1,4 +1,4 @@
-import * as optimismSDK from "@eth-optimism/sdk";
+import * as optimismSDK from "@across-protocol/optimism-sdk";
 import { Withdrawal } from "..";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { L1Token, TokensBridged } from "../../interfaces";
@@ -59,16 +59,29 @@ export async function getCrossChainMessages(
 
 export interface CrossChainMessageWithStatus extends CrossChainMessageWithEvent {
   status: string;
+  logIndex: number;
 }
 export async function getMessageStatuses(
   _chainId: OVM_CHAIN_ID,
   crossChainMessages: CrossChainMessageWithEvent[],
   crossChainMessenger: OVM_CROSS_CHAIN_MESSENGER
 ): Promise<CrossChainMessageWithStatus[]> {
+  // For each token bridge event, store a unique log index for the event within the arbitrum transaction hash.
+  // This is important for bridge transactions containing multiple events.
+  const uniqueTokenhashes = {};
+  const logIndexesForMessage = [];
+  for (const event of crossChainMessages.map((m) => m.event)) {
+    uniqueTokenhashes[event.transactionHash] = uniqueTokenhashes[event.transactionHash] ?? 0;
+    const logIndex = uniqueTokenhashes[event.transactionHash];
+    logIndexesForMessage.push(logIndex);
+    uniqueTokenhashes[event.transactionHash] += 1;
+  }
+
   const statuses = await Promise.all(
-    crossChainMessages.map((message) => {
+    crossChainMessages.map((message, i) => {
       return (crossChainMessenger as optimismSDK.CrossChainMessenger).getMessageStatus(
-        message.message as optimismSDK.MessageLike
+        message.message as optimismSDK.MessageLike,
+        logIndexesForMessage[i]
       );
     })
   );
@@ -77,6 +90,7 @@ export async function getMessageStatuses(
       status: optimismSDK.MessageStatus[status],
       message: crossChainMessages[i].message,
       event: crossChainMessages[i].event,
+      logIndex: logIndexesForMessage[i],
     };
   });
 }
@@ -88,32 +102,7 @@ export async function getOptimismFinalizableMessages(
   crossChainMessenger: OVM_CROSS_CHAIN_MESSENGER
 ): Promise<CrossChainMessageWithStatus[]> {
   const crossChainMessages = await getCrossChainMessages(chainId, tokensBridged, crossChainMessenger);
-  // Temporary fix until we're well past the bedrock upgrade. Remove non Bedrock messages.
-  // Example way to detect whether message is bedrock:
-  // - https://github.com/ethereum-optimism/optimism/blob/develop/packages/sdk/src/cross-chain-messenger.ts#L332
-  // - https://github.com/ethereum-optimism/optimism/blob/develop/packages/core-utils/src/optimism/encoding.ts#L34
-  const bedrockMessages = (
-    await Promise.all(
-      crossChainMessages.map(async (crossChainMessage) => {
-        const resolved = await crossChainMessenger.toCrossChainMessage(crossChainMessage.message);
-        const version = BigNumber.from(resolved.messageNonce).shr(240).toNumber();
-        if (version !== 1) {
-          return undefined;
-        } else {
-          return crossChainMessage;
-        }
-      })
-    )
-  ).filter((m) => m !== undefined);
-  // Temporarily filter out messages with multiple withdrawals until eth-optimism sdk can handle them:
-  // https://github.com/ethereum-optimism/optimism/issues/5983
-  const messagesWithSingleWithdrawals = crossChainMessages.filter(
-    (message, i) =>
-      !crossChainMessages.some(
-        (otherMessage, j) => i !== j && otherMessage.event.transactionHash === message.event.transactionHash
-      )
-  );
-  const messageStatuses = await getMessageStatuses(chainId, messagesWithSingleWithdrawals, crossChainMessenger);
+  const messageStatuses = await getMessageStatuses(chainId, crossChainMessages, crossChainMessenger);
   logger.debug({
     at: "OptimismFinalizer",
     message: "Optimism message statuses",
@@ -154,10 +143,12 @@ export async function finalizeOptimismMessage(
 export async function proveOptimismMessage(
   _chainId: OVM_CHAIN_ID,
   crossChainMessenger: OVM_CROSS_CHAIN_MESSENGER,
-  message: CrossChainMessageWithStatus
+  message: CrossChainMessageWithStatus,
+  logIndex = 0
 ): Promise<Multicall2Call> {
   const callData = await (crossChainMessenger as optimismSDK.CrossChainMessenger).populateTransaction.proveMessage(
-    message.message as optimismSDK.MessageLike
+    message.message as optimismSDK.MessageLike,
+    logIndex
   );
   return {
     callData: callData.data,
@@ -204,7 +195,7 @@ export async function multicallOptimismL1Proofs(
     await getOptimismFinalizableMessages(chainId, logger, tokensBridgedEvents, crossChainMessenger)
   ).filter((message) => message.status === optimismSDK.MessageStatus[optimismSDK.MessageStatus.READY_TO_PROVE]);
   const callData = await Promise.all(
-    provableMessages.map((message) => proveOptimismMessage(chainId, crossChainMessenger, message))
+    provableMessages.map((message) => proveOptimismMessage(chainId, crossChainMessenger, message, message.logIndex))
   );
   const withdrawals = provableMessages.map((message) => {
     const l1TokenInfo = getL1TokenInfoForOptimismToken(chainId, hubPoolClient, message.event.l2TokenAddress);

--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -107,13 +107,13 @@ export async function getOptimismFinalizableMessages(
   ).filter((m) => m !== undefined);
   // Temporarily filter out messages with multiple withdrawals until eth-optimism sdk can handle them:
   // https://github.com/ethereum-optimism/optimism/issues/5983
-  const messagesWithMultipleWithdrawals = crossChainMessages.filter(
+  const messagesWithSingleWithdrawals = crossChainMessages.filter(
     (message, i) =>
       !crossChainMessages.some(
         (otherMessage, j) => i !== j && otherMessage.event.transactionHash === message.event.transactionHash
       )
   );
-  const messageStatuses = await getMessageStatuses(chainId, messagesWithMultipleWithdrawals, crossChainMessenger);
+  const messageStatuses = await getMessageStatuses(chainId, messagesWithSingleWithdrawals, crossChainMessenger);
   logger.debug({
     at: "OptimismFinalizer",
     message: "Optimism message statuses",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,6 +35,18 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
+"@across-protocol/optimism-sdk@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@across-protocol/optimism-sdk/-/optimism-sdk-2.1.3.tgz#d03e61ee62cfdade932b4b616ccc88720ea435c3"
+  integrity sha512-cjEr5+deePV632MMezI9fxMZI+BBsi55Sm7RkaSrY13igsCvkERleXPSHTtT8srT9lVcIZWsxNE3O9GtE1R83g==
+  dependencies:
+    "@eth-optimism/contracts" "0.6.0"
+    "@eth-optimism/contracts-bedrock" "0.14.0"
+    "@eth-optimism/core-utils" "0.12.0"
+    lodash "^4.17.21"
+    merkletreejs "^0.2.27"
+    rlp "^2.2.7"
+
 "@across-protocol/sdk-v2@0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.8.2.tgz#53be9495cd1e865c32e9b6f9c5e40bbd1e92d100"


### PR DESCRIPTION
Temporary fix that uses a fork of @eth-optimism/sdk that supports multiple messages within a withdrawal L2 txn.

[This commit](https://github.com/across-protocol/optimism/commit/2bbdb4dc69d8b563b14fdc498f68ef9e71dc71e1) adds a `logIndex` modeled after how @arbitrum/sdk handles multiple messages. Requires caller to pass in the relative log index of the message that they want to prove and finalize into the sdk.
