### PR TITLE
fix(AdapterManager): Pad gas for deposits to Optimism

### DIFF
--- a/src/clients/bridges/OptimismAdapter.ts
+++ b/src/clients/bridges/OptimismAdapter.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import {
   Contract,
   BigNumber,
@@ -8,7 +9,7 @@ import {
   TransactionResponse,
 } from "../../utils";
 import { spreadEventWithBlockNumber, assign, winston } from "../../utils";
-import { SpokePoolClient } from "../../clients";
+import { AugmentedTransaction, SpokePoolClient, TransactionClient } from "../../clients";
 import { BaseAdapter, weth9Abi, ovmL1BridgeInterface, ovmL2BridgeInterface, atomicDepositorInterface } from "./";
 import { SortableEvent } from "../../interfaces";
 import { OutstandingTransfers } from "../../interfaces";
@@ -32,6 +33,8 @@ const atomicDepositorAddress = "0x26eaf37ee5daf49174637bdcd2f7759a25206c34";
 
 export class OptimismAdapter extends BaseAdapter {
   public l2Gas: number;
+  private txnClient: TransactionClient;
+
   constructor(
     logger: winston.Logger,
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
@@ -42,6 +45,7 @@ export class OptimismAdapter extends BaseAdapter {
   ) {
     super(spokePoolClients, 10, monitoredAddresses, logger);
     this.l2Gas = 200000;
+    this.txnClient = new TransactionClient(logger);
   }
 
   async getOutstandingCrossChainTransfers(l1Tokens: string[]): Promise<OutstandingTransfers> {
@@ -125,21 +129,35 @@ export class OptimismAdapter extends BaseAdapter {
     l2Token: string,
     amount: BigNumber
   ): Promise<TransactionResponse> {
+    const { chainId: destinationChainId, l2Gas, txnClient } = this;
+    assert(destinationChainId === 10, `chainId ${destinationChainId} is not supported`);
+
+    const contract = this.getL1TokenGateway(l1Token);
+    const originChainId = (await contract.provider.getNetwork()).chainId;
+    assert(originChainId !== destinationChainId);
+
     let method = "depositERC20";
-    let args = [l1Token, l2Token, amount, this.l2Gas, "0x"];
+    let args = [l1Token, l2Token, amount, l2Gas, "0x"];
 
     // If this token is WETH(the tokenToEvent maps to the ETH method) then we modify the params to call bridgeWethToOvm
     // on the atomic depositor contract. Note that value is still 0 as this method will pull WETH from the caller.
     if (this.isWeth(l1Token)) {
       method = "bridgeWethToOvm";
-      args = [address, amount, this.l2Gas, this.chainId];
+      args = [address, amount, l2Gas, destinationChainId];
     }
-    this.logger.debug({ at: this.getName(), message: "Bridging tokens", l1Token, l2Token, amount });
 
-    if (this.chainId !== 10) {
-      throw new Error(`chainId ${this.chainId} is not supported`);
+    // Pad gas when bridging to Optimism: https://community.optimism.io/docs/developers/bedrock/differences
+    const gasLimitMultiplier = 1.5;
+    const _txnRequest: AugmentedTransaction = { contract, chainId: originChainId, method, args, gasLimitMultiplier };
+    const { reason, succeed, transaction: txnRequest } = (await txnClient.simulate([_txnRequest]))[0];
+    if (!succeed) {
+      const message = `Failed to simulate ${method} deposit to chainId ${destinationChainId} for mainnet token ${l1Token}`;
+      this.logger.warn({ at: this.getName(), message, reason });
+      throw new Error(`${message} (${reason})`);
     }
-    return await runTransaction(this.logger, this.getL1TokenGateway(l1Token), method, args);
+
+    this.logger.debug({ at: this.getName(), message: "Bridging tokens", l1Token, l2Token, amount });
+    return (await txnClient.submit(originChainId, [txnRequest]))[0];
   }
 
   async wrapEthIfAboveThreshold(threshold: BigNumber): Promise<TransactionResponse | null> {


### PR DESCRIPTION
As per the recent change in the MultiCallerClient, when submitting transactions destined for the Optimism deposit contract on Ethereum, it's necessary to pad the gas that is estimated via estimateGas(). The TransactionClient class has been used for this because it's a drop-in replacement for runTransaction(), and the MultiCallerClient offers limited benefits in this case because coincidental rebalancing to multiple chains seems unlikely.

Test deposits and fills here:
https://etherscan.io/tx/0xe4802ea7f5c3f0f6b3234fc69d718850df6f11598d36413eec4e9600196e9020
https://optimistic.etherscan.io/tx/0x03aca8577d58391b6051086dac47a3785c16d03d7bfdf8028bba7dd8b4b7e13e

https://etherscan.io/tx/0x94f70a778270a94e242c7463044b73bded6f45e5c122e0cb65709eb7384b904c
https://optimistic.etherscan.io/tx/0x53caa311440971e14c2f0d50686fd84833d196df91a9630074fc3f5e2697b778

https://etherscan.io/tx/0x31d56649c764c4396631b54ae89d5ddaebf3a4bdbf1ba087c13149289400e044
https://optimistic.etherscan.io/tx/0xad35b26ee1cec22d06aef32d66181de80b324b962a0844a1eea154bdd1a77807

https://etherscan.io/tx/0xd2da3ce3d790f723a8b2e8634857ebcf9f3499955c0cc7b3fec3e10409c02503
https://optimistic.etherscan.io/tx/0x1feb13d66e6ef9393f641e63165bd206ca524c559ca8c254235238d9fa363d1f