### PR TITLE
feat: Add slow fill "grey" list mode to Relayer

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -161,19 +161,6 @@ export class Relayer {
         continue;
       }
 
-      // If depositor is on the slow deposit list, then send a zero fill to initiate a slow relay and return early.
-      if (config.slowDepositors.includes(deposit.depositor) && fillCount === 0) {
-        if (sendSlowRelays && tokenClient.hasBalanceForZeroFill(deposit) && fillCount === 0) {
-          this.logger.debug({
-            at: "Relayer",
-            message: "Initiating slow fill for grey listed depositor",
-            depositor: deposit.depositor,
-          });
-          this.zeroFillDeposit(deposit);
-        }
-        continue;
-      }
-
       // We query the relayer API to get the deposit limits for different token and destination combinations.
       // The relayer should *not* be filling deposits that the HubPool doesn't have liquidity for otherwise the relayer's
       // refund will be stuck for potentially 7 days.
@@ -209,6 +196,22 @@ export class Relayer {
           message: "Skipping fill for deposit with message",
           deposit,
         });
+        continue;
+      }
+
+      // If depositor is on the slow deposit list, then send a zero fill to initiate a slow relay and return early.
+      if (
+        config.slowDepositors.includes(deposit.depositor) &&
+        fillCount === 0 &&
+        sendSlowRelays &&
+        tokenClient.hasBalanceForZeroFill(deposit)
+      ) {
+        this.logger.debug({
+          at: "Relayer",
+          message: "Initiating slow fill for grey listed depositor",
+          depositor: deposit.depositor,
+        });
+        this.zeroFillDeposit(deposit);
         continue;
       }
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -161,6 +161,19 @@ export class Relayer {
         continue;
       }
 
+      // If depositor is on the slow deposit list, then send a zero fill to initiate a slow relay and return early.
+      if (config.slowDepositors.includes(deposit.depositor) && fillCount === 0) {
+        if (sendSlowRelays && tokenClient.hasBalanceForZeroFill(deposit) && fillCount === 0) {
+          this.logger.debug({
+            at: "Relayer",
+            message: "Initiating slow fill for grey listed depositor",
+            depositor: deposit.depositor,
+          });
+          this.zeroFillDeposit(deposit);
+        }
+        continue;
+      }
+
       // We query the relayer API to get the deposit limits for different token and destination combinations.
       // The relayer should *not* be filling deposits that the HubPool doesn't have liquidity for otherwise the relayer's
       // refund will be stuck for potentially 7 days.

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -17,6 +17,8 @@ export class RelayerConfig extends CommonConfig {
   readonly relayerGasMultiplier: BigNumber;
   readonly minRelayerFeePct: BigNumber;
   readonly acceptInvalidFills: boolean;
+  // List of depositors we only want to send slow fills for.
+  readonly slowDepositors: string[];
   // Following distances in blocks to guarantee finality on each chain.
   readonly minDepositConfirmations: {
     [threshold: number]: { [chainId: number]: number };
@@ -33,6 +35,7 @@ export class RelayerConfig extends CommonConfig {
   constructor(env: ProcessEnv) {
     const {
       RELAYER_DESTINATION_CHAINS,
+      SLOW_DEPOSITORS,
       DEBUG_PROFITABILITY,
       RELAYER_GAS_MULTIPLIER,
       RELAYER_INVENTORY_CONFIG,
@@ -51,6 +54,9 @@ export class RelayerConfig extends CommonConfig {
     this.relayerDestinationChains = RELAYER_DESTINATION_CHAINS ? JSON.parse(RELAYER_DESTINATION_CHAINS) : [];
     // Empty means all tokens.
     this.relayerTokens = RELAYER_TOKENS
+      ? JSON.parse(RELAYER_TOKENS).map((token) => ethers.utils.getAddress(token))
+      : [];
+    this.slowDepositors = SLOW_DEPOSITORS
       ? JSON.parse(RELAYER_TOKENS).map((token) => ethers.utils.getAddress(token))
       : [];
     this.inventoryConfig = RELAYER_INVENTORY_CONFIG ? JSON.parse(RELAYER_INVENTORY_CONFIG) : {};

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -57,7 +57,7 @@ export class RelayerConfig extends CommonConfig {
       ? JSON.parse(RELAYER_TOKENS).map((token) => ethers.utils.getAddress(token))
       : [];
     this.slowDepositors = SLOW_DEPOSITORS
-      ? JSON.parse(RELAYER_TOKENS).map((token) => ethers.utils.getAddress(token))
+      ? JSON.parse(SLOW_DEPOSITORS).map((depositor) => ethers.utils.getAddress(depositor))
       : [];
     this.inventoryConfig = RELAYER_INVENTORY_CONFIG ? JSON.parse(RELAYER_INVENTORY_CONFIG) : {};
     this.minRelayerFeePct = toBNWei(MIN_RELAYER_FEE_PCT || Constants.RELAYER_MIN_FEE_PCT);

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -108,6 +108,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       },
       {
         relayerTokens: [],
+        slowDepositors: [],
         relayerDestinationChains: [],
         maxRelayerLookBack: 24 * 60 * 60,
         minDepositConfirmations: defaultMinDepositConfirmations,

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -91,6 +91,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       },
       {
         relayerTokens: [],
+        slowDepositors: [],
         relayerDestinationChains: [],
         maxRelayerLookBack: 24 * 60 * 60,
         quoteTimeBuffer: 0,

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -89,6 +89,7 @@ describe("Relayer: Token balance shortfall", async function () {
       },
       {
         relayerTokens: [],
+        slowDepositors: [],
         relayerDestinationChains: [],
         maxRelayerLookBack: 24 * 60 * 60,
         quoteTimeBuffer: 0,


### PR DESCRIPTION
Enables relayer to mark certain depositors as slow-fill only. Could also use this pattern for a depositor "blacklist"