### PR TITLE
improve(multicaller-client): Ignore expected revert reasons for batch txns

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -183,7 +183,7 @@ export class MultiCallerClient {
     );
     const batchSimResults = await this.txnClient.simulate(batchTxns);
     const batchesAllSucceeded = batchSimResults.every(({ succeed, transaction, reason }, idx) => {
-      if (this.canIgnoreRevertReason({ succeed, transaction, reason })) {
+      if (!succeed && this.canIgnoreRevertReason({ succeed, transaction, reason })) {
         this.logger.debug({
           at: "MultiCallerClient#executeChainTxnQueue",
           message: `Ignoring revert reason for ${networkName} transaction batch!`,

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -190,7 +190,6 @@ export class MultiCallerClient {
           batchTxn: { ...transaction, contract: transaction.contract.address },
           reason,
         });
-        return true;
       } else {
         this.logger[succeed ? "debug" : "error"]({
           at: "MultiCallerClient#executeChainTxnQueue",

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -183,21 +183,13 @@ export class MultiCallerClient {
     );
     const batchSimResults = await this.txnClient.simulate(batchTxns);
     const batchesAllSucceeded = batchSimResults.every(({ succeed, transaction, reason }, idx) => {
-      if (!succeed && this.canIgnoreRevertReason({ succeed, transaction, reason })) {
-        this.logger.debug({
-          at: "MultiCallerClient#executeChainTxnQueue",
-          message: `Ignoring revert reason for ${networkName} transaction batch!`,
-          batchTxn: { ...transaction, contract: transaction.contract.address },
-          reason,
-        });
-      } else {
-        this.logger[succeed ? "debug" : "error"]({
-          at: "MultiCallerClient#executeChainTxnQueue",
-          message: `${succeed ? "Successfully simulated" : "Failed to simulate"} ${networkName} transaction batch!`,
-          batchTxn: { ...transaction, contract: transaction.contract.address },
-          reason,
-        });
-      }
+      // If txn succeeded or the revert reason is known to be benign, then log at debug level.
+      this.logger[succeed || this.canIgnoreRevertReason({ succeed, transaction, reason }) ? "debug" : "error"]({
+        at: "MultiCallerClient#executeChainTxnQueue",
+        message: `${succeed ? "Successfully simulated" : "Failed to simulate"} ${networkName} transaction batch!`,
+        batchTxn: { ...transaction, contract: transaction.contract.address },
+        reason,
+      });
       batchTxns[idx].gasLimit = succeed ? transaction.gasLimit : undefined;
       return succeed;
     });


### PR DESCRIPTION
Today  the Multicaller client ignores known revert reasons when simulating individual transactions but not batch transactions. We should do the same for batch txns because this handles the common case where 
the batch contains only 1 txn and that has a clear revert reason that we expect.

Signed-off-by: nicholaspai <npai.nyc@gmail.com>
