### PR TITLE
feat(ProfitClient): Consider refund fees

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -1,11 +1,14 @@
 import { Provider } from "@ethersproject/abstract-provider";
+import { utils as ethersUtils } from "ethers";
 import * as constants from "../common/Constants";
 import { assert, BigNumber, formatFeePct, max, winston, toBNWei, toBN, assign } from "../utils";
 import { HubPoolClient } from ".";
 import { Deposit, DepositWithBlock, L1Token, SpokePoolClientsByChain } from "../interfaces";
-import { priceClient, relayFeeCalculator } from "@across-protocol/sdk-v2";
-import { constants as sdkConstants } from "@across-protocol/sdk-v2";
+import { constants as sdkConstants, priceClient, relayFeeCalculator, utils as sdkUtils } from "@across-protocol/sdk-v2";
+
+const { formatEther } = ethersUtils;
 const { TOKEN_SYMBOLS_MAP, CHAIN_IDs } = sdkConstants;
+const { fixedPointAdjustment: fixedPoint } = sdkUtils;
 
 // We use wrapped ERC-20 versions instead of the native tokens such as ETH, MATIC for ease of computing prices.
 // @todo: These don't belong in the ProfitClient; they should be relocated.
@@ -150,7 +153,7 @@ export class ProfitClient {
     const gasCostUsd = nativeGasCost
       .mul(this.gasMultiplier)
       .mul(gasPriceUsd)
-      .div(toBNWei(1))
+      .div(fixedPoint)
       .div(toBN(10).pow(GAS_TOKEN_DECIMALS));
 
     return {
@@ -188,7 +191,7 @@ export class ProfitClient {
 
   appliedRelayerFeePct(deposit: Deposit): BigNumber {
     // Return the maximum available relayerFeePct (max of Deposit and any SpeedUp).
-    return max(toBN(deposit.relayerFeePct), deposit.newRelayerFeePct ? toBN(deposit.newRelayerFeePct) : toBN(0));
+    return max(toBN(deposit.relayerFeePct), toBN(deposit.newRelayerFeePct ?? 0));
   }
 
   calculateFillProfitability(
@@ -215,13 +218,13 @@ export class ProfitClient {
     const grossRelayerFeePct = this.appliedRelayerFeePct(deposit);
 
     // Calculate relayer fee and capital outlay in relay token terms.
-    const grossRelayerFee = grossRelayerFeePct.mul(scaledFillAmount).div(toBNWei(1));
+    const grossRelayerFee = grossRelayerFeePct.mul(scaledFillAmount).div(fixedPoint);
     const relayerCapital = scaledFillAmount.sub(grossRelayerFee);
 
     // Normalise to USD terms.
-    const fillAmountUsd = scaledFillAmount.mul(tokenPriceUsd).div(toBNWei(1));
-    const grossRelayerFeeUsd = grossRelayerFee.mul(tokenPriceUsd).div(toBNWei(1));
-    const relayerCapitalUsd = relayerCapital.mul(tokenPriceUsd).div(toBNWei(1));
+    const fillAmountUsd = scaledFillAmount.mul(tokenPriceUsd).div(fixedPoint);
+    const grossRelayerFeeUsd = grossRelayerFee.mul(tokenPriceUsd).div(fixedPoint);
+    const relayerCapitalUsd = relayerCapital.mul(tokenPriceUsd).div(fixedPoint);
 
     // Estimate the gas cost of filling this relay.
     const { nativeGasCost, gasPriceUsd, gasCostUsd } = this.estimateFillCost(deposit.destinationChainId);
@@ -285,16 +288,16 @@ export class ProfitClient {
         message: `${l1Token.symbol} deposit ${depositId} on chain ${originChainId} is ${profitable}`,
         deposit,
         l1Token,
-        fillAmount,
-        fillAmountUsd: fill.fillAmountUsd,
+        fillAmount: formatEther(fillAmount),
+        fillAmountUsd: formatEther(fill.fillAmountUsd),
         grossRelayerFeePct: `${formatFeePct(fill.grossRelayerFeePct)}%`,
-        nativeGasCost: fill.nativeGasCost,
+        nativeGasCost: formatEther(fill.nativeGasCost),
         gasMultiplier: `${formatFeePct(fill.gasMultiplier)}%`,
-        gasPriceUsd: fill.gasPriceUsd,
-        relayerCapitalUsd: `${fill.relayerCapitalUsd}`,
-        grossRelayerFeeUsd: fill.grossRelayerFeeUsd,
-        gasCostUsd: fill.gasCostUsd,
-        netRelayerFeeUsd: `${fill.netRelayerFeeUsd}`,
+        gasPriceUsd: formatEther(fill.gasPriceUsd),
+        relayerCapitalUsd: formatEther(fill.relayerCapitalUsd),
+        grossRelayerFeeUsd: formatEther(fill.grossRelayerFeeUsd),
+        gasCostUsd: formatEther(fill.gasCostUsd),
+        netRelayerFeeUsd: formatEther(fill.netRelayerFeeUsd),
         netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)}%`,
         minRelayerFeePct: `${formatFeePct(minRelayerFeePct)}%`,
         fillProfitable: fill.fillProfitable,

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -205,7 +205,11 @@ export class Relayer {
         continue;
       }
       if (this.clients.tokenClient.hasBalanceForFill(deposit, unfilledAmount)) {
-        if (this.clients.profitClient.isFillProfitable(deposit, unfilledAmount, l1Token)) {
+        // @todo: For UBA, compute the anticipated refund fee(s) for candidate refund chain(s).
+        // @todo: Factor in the gas cost of submitting the RefundRequest on alt refund chains.
+        const refundFee = toBN(0);
+
+        if (this.clients.profitClient.isFillProfitable(deposit, unfilledAmount, refundFee, l1Token)) {
           await this.fillRelay(deposit, unfilledAmount);
         } else {
           this.clients.profitClient.captureUnprofitableFill(deposit, unfilledAmount);

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -71,8 +71,6 @@ describe("Monitor", async function () {
       0
     ));
 
-    const configuredNetworks = [hubPoolClient.chainId, repaymentChainId, originChainId, destinationChainId];
-
     defaultMonitorEnvVars = {
       STARTING_BLOCK_NUMBER: "0",
       ENDING_BLOCK_NUMBER: "100",
@@ -85,14 +83,13 @@ describe("Monitor", async function () {
       MONITOR_REPORT_ENABLED: "true",
       MONITOR_REPORT_INTERVAL: "10",
       MONITORED_RELAYERS: `["${depositor.address}"]`,
-      CONFIGURED_NETWORKS: JSON.stringify(configuredNetworks),
     };
     const monitorConfig = new MonitorConfig(defaultMonitorEnvVars);
 
     // Set the config store version to 0 to match the default version in the ConfigStoreClient.
     process.env.CONFIG_STORE_VERSION = "0";
 
-    const chainIds = configuredNetworks;
+    const chainIds = [hubPoolClient.chainId, repaymentChainId, originChainId, destinationChainId];
     bundleDataClient = new BundleDataClient(
       spyLogger,
       {

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -20,6 +20,7 @@ const { fixedPointAdjustment: fixedPoint } = sdkUtils;
 const { formatEther } = ethers.utils;
 
 const chainIds: number[] = [1, 10, 137, 288, 42161];
+const zeroRefundFee = toBN(0);
 
 const tokens: { [symbol: string]: L1Token } = {
   MATIC: { address: MATIC, decimals: 18, symbol: "MATIC" },
@@ -63,14 +64,19 @@ const maxRelayerFeePct = toBNWei(maxRelayerFeeBps).div(1e4);
 const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
 let hubPoolClient: MockHubPoolClient, profitClient: MockProfitClient;
 
-function testProfitability(deposit: Deposit, fillAmountUsd: BigNumber, gasCostUsd: BigNumber): FillProfit {
+function testProfitability(
+  deposit: Deposit,
+  fillAmountUsd: BigNumber,
+  gasCostUsd: BigNumber,
+  refundFeeUsd: BigNumber
+): FillProfit {
   const { relayerFeePct } = deposit;
 
   const grossRelayerFeeUsd = fillAmountUsd.mul(relayerFeePct).div(fixedPoint);
   const relayerCapitalUsd = fillAmountUsd.sub(grossRelayerFeeUsd);
 
   const minRelayerFeeUsd = relayerCapitalUsd.mul(minRelayerFeePct).div(fixedPoint);
-  const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd);
+  const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd.add(refundFeeUsd));
   const netRelayerFeePct = netRelayerFeeUsd.mul(fixedPoint).div(relayerCapitalUsd);
 
   const fillProfitable = netRelayerFeeUsd.gte(minRelayerFeeUsd);
@@ -205,23 +211,27 @@ describe("ProfitClient: Consider relay profit", async function () {
 
       // Verify that it works before we break it.
       expect(() =>
-        profitClient.calculateFillProfitability(deposit, fillAmount, l1Token, minRelayerFeePct)
+        profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct)
       ).to.not.throw();
 
       spyLogger.debug({ message: `Verifying exception on gas cost estimation lookup failure on chain ${chainId}.` });
       profitClient.setGasCosts({});
-      expect(() => profitClient.calculateFillProfitability(deposit, fillAmount, l1Token, minRelayerFeePct)).to.throw();
+      expect(() =>
+        profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct)
+      ).to.throw();
       profitClient.setGasCosts(gasCost);
 
       spyLogger.debug({ message: `Verifying exception on token price lookup failure on chain ${chainId}.` });
       profitClient.setTokenPrices({ [l1Token.address]: toBN(0) });
       // Setting price to 0 causes a downstream error in calculateFillProfitability.
-      expect(() => profitClient.calculateFillProfitability(deposit, fillAmount, l1Token, minRelayerFeePct)).to.throw();
+      expect(() =>
+        profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct)
+      ).to.throw();
       setDefaultTokenPrices(profitClient);
 
       // Verify we left everything as we found it.
       expect(() =>
-        profitClient.calculateFillProfitability(deposit, fillAmount, l1Token, minRelayerFeePct)
+        profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct)
       ).to.not.throw();
     });
   });
@@ -273,7 +283,7 @@ describe("ProfitClient: Consider relay profit", async function () {
             const relayerFeePct = _relayerFeePct.gt(maxRelayerFeePct) ? maxRelayerFeePct : _relayerFeePct;
             const deposit = { relayerFeePct, destinationChainId } as Deposit;
 
-            const fill: FillProfit = testProfitability(deposit, fillAmountUsd, gasCostUsd);
+            const fill: FillProfit = testProfitability(deposit, fillAmountUsd, gasCostUsd, zeroRefundFee);
             spyLogger.debug({
               message: `Expect ${l1Token.symbol} deposit is ${fill.fillProfitable ? "" : "un"}profitable:`,
               fillAmount,
@@ -283,12 +293,69 @@ describe("ProfitClient: Consider relay profit", async function () {
               gasCostPct: `${formatFeePct(gasCostPct)} %`,
               relayerCapitalUsd: fill.relayerCapitalUsd,
               minRelayerFeePct: `${formatFeePct(minRelayerFeePct)} %`,
-              minRelayerFeeUsd: minRelayerFeePct.mul(fillAmountUsd).div(toBNWei(1)),
+              minRelayerFeeUsd: minRelayerFeePct.mul(fillAmountUsd).div(fixedPoint),
               netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)} %`,
               netRelayerFeeUsd: fill.netRelayerFeeUsd,
             });
 
-            expect(profitClient.isFillProfitable(deposit, nativeFillAmount, l1Token)).to.equal(fill.fillProfitable);
+            expect(profitClient.isFillProfitable(deposit, nativeFillAmount, zeroRefundFee, l1Token)).to.equal(
+              fill.fillProfitable
+            );
+          });
+        });
+      });
+    });
+  });
+
+  it("Considers refund fees when computing profitability", async function () {
+    const fillAmounts = [".001", "0.1", 1, 10, 100, 1_000, 100_000];
+    const refundFeeMultipliers = ["-0.1", "-0.01", "-0.001", "-0.0001", 0.0001, 0.001, 0.01, 0.1, 1];
+
+    chainIds.forEach((destinationChainId: number) => {
+      const { gasCostUsd } = profitClient.estimateFillCost(destinationChainId);
+
+      Object.values(tokens).forEach((l1Token: L1Token) => {
+        const tokenPriceUsd = profitClient.getPriceOfToken(l1Token.address);
+        hubPoolClient.setTokenInfoToReturn(l1Token);
+
+        fillAmounts.forEach((_fillAmount) => {
+          const fillAmount = toBNWei(_fillAmount);
+          const nativeFillAmount = toBNWei(_fillAmount, l1Token.decimals);
+          spyLogger.debug({ message: `Testing fillAmount ${formatEther(fillAmount)}.` });
+
+          const fillAmountUsd = fillAmount.mul(tokenPriceUsd).div(fixedPoint);
+          const gasCostPct = gasCostUsd.mul(fixedPoint).div(fillAmountUsd);
+
+          const relayerFeePct = toBN(0.0001);
+          const deposit = { relayerFeePct, destinationChainId } as Deposit;
+
+          refundFeeMultipliers.forEach((_multiplier) => {
+            const feeMultiplier = toBNWei(_multiplier);
+            const refundFee = fillAmount.mul(feeMultiplier).div(fixedPoint);
+            const nativeRefundFee = nativeFillAmount.mul(feeMultiplier).div(fixedPoint);
+            const refundFeeUsd = refundFee.mul(tokenPriceUsd).div(fixedPoint);
+            const fill: FillProfit = testProfitability(deposit, fillAmountUsd, gasCostUsd, refundFeeUsd);
+            spyLogger.debug({
+              message: `Expect ${l1Token.symbol} deposit is ${fill.fillProfitable ? "" : "un"}profitable:`,
+              tokenPrice: formatEther(tokenPriceUsd),
+              fillAmount: formatEther(fillAmount),
+              fillAmountUsd: formatEther(fillAmountUsd),
+              gasCostUsd: formatEther(gasCostUsd),
+              refundFee: formatEther(refundFee),
+              feeMultiplier: formatEther(feeMultiplier),
+              refundFeeUsd: formatEther(refundFeeUsd),
+              grossRelayerFeePct: `${formatFeePct(relayerFeePct)} %`,
+              gasCostPct: `${formatFeePct(gasCostPct)} %`,
+              relayerCapitalUsd: formatEther(fill.relayerCapitalUsd),
+              minRelayerFeePct: `${formatFeePct(minRelayerFeePct)} %`,
+              minRelayerFeeUsd: formatEther(minRelayerFeePct.mul(fillAmountUsd).div(fixedPoint)),
+              netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)} %`,
+              netRelayerFeeUsd: formatEther(fill.netRelayerFeeUsd),
+            });
+
+            expect(profitClient.isFillProfitable(deposit, nativeFillAmount, nativeRefundFee, l1Token)).to.equal(
+              fill.fillProfitable
+            );
           });
         });
       });
@@ -345,11 +412,11 @@ describe("ProfitClient: Consider relay profit", async function () {
     } as Deposit;
 
     let fill: FillProfit;
-    fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token, minRelayerFeePct);
+    fill = profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct);
     expect(fill.grossRelayerFeePct.eq(deposit.relayerFeePct)).to.be.true;
 
     deposit["newRelayerFeePct"] = toBNWei("0.1");
-    fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token, minRelayerFeePct);
+    fill = profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct);
     expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct)).to.be.true;
   });
 
@@ -365,12 +432,12 @@ describe("ProfitClient: Consider relay profit", async function () {
     const fillAmount = toBNWei(1);
 
     let fill: FillProfit;
-    fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token, minRelayerFeePct);
+    fill = profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct);
     expect(fill.grossRelayerFeePct.eq(deposit.relayerFeePct)).to.be.true;
 
     deposit.relayerFeePct = toBNWei(".001");
     expect(deposit.relayerFeePct.lt(deposit.newRelayerFeePct)).to.be.true; // Sanity check
-    fill = profitClient.calculateFillProfitability(deposit, fillAmount, l1Token, minRelayerFeePct);
+    fill = profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct);
     expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct)).to.be.true;
   });
 

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -1,3 +1,4 @@
+import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { BigNumber, formatFeePct, toBN, toBNWei } from "../src/utils";
 import {
   expect,
@@ -14,6 +15,9 @@ import { MockHubPoolClient, MockProfitClient } from "./mocks";
 import { Deposit, DepositWithBlock, L1Token } from "../src/interfaces";
 import { FillProfit, GAS_TOKEN_BY_CHAIN_ID, SpokePoolClient, MATIC, USDC, WBTC, WETH } from "../src/clients";
 import { ConfigStoreClient } from "../src/clients";
+
+const { fixedPointAdjustment: fixedPoint } = sdkUtils;
+const { formatEther } = ethers.utils;
 
 const chainIds: number[] = [1, 10, 137, 288, 42161];
 
@@ -62,12 +66,12 @@ let hubPoolClient: MockHubPoolClient, profitClient: MockProfitClient;
 function testProfitability(deposit: Deposit, fillAmountUsd: BigNumber, gasCostUsd: BigNumber): FillProfit {
   const { relayerFeePct } = deposit;
 
-  const grossRelayerFeeUsd = fillAmountUsd.mul(relayerFeePct).div(toBNWei(1));
+  const grossRelayerFeeUsd = fillAmountUsd.mul(relayerFeePct).div(fixedPoint);
   const relayerCapitalUsd = fillAmountUsd.sub(grossRelayerFeeUsd);
 
-  const minRelayerFeeUsd = relayerCapitalUsd.mul(minRelayerFeePct).div(toBNWei(1));
+  const minRelayerFeeUsd = relayerCapitalUsd.mul(minRelayerFeePct).div(fixedPoint);
   const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd);
-  const netRelayerFeePct = netRelayerFeeUsd.mul(toBNWei(1)).div(relayerCapitalUsd);
+  const netRelayerFeePct = netRelayerFeeUsd.mul(fixedPoint).div(relayerCapitalUsd);
 
   const fillProfitable = netRelayerFeeUsd.gte(minRelayerFeeUsd);
 
@@ -173,8 +177,8 @@ describe("ProfitClient: Consider relay profit", async function () {
         const expectedFillCostUsd = nativeGasCost
           .mul(tokenPrices[gasToken.symbol])
           .mul(toBNWei(gasMultiplier))
-          .div(toBNWei(1))
-          .div(toBNWei(1));
+          .div(fixedPoint)
+          .div(fixedPoint);
         const { gasCostUsd } = profitClient.estimateFillCost(chainId);
         expect(expectedFillCostUsd.eq(gasCostUsd)).to.be.true;
       });
@@ -249,10 +253,10 @@ describe("ProfitClient: Consider relay profit", async function () {
         fillAmounts.forEach((_fillAmount: number | string) => {
           const fillAmount = toBNWei(_fillAmount);
           const nativeFillAmount = toBNWei(_fillAmount, l1Token.decimals);
-          spyLogger.debug({ message: `Testing fillAmount ${_fillAmount} (${fillAmount}).` });
+          spyLogger.debug({ message: `Testing fillAmount ${formatEther(fillAmount)}.` });
 
-          const fillAmountUsd = fillAmount.mul(tokenPriceUsd).div(toBNWei(1));
-          const gasCostPct = gasCostUsd.mul(toBNWei(1)).div(fillAmountUsd);
+          const fillAmountUsd = fillAmount.mul(tokenPriceUsd).div(fixedPoint);
+          const gasCostPct = gasCostUsd.mul(fixedPoint).div(fillAmountUsd);
 
           const relayerFeePcts: BigNumber[] = [
             toBNWei(-1),


### PR DESCRIPTION
This change permits the ProfitClient to incorporate the cost/benefit of taking refunds on a particular chain. This is necessary for the UBA model, but the implementation is backwards-compatible with pre-UBA fees by setting the refund fee to 0.

A follow-up change will set the refundFee correctly from within the Relayer class, depending on the version applicable to the deposit.

Fixes ACX-1201