### PR TITLE
improve(ProfitClient): Permit gas costs to be ignored

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -93,7 +93,7 @@ export class ProfitClient {
   ) {
     // Require 1% <= gasMultiplier <= 400%
     assert(
-      this.gasMultiplier.gte(toBNWei("0.01")) && this.gasMultiplier.lte(toBNWei(4)),
+      this.gasMultiplier.gte(toBNWei("0.00")) && this.gasMultiplier.lte(toBNWei(4)),
       `Gas multiplier out of range (${this.gasMultiplier})`
     );
 
@@ -239,7 +239,7 @@ export class ProfitClient {
     const netRelayerFeePct = netRelayerFeeUsd.mul(fixedPoint).div(relayerCapitalUsd);
 
     // If token price or gas cost is unknown, assume the relay is unprofitable.
-    const fillProfitable = tokenPriceUsd.gt(0) && gasCostUsd.gt(0) && netRelayerFeePct.gte(minRelayerFeePct);
+    const fillProfitable = tokenPriceUsd.gt(0) && gasPriceUsd.gt(0) && netRelayerFeePct.gte(minRelayerFeePct);
 
     return {
       grossRelayerFeePct,

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -238,7 +238,7 @@ export class ProfitClient {
     const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd).sub(refundFeeUsd);
     const netRelayerFeePct = netRelayerFeeUsd.mul(fixedPoint).div(relayerCapitalUsd);
 
-    // If token price or gas cost is unknown, assume the relay is unprofitable.
+    // If token price or gas price is unknown, assume the relay is unprofitable.
     const fillProfitable = tokenPriceUsd.gt(0) && gasPriceUsd.gt(0) && netRelayerFeePct.gte(minRelayerFeePct);
 
     return {


### PR DESCRIPTION
Recent testing has been difficult because third-party relayers are eager to make fills, and are sometimes doing so at a loss. This means it can be surprisingly difficult to set a relayer fee low enough to be ignored by others. This change permits a 0x gas multiplier to be used, thereby instructing the relayer to ignore the cost of gas entirely. Deposits can thus be set with a 0% relayerFeePct, which is good enough to be ignored by most third parties. The pre-existing profitability protections are still in place, and control remains in the hands of the user as to how they want to configure their relayer.