### PR TITLE
improve(relayer): Retain deposit version numbers

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1,3 +1,4 @@
+import { groupBy } from "lodash";
 import {
   BigNumber,
   winston,
@@ -38,17 +39,27 @@ export class Relayer {
       this.config.maxRelayerLookBack,
       this.clients.configStoreClient
     );
-    if (unfilledDeposits.some((x) => x.requiresNewConfigStoreVersion)) {
+
+    const maxVersion = this.clients.configStoreClient.configStoreVersion;
+    const { supportedDeposits = [], unsupportedDeposits = [] } = groupBy(unfilledDeposits, (deposit) =>
+      deposit.version <= maxVersion ? "supportedDeposits" : "unsupportedDeposits"
+    );
+
+    if (unsupportedDeposits.length > 0) {
+      const deposits = unsupportedDeposits.map((unsupported) => {
+        const { originChainId, depositId, transactionHash } = unsupported.deposit;
+        return { originChainId, depositId, version: unsupported.version, transactionHash };
+      });
       this.logger.warn({
         at: "Relayer",
-        message: "Skipping some deposits because ConfigStore version is not updated, are you using the latest code?",
-        latestVersionSupported: CONFIG_STORE_VERSION,
+        message: "Skipping deposits that are not supported by this relayer version.",
+        latestVersionSupported: maxVersion,
         latestInConfigStore: this.clients.configStoreClient.getConfigStoreVersionForTimestamp(),
+        deposits,
       });
     }
 
-    const unfilledDepositAmountsPerChain: { [chainId: number]: BigNumber } = unfilledDeposits
-      .filter((x) => !x.requiresNewConfigStoreVersion)
+    const unfilledDepositAmountsPerChain: { [chainId: number]: BigNumber } = supportedDeposits
       // Sum the total unfilled deposit amount per origin chain and set a MDC for that chain.
       .reduce((agg, curr) => {
         const unfilledAmountUsd = this.clients.profitClient.getFillAmountInUsd(curr.deposit, curr.unfilledAmount);

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -154,12 +154,14 @@ describe("Relayer: Unfilled Deposits", async function () {
           deposit: deposit1Complete,
           fillCount: 0,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
         {
           unfilledAmount: deposit2.amount,
           deposit: deposit2Complete,
           fillCount: 0,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
       ]);
   });
@@ -232,12 +234,14 @@ describe("Relayer: Unfilled Deposits", async function () {
           deposit: deposit1Complete,
           fillCount: 1,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
         {
           unfilledAmount: deposit2.amount,
           deposit: deposit2Complete,
           fillCount: 0,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
       ]);
 
@@ -261,12 +265,14 @@ describe("Relayer: Unfilled Deposits", async function () {
           deposit: deposit1Complete,
           fillCount: 3,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
         {
           unfilledAmount: deposit2.amount,
           deposit: deposit2Complete,
           fillCount: 0,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
       ]);
 
@@ -288,6 +294,7 @@ describe("Relayer: Unfilled Deposits", async function () {
           deposit: deposit2Complete,
           fillCount: 0,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
       ]);
   });
@@ -315,6 +322,7 @@ describe("Relayer: Unfilled Deposits", async function () {
           deposit: deposit1Complete,
           fillCount: 0,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
       ]);
   });
@@ -404,6 +412,7 @@ describe("Relayer: Unfilled Deposits", async function () {
           deposit: deposit1Complete,
           fillCount: 1,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
       ]);
 
@@ -447,6 +456,7 @@ describe("Relayer: Unfilled Deposits", async function () {
           deposit: depositWithSpeedUp,
           fillCount: 1,
           invalidFills: [],
+          version: configStoreClient.configStoreVersion,
         },
       ]);
   });


### PR DESCRIPTION
Upgrade the existing "supported version" filtering logic by retaining the applicable version number in the [Relayer]UnfilledDeposit object. The benefit of retaining the version number is that it allows downstream recipients of the [Relayer]UnfilledDeposit type to implement different behaviour based on the version number. The new method of pulling out the version numbers should be a tiny bit more efficient too, since there's less looping involved.

As part of this I also found that we had two competing definitions for an UnfilledRelay - one in the SpokePool interfaces from the SDK, and another locally defined in FillUtils. For now I have renamed them to avoid confusion, but they'll need to be merged back in the SDK as part of getting the dataworker ready for the UBA model.