### PR TITLE
fix(getGasPrice): Use new Polygon gasstation URI

### DIFF
--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -166,7 +166,7 @@ async function getPolygonPriorityFee(): Promise<{
   blockTime: number;
   blockNumber: number;
 }> {
-  const res = await fetch("https://gasstation-mainnet.matic.network");
+  const res = await fetch("https://gasstation.polygon.technology");
   return (await res.json()) as {
     safeLow: number;
     standard: number;


### PR DESCRIPTION
Polygon added a new endpoint a while ago and have recently
deactived the pre-existing matic.network.