### PR TITLE
chore(UBA): Instantiate ubaClient in relayer clients

### DIFF
--- a/src/clients/UBAClient.ts
+++ b/src/clients/UBAClient.ts
@@ -1,3 +1,17 @@
-import { clients } from "@across-protocol/sdk-v2";
+import winston from "winston";
+import { clients, relayFeeCalculator } from "@across-protocol/sdk-v2";
+import { HubPoolClient } from "./HubPoolClient";
+import { SpokePoolClient } from "./SpokePoolClient";
 
-export class UBAClient extends clients.UBAClient {}
+type RelayFeeCalculatorConfig = relayFeeCalculator.RelayFeeCalculatorConfig;
+
+export class UBAClient extends clients.UBAClient {
+  constructor(
+    chainIdIndices: number[],
+    hubPoolClient: HubPoolClient,
+    spokePoolClients: { [chainId: number]: SpokePoolClient },
+    logger: winston.Logger
+  ) {
+    super(chainIdIndices, hubPoolClient, spokePoolClients, {} as RelayFeeCalculatorConfig, logger);
+  }
+}

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -1,6 +1,6 @@
 import winston from "winston";
 import { Wallet } from "../utils";
-import { TokenClient, ProfitClient, BundleDataClient, InventoryClient, AcrossApiClient } from "../clients";
+import { TokenClient, ProfitClient, BundleDataClient, InventoryClient, AcrossApiClient, UBAClient } from "../clients";
 import { AdapterManager, CrossChainTransferClient } from "../clients/bridges";
 import { RelayerConfig } from "./RelayerConfig";
 import { Clients, constructClients, updateClients, updateSpokePoolClients } from "../common";
@@ -9,6 +9,7 @@ import { constructSpokePoolClientsWithLookback } from "../common";
 
 export interface RelayerClients extends Clients {
   spokePoolClients: SpokePoolClientsByChain;
+  ubaClient: UBAClient;
   tokenClient: TokenClient;
   profitClient: ProfitClient;
   inventoryClient: InventoryClient;
@@ -33,6 +34,8 @@ export async function constructRelayerClients(
     baseSigner,
     config.maxRelayerLookBack
   );
+
+  const ubaClient = new UBAClient(config.chainIdListIndices, commonClients.hubPoolClient, spokePoolClients, logger);
 
   // We only use the API client to load /limits for chains so we should remove any chains that are not included in the
   // destination chain list.
@@ -90,7 +93,7 @@ export async function constructRelayerClients(
     config.bundleRefundLookback
   );
 
-  return { ...commonClients, spokePoolClients, tokenClient, profitClient, inventoryClient, acrossApiClient };
+  return { ...commonClients, spokePoolClients, ubaClient, tokenClient, profitClient, inventoryClient, acrossApiClient };
 }
 
 export async function updateRelayerClients(clients: RelayerClients, config: RelayerConfig): Promise<void> {


### PR DESCRIPTION
Simple change; the UBA client isn't actively used yet but that will follow shortly. The relayFeeCalculatorConfig is stubbed out because there's currently no need for it, but that may change later.

Closes ACX-1211