### PR TITLE
improve(utils): Add reasonable gas fee scaler defaults for Optimism and Ethereum

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -143,6 +143,14 @@ export const MAX_REORG_DISTANCE: { [chainId: number]: number } = {
   421613: 0,
 };
 
+// Reasonable default maxFeePerGas and maxPriorityFeePerGas scalers for each chain.
+export const DEFAULT_GAS_FEE_SCALERS: {
+  [chainId: number]: { maxFeePerGasScaler: number; maxPriorityFeePerGasScaler: number };
+} = {
+  1: { maxFeePerGasScaler: 1.2, maxPriorityFeePerGasScaler: 3 },
+  10: { maxFeePerGasScaler: 1.2, maxPriorityFeePerGasScaler: 1 },
+};
+
 // This is how many seconds stale the block number can be for us to use it for evaluating the reorg distance in the cache provider.
 export const BLOCK_NUMBER_TTL = 60;
 

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -147,8 +147,8 @@ export const MAX_REORG_DISTANCE: { [chainId: number]: number } = {
 export const DEFAULT_GAS_FEE_SCALERS: {
   [chainId: number]: { maxFeePerGasScaler: number; maxPriorityFeePerGasScaler: number };
 } = {
-  1: { maxFeePerGasScaler: 1.2, maxPriorityFeePerGasScaler: 3 },
-  10: { maxFeePerGasScaler: 1.2, maxPriorityFeePerGasScaler: 1 },
+  1: { maxFeePerGasScaler: 3, maxPriorityFeePerGasScaler: 1.2 },
+  10: { maxFeePerGasScaler: 2, maxPriorityFeePerGasScaler: 1 },
 };
 
 // This is how many seconds stale the block number can be for us to use it for evaluating the reorg distance in the cache provider.

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -47,9 +47,11 @@ export async function runTransaction(
 
   try {
     const priorityFeeScaler =
-      Number(process.env[`PRIORITY_FEE_SCALER_${chainId}`] || process.env.PRIORITY_FEE_SCALER) || DEFAULT_GAS_FEE_SCALERS[chainId].maxPriorityFeePerGasScaler;
+      Number(process.env[`PRIORITY_FEE_SCALER_${chainId}`] || process.env.PRIORITY_FEE_SCALER) ||
+      DEFAULT_GAS_FEE_SCALERS[chainId].maxPriorityFeePerGasScaler;
     const maxFeePerGasScaler =
-      Number(process.env[`MAX_FEE_PER_GAS_SCALER_${chainId}`] || process.env.MAX_FEE_PER_GAS_SCALER) || DEFAULT_GAS_FEE_SCALERS[chainId].maxFeePerGasScaler;
+      Number(process.env[`MAX_FEE_PER_GAS_SCALER_${chainId}`] || process.env.MAX_FEE_PER_GAS_SCALER) ||
+      DEFAULT_GAS_FEE_SCALERS[chainId].maxFeePerGasScaler;
 
     const gas = await getGasPrice(contract.provider, priorityFeeScaler, maxFeePerGasScaler);
     logger.debug({

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -48,10 +48,10 @@ export async function runTransaction(
   try {
     const priorityFeeScaler =
       Number(process.env[`PRIORITY_FEE_SCALER_${chainId}`] || process.env.PRIORITY_FEE_SCALER) ||
-      DEFAULT_GAS_FEE_SCALERS[chainId].maxPriorityFeePerGasScaler;
+      DEFAULT_GAS_FEE_SCALERS[chainId]?.maxPriorityFeePerGasScaler;
     const maxFeePerGasScaler =
       Number(process.env[`MAX_FEE_PER_GAS_SCALER_${chainId}`] || process.env.MAX_FEE_PER_GAS_SCALER) ||
-      DEFAULT_GAS_FEE_SCALERS[chainId].maxFeePerGasScaler;
+      DEFAULT_GAS_FEE_SCALERS[chainId]?.maxFeePerGasScaler;
 
     const gas = await getGasPrice(contract.provider, priorityFeeScaler, maxFeePerGasScaler);
     logger.debug({

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -1,7 +1,7 @@
 import { typeguards } from "@across-protocol/sdk-v2";
 import { AugmentedTransaction } from "../clients";
 import { winston, Contract, getContractInfoFromAddress, fetch, ethers, Wallet } from "../utils";
-import { multicall3Addresses } from "../common";
+import { DEFAULT_GAS_FEE_SCALERS, multicall3Addresses } from "../common";
 import { toBNWei, BigNumber, toBN, toGWei, TransactionResponse } from "../utils";
 import { getAbi } from "@uma/contracts-node";
 import dotenv from "dotenv";
@@ -47,9 +47,9 @@ export async function runTransaction(
 
   try {
     const priorityFeeScaler =
-      Number(process.env[`PRIORITY_FEE_SCALER_${chainId}`] || process.env.PRIORITY_FEE_SCALER) || undefined;
+      Number(process.env[`PRIORITY_FEE_SCALER_${chainId}`] || process.env.PRIORITY_FEE_SCALER) || DEFAULT_GAS_FEE_SCALERS[chainId].maxPriorityFeePerGasScaler;
     const maxFeePerGasScaler =
-      Number(process.env[`MAX_FEE_PER_GAS_SCALER_${chainId}`] || process.env.MAX_FEE_PER_GAS_SCALER) || undefined;
+      Number(process.env[`MAX_FEE_PER_GAS_SCALER_${chainId}`] || process.env.MAX_FEE_PER_GAS_SCALER) || DEFAULT_GAS_FEE_SCALERS[chainId].maxFeePerGasScaler;
 
     const gas = await getGasPrice(contract.provider, priorityFeeScaler, maxFeePerGasScaler);
     logger.debug({


### PR DESCRIPTION
Resolve  the issue where we are over scaling the Optimism priority fee. The priority fee returned by Optimism gas estimator is already scaled quite aggressively.

Fixes ACX-1208