### PR TITLE
improve: Suppress additional "relay filled" errors

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -424,7 +424,9 @@ export class MultiCallerClient {
     const knownReason = [...knownRevertReasons].some((knownReason) =>
       [knownReason, `execution reverted: ${knownReason}`].includes(reason)
     );
-    return knownReason || (unknownRevertReasonMethodsToIgnore.has(_txn.method) && reason.includes(unknownRevertReason));
+    return !txn.succeed && (
+        knownReason || (unknownRevertReasonMethodsToIgnore.has(_txn.method) && reason.includes(unknownRevertReason))
+    );
   }
 
   // Filter out transactions that revert for non-critical, expected reasons. For example, the "relay filled" error may

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -422,10 +422,7 @@ export class MultiCallerClient {
   protected canIgnoreRevertReason(txn: TransactionSimulationResult): boolean {
     const { transaction: _txn, reason } = txn;
     const knownReason = [...knownRevertReasons].some((knownReason) => reason.includes(knownReason));
-    return (
-      !txn.succeed &&
-      (knownReason || (unknownRevertReasonMethodsToIgnore.has(_txn.method) && reason.includes(unknownRevertReason)))
-    );
+    return knownReason || (unknownRevertReasonMethodsToIgnore.has(_txn.method) && reason.includes(unknownRevertReason));
   }
 
   // Filter out transactions that revert for non-critical, expected reasons. For example, the "relay filled" error may

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -420,13 +420,11 @@ export class MultiCallerClient {
   // in order to not ignore errors thrown by non-contract reverts. For example, a NodeJS error might result in a reason
   // string that includes more than just the contract revert reason.
   protected canIgnoreRevertReason(txn: TransactionSimulationResult): boolean {
-    // prettier-ignore
-    return (
-      !txn.succeed && (
-        knownRevertReasons.has(txn.reason) ||
-        (unknownRevertReasonMethodsToIgnore.has(txn.transaction.method) && txn.reason === unknownRevertReason)
-      )
+    const { transaction: _txn, reason } = txn;
+    const knownReason = [...knownRevertReasons].some((knownReason) =>
+      [knownReason, `execution reverted: ${knownReason}`].includes(reason)
     );
+    return knownReason || (unknownRevertReasonMethodsToIgnore.has(_txn.method) && reason === unknownRevertReason);
   }
 
   // Filter out transactions that revert for non-critical, expected reasons. For example, the "relay filled" error may

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -421,11 +421,10 @@ export class MultiCallerClient {
   // string that includes more than just the contract revert reason.
   protected canIgnoreRevertReason(txn: TransactionSimulationResult): boolean {
     const { transaction: _txn, reason } = txn;
-    const knownReason = [...knownRevertReasons].some((knownReason) =>
-      [knownReason, `execution reverted: ${knownReason}`].includes(reason)
-    );
-    return !txn.succeed && (
-        knownReason || (unknownRevertReasonMethodsToIgnore.has(_txn.method) && reason.includes(unknownRevertReason))
+    const knownReason = [...knownRevertReasons].some((knownReason) => reason.includes(knownReason));
+    return (
+      !txn.succeed &&
+      (knownReason || (unknownRevertReasonMethodsToIgnore.has(_txn.method) && reason.includes(unknownRevertReason)))
     );
   }
 

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -424,7 +424,7 @@ export class MultiCallerClient {
     const knownReason = [...knownRevertReasons].some((knownReason) =>
       [knownReason, `execution reverted: ${knownReason}`].includes(reason)
     );
-    return knownReason || (unknownRevertReasonMethodsToIgnore.has(_txn.method) && reason === unknownRevertReason);
+    return knownReason || (unknownRevertReasonMethodsToIgnore.has(_txn.method) && reason.includes(unknownRevertReason));
   }
 
   // Filter out transactions that revert for non-critical, expected reasons. For example, the "relay filled" error may


### PR DESCRIPTION
Sometimes the error is returned as `execution reverted: <reason>`, so add detection for that. Additionally, refactor the detection logic to be more concise (no intended change in behaviour).