### PR TITLE
improve: Downscale Optimism priority fees

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -148,7 +148,7 @@ export const DEFAULT_GAS_FEE_SCALERS: {
   [chainId: number]: { maxFeePerGasScaler: number; maxPriorityFeePerGasScaler: number };
 } = {
   1: { maxFeePerGasScaler: 3, maxPriorityFeePerGasScaler: 1.2 },
-  10: { maxFeePerGasScaler: 2, maxPriorityFeePerGasScaler: 1 },
+  10: { maxFeePerGasScaler: 2, maxPriorityFeePerGasScaler: 0.05 },
 };
 
 // This is how many seconds stale the block number can be for us to use it for evaluating the reorg distance in the cache provider.


### PR DESCRIPTION
ethers is sneakily defaulting to a priority fee of 1.5 Gwei, so the priority fees are being totally over-estimated and the bots are paying too much.

Having analysed some fills on Optimism, it seems like we can easily get away with 0.075 Gwei for a priority fee (and possibly even lower).