### PR TITLE
fix: Bump SDK for better Arbitrum gas pricing

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@across-protocol/contracts-v2": "2.3.0",
     "@arbitrum/sdk": "^3.1.3",
     "@across-protocol/optimism-sdk": "2.1.3",
-    "@across-protocol/sdk-v2": "0.9.0",
+    "@across-protocol/sdk-v2": "0.9.1",
     "@defi-wonderland/smock": "^2.3.4",
     "@eth-optimism/sdk": "^2.1.0",
     "@ethersproject/abi": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,10 +47,10 @@
     merkletreejs "^0.2.27"
     rlp "^2.2.7"
 
-"@across-protocol/sdk-v2@0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.9.0.tgz#b5c923d14c0e8fab080cf8f9a289f51cf7226d1a"
-  integrity sha512-8MUKpwtganAyeX30r8CqLY1nTjvJ59lTGkoMY7qsLCb4AAfXHRAuPT2nEQwmdzkbn+hWTjTGsUkI2s55VQGumQ==
+"@across-protocol/sdk-v2@0.9.1":
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.9.1.tgz#4b4d260019edf0d8ceed96a0ecc3805192a4552d"
+  integrity sha512-3naonjJ/r94ZlN/64dE+XD2s9jVHpvtQbC56/BwtxMLjsyO/sfYEsON18Md1FsvzfvA7Dh6yTaMArM9aVTAuYA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/contracts-v2" "2.3.0"


### PR DESCRIPTION
The SDK recently migrated to using EIP1559 pricing for Arbitrum, but this is misleading because the priority fee is always refunded (and Ethers hardcodes it to 1.5 Gwei). This caused deposits destined for Arbitrum to be considered unprofitable.