### PR TITLE
improve(Relayer): More intelligent UBA refund chain selection

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -326,7 +326,7 @@ export class ProfitClient {
     l1Token: L1Token
   ): boolean {
     const { profitable } =  this.computeFillProfitability(deposit, fillAmount, refundFee, l1Token);
-    return profitable;
+    return profitable ?? false;
   }
 
   captureUnprofitableFill(deposit: DepositWithBlock, fillAmount: BigNumber): void {

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -270,7 +270,7 @@ export class ProfitClient {
     return fillAmount.mul(tokenPriceInUsd).div(toBN(10).pow(l1TokenInfo.decimals));
   }
 
-  isFillProfitable(
+  computeFillProfitability(
     deposit: Deposit,
     fillAmount: BigNumber,
     refundFee: BigNumber,
@@ -317,6 +317,16 @@ export class ProfitClient {
     }
 
     return fill;
+  }
+
+ isFillProfitable(
+    deposit: Deposit,
+    fillAmount: BigNumber,
+    refundFee: BigNumber,
+    l1Token: L1Token
+  ): boolean {
+    const { profitable } =  this.computeFillProfitability(deposit, fillAmount, refundFee, l1Token);
+    return profitable;
   }
 
   captureUnprofitableFill(deposit: DepositWithBlock, fillAmount: BigNumber): void {

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -319,13 +319,8 @@ export class ProfitClient {
     return fill;
   }
 
- isFillProfitable(
-    deposit: Deposit,
-    fillAmount: BigNumber,
-    refundFee: BigNumber,
-    l1Token: L1Token
-  ): boolean {
-    const { profitable } =  this.computeFillProfitability(deposit, fillAmount, refundFee, l1Token);
+  isFillProfitable(deposit: Deposit, fillAmount: BigNumber, refundFee: BigNumber, l1Token: L1Token): boolean {
+    const { profitable } = this.computeFillProfitability(deposit, fillAmount, refundFee, l1Token);
     return profitable ?? false;
   }
 

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -31,7 +31,7 @@ export type FillProfit = {
   relayerCapitalUsd: BigNumber; // Amount to be sent by the relayer in USD.
   netRelayerFeePct: BigNumber; // Relayer fee after gas costs as a portion of relayerCapitalUsd.
   netRelayerFeeUsd: BigNumber; // Relayer fee in USD after paying for gas costs.
-  fillProfitable: boolean; // Fill profitability indicator.
+  profitable: boolean; // Fill profitability indicator.
 };
 
 export const GAS_TOKEN_BY_CHAIN_ID: { [chainId: number]: string } = {
@@ -239,7 +239,7 @@ export class ProfitClient {
     const netRelayerFeePct = netRelayerFeeUsd.mul(fixedPoint).div(relayerCapitalUsd);
 
     // If token price or gas price is unknown, assume the relay is unprofitable.
-    const fillProfitable = tokenPriceUsd.gt(0) && gasPriceUsd.gt(0) && netRelayerFeePct.gte(minRelayerFeePct);
+    const profitable = tokenPriceUsd.gt(0) && gasPriceUsd.gt(0) && netRelayerFeePct.gte(minRelayerFeePct);
 
     return {
       grossRelayerFeePct,
@@ -254,7 +254,7 @@ export class ProfitClient {
       relayerCapitalUsd,
       netRelayerFeePct,
       netRelayerFeeUsd,
-      fillProfitable,
+      profitable,
     };
   }
 
@@ -270,7 +270,12 @@ export class ProfitClient {
     return fillAmount.mul(tokenPriceInUsd).div(toBN(10).pow(l1TokenInfo.decimals));
   }
 
-  isFillProfitable(deposit: Deposit, fillAmount: BigNumber, refundFee: BigNumber, l1Token: L1Token): boolean {
+  isFillProfitable(
+    deposit: Deposit,
+    fillAmount: BigNumber,
+    refundFee: BigNumber,
+    l1Token: L1Token
+  ): FillProfit | undefined {
     const minRelayerFeePct = this.minRelayerFeePct(l1Token.symbol, deposit.originChainId, deposit.destinationChainId);
     let fill: FillProfit;
 
@@ -283,12 +288,12 @@ export class ProfitClient {
         deposit,
         fillAmount,
       });
-      return false;
+      return undefined;
     }
 
-    if (!fill.fillProfitable || this.debugProfitability) {
+    if (!fill.profitable || this.debugProfitability) {
       const { depositId, originChainId } = deposit;
-      const profitable = fill.fillProfitable ? "profitable" : "unprofitable";
+      const profitable = fill.profitable ? "profitable" : "unprofitable";
       this.logger.debug({
         at: "ProfitClient#isFillProfitable",
         message: `${l1Token.symbol} deposit ${depositId} on chain ${originChainId} is ${profitable}`,
@@ -307,11 +312,11 @@ export class ProfitClient {
         netRelayerFeeUsd: formatEther(fill.netRelayerFeeUsd),
         netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)}%`,
         minRelayerFeePct: `${formatFeePct(minRelayerFeePct)}%`,
-        fillProfitable: fill.fillProfitable,
+        profitable: fill.profitable,
       });
     }
 
-    return fill.fillProfitable;
+    return fill;
   }
 
   captureUnprofitableFill(deposit: DepositWithBlock, fillAmount: BigNumber): void {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -351,8 +351,9 @@ export class Relayer {
       return profitable ? preferredChainId : undefined;
     }
 
-    // @todo: Filter refundChains by whether the token is supported on that chain.
-    const refundChainIds = this.config.relayerDestinationChains;
+    // Ensure that the refund token exists on the candidate chainId.
+    const refundChainIds = this.config.relayerDestinationChains
+      .filter((chainId) => hubPoolClient.l2TokenEnabledForL1Token(hubPoolToken.address, chainId));
 
     // Estimate the profitability of taking a refund on each candidate refundChainId.
     const refundFees = this.computeRefundFees(version, fillAmount, refundChainIds, hubPoolToken.symbol);

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -347,7 +347,7 @@ export class Relayer {
 
     const preferredChainId = await inventoryClient.determineRefundChainId(deposit);
     if (!sdkUtils.isUBA(version)) {
-      const { profitable } = profitClient.isFillProfitable(deposit, fillAmount, toBN(0), hubPoolToken);
+      const profitable = profitClient.isFillProfitable(deposit, fillAmount, toBN(0), hubPoolToken);
       return profitable ? preferredChainId : undefined;
     }
 
@@ -358,7 +358,7 @@ export class Relayer {
     const refundFees = this.computeRefundFees(version, fillAmount, refundChainIds, hubPoolToken.symbol);
     const refundChainProfits = Object.fromEntries(
       refundChainIds
-        .map((chainId) => profitClient.isFillProfitable(deposit, fillAmount, refundFees[chainId], hubPoolToken))
+        .map((chainId) => profitClient.computeFillProfitability(deposit, fillAmount, refundFees[chainId], hubPoolToken))
         .map(({ profitable, netRelayerFeePct }, idx) => [refundChainIds[idx], { profitable, netRelayerFeePct }])
     );
 

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -362,12 +362,15 @@ export class Relayer {
         .map(({ profitable, netRelayerFeePct }, idx) => [refundChainIds[idx], { profitable, netRelayerFeePct }])
     );
 
-    const refundChainsByProfit = refundChainIds.sort((chainA, chainB) =>
-      refundChainProfits[chainA].netRelayerFeePct.gte(refundChainProfits[chainB].netRelayerFeePct) ? 1 : -1
+    const refundChainsByProfit = refundChainIds
+      .filter((chainId) => ![preferredChainId, destinationChainId, hubPoolClient.chainId].includes(chainId))
+      .sort((chainA, chainB) =>
+        refundChainProfits[chainA].netRelayerFeePct.gte(refundChainProfits[chainB].netRelayerFeePct) ? 1 : -1
     );
 
     // If none of the preferred refund chains are profitable, take the refund wherever it's profitable.
     // This may also produce no chainId, in which case the fill is truly unprofitable.
+    // @note: duplicates may appear; it's OK provided the array is ordered by descending preference.
     const repaymentChainId = [
       preferredChainId,
       destinationChainId,

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -352,8 +352,9 @@ export class Relayer {
     }
 
     // Ensure that the refund token exists on the candidate chainId.
-    const refundChainIds = this.config.relayerDestinationChains
-      .filter((chainId) => hubPoolClient.l2TokenEnabledForL1Token(hubPoolToken.address, chainId));
+    const refundChainIds = this.config.relayerDestinationChains.filter((chainId) =>
+      hubPoolClient.l2TokenEnabledForL1Token(hubPoolToken.address, chainId)
+    );
 
     // Estimate the profitability of taking a refund on each candidate refundChainId.
     const refundFees = this.computeRefundFees(version, fillAmount, refundChainIds, hubPoolToken.symbol);

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -334,9 +334,9 @@ export class Relayer {
         );
       });
 
-    const originChain = getNetworkName(originChainId);
-    const destinationChain = getNetworkName(destinationChainId);
-    if (fillAmount.eq(deposit.amount) && !fillsInQueueForSameDeposit) {
+    if (!fillAmount.eq(deposit.amount) || fillsInQueueForSameDeposit) {
+      const originChain = getNetworkName(originChainId);
+      const destinationChain = getNetworkName(destinationChainId);
       this.logger.debug({
         at: "Relayer",
         message: `Skipping repayment chain determination for partial fill on ${destinationChain}`,

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -11,7 +11,7 @@ import {
   buildFillRelayWithUpdatedFeeProps,
   isDepositSpedUp,
 } from "../utils";
-import { createFormatFunction, etherscanLink, formatFeePct, RelayerUnfilledDeposit, toBN, toBNWei } from "../utils";
+import { createFormatFunction, etherscanLink, formatFeePct, toBN, toBNWei } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
 import { Deposit, DepositWithBlock, L1Token } from "../interfaces";
 import { RelayerConfig } from "./RelayerConfig";
@@ -214,7 +214,6 @@ export class Relayer {
         } else {
           profitClient.captureUnprofitableFill(deposit, unfilledAmount);
         }
-
       } else {
         tokenClient.captureTokenShortfallForFill(deposit, unfilledAmount);
         // If we don't have enough balance to fill the unfilled amount and the fill count on the deposit is 0 then send a
@@ -369,9 +368,12 @@ export class Relayer {
 
     // If none of the preferred refund chains are profitable, take the refund wherever it's profitable.
     // This may also produce no chainId, in which case the fill is truly unprofitable.
-    const repaymentChainId =
-      [preferredChainId, destinationChainId, hubPoolClient.chainId, ...refundChainsByProfit]
-        .find((chainId) => refundChainProfits[chainId].profitable)[0];
+    const repaymentChainId = [
+      preferredChainId,
+      destinationChainId,
+      hubPoolClient.chainId,
+      ...refundChainsByProfit,
+    ].find((chainId) => refundChainProfits[chainId].profitable)[0];
 
     return repaymentChainId;
   }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -363,14 +363,15 @@ export class Relayer {
         .map(({ profitable, netRelayerFeePct }, idx) => [refundChainIds[idx], { profitable, netRelayerFeePct }])
     );
 
+    // Sort the residual chainIds according to their respective profitabilities.
     const refundChainsByProfit = refundChainIds
       .filter((chainId) => ![preferredChainId, destinationChainId, hubPoolClient.chainId].includes(chainId))
       .sort((chainA, chainB) =>
         refundChainProfits[chainA].netRelayerFeePct.gte(refundChainProfits[chainB].netRelayerFeePct) ? 1 : -1
       );
 
-    // If none of the preferred refund chains are profitable, take the refund wherever it's profitable.
-    // This may also produce no chainId, in which case the fill is truly unprofitable.
+    // If none of the preferred refund chains are profitable, take the refund wherever it's most
+    // profitable This may also produce no chainId, in which case the fill is truly unprofitable.
     // @note: duplicates may appear; it's OK provided the array is ordered by descending preference.
     const repaymentChainId = [
       preferredChainId,

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -366,7 +366,7 @@ export class Relayer {
       .filter((chainId) => ![preferredChainId, destinationChainId, hubPoolClient.chainId].includes(chainId))
       .sort((chainA, chainB) =>
         refundChainProfits[chainA].netRelayerFeePct.gte(refundChainProfits[chainB].netRelayerFeePct) ? 1 : -1
-    );
+      );
 
     // If none of the preferred refund chains are profitable, take the refund wherever it's profitable.
     // This may also produce no chainId, in which case the fill is truly unprofitable.

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -2,6 +2,7 @@ import { groupBy } from "lodash";
 import { clients as sdkClients, utils as sdkUtils } from "@across-protocol/sdk-v2";
 import {
   BigNumber,
+  isDefined,
   winston,
   buildFillRelayProps,
   getNetworkName,
@@ -10,9 +11,9 @@ import {
   buildFillRelayWithUpdatedFeeProps,
   isDepositSpedUp,
 } from "../utils";
-import { createFormatFunction, etherscanLink, formatFeePct, toBN, toBNWei } from "../utils";
+import { createFormatFunction, etherscanLink, formatFeePct, RelayerUnfilledDeposit, toBN, toBNWei } from "../utils";
 import { RelayerClients } from "./RelayerClientHelper";
-import { Deposit, DepositWithBlock } from "../interfaces";
+import { Deposit, DepositWithBlock, L1Token } from "../interfaces";
 import { RelayerConfig } from "./RelayerConfig";
 
 const { UBAActionType } = sdkClients;
@@ -207,15 +208,13 @@ export class Relayer {
         // The SpokePool guarantees the sum of the fees is <= 100% of the deposit amount.
         deposit.realizedLpFeePct = await this.computeRealizedLpFeePct(version, deposit, l1Token.symbol);
 
-        const repaymentChainId = await this.resolveRepaymentChain(deposit, unfilledAmount);
-        // @todo: For UBA, compute the anticipated refund fee(s) for *all* candidate refund chain(s).
-        const refundFee = await this.computeRefundFee(version, unfilledAmount, repaymentChainId, l1Token.symbol);
-
-        if (profitClient.isFillProfitable(deposit, unfilledAmount, refundFee, l1Token)) {
+        const repaymentChainId = await this.resolveRepaymentChain(version, deposit, unfilledAmount, l1Token);
+        if (isDefined(repaymentChainId)) {
           this.fillRelay(deposit, unfilledAmount, repaymentChainId);
         } else {
           profitClient.captureUnprofitableFill(deposit, unfilledAmount);
         }
+
       } else {
         tokenClient.captureTokenShortfallForFill(deposit, unfilledAmount);
         // If we don't have enough balance to fill the unfilled amount and the fill count on the deposit is 0 then send a
@@ -313,7 +312,15 @@ export class Relayer {
     }
   }
 
-  protected async resolveRepaymentChain(deposit: Deposit, fillAmount: BigNumber): Promise<number> {
+  protected async resolveRepaymentChain(
+    version: number,
+    deposit: DepositWithBlock,
+    fillAmount: BigNumber,
+    hubPoolToken: L1Token
+  ): Promise<number | undefined> {
+    const { depositId, originChainId, destinationChainId, transactionHash: depositHash } = deposit;
+    const { hubPoolClient, inventoryClient, profitClient } = this.clients;
+
     // TODO: Consider adding some way for Relayer to delete transactions in Queue for fills for same deposit.
     // This way the relayer could set a repayment chain ID for any fill that follows a 1 wei fill in the queue.
     // This isn't implemented due to complexity because its a very rare case in production, because its very
@@ -321,28 +328,50 @@ export class Relayer {
     // then later on in the run have enough balance to fully fill it.
     const fillsInQueueForSameDeposit = this.clients.multiCallerClient
       .getQueuedTransactions(deposit.destinationChainId)
-      .some((tx) => {
-        const { method, args } = tx;
-        const { depositId, originChainId } = deposit;
+      .some(({ method, args }) => {
         return (
           (method === "fillRelay" && args[9] === depositId && args[6] === originChainId) ||
           (method === "fillRelayWithUpdatedDeposit" && args[11] === depositId && args[7] === originChainId)
         );
       });
 
-    // Fetch the repayment chain from the inventory client. Sanity check that it is one of the known chainIds.
-    // We can only overwrite repayment chain ID if we can fully fill the deposit.
-    let repaymentChainId = deposit.destinationChainId;
-
+    const originChain = getNetworkName(originChainId);
+    const destinationChain = getNetworkName(destinationChainId);
     if (fillAmount.eq(deposit.amount) && !fillsInQueueForSameDeposit) {
-      const destinationChainId = deposit.destinationChainId.toString();
-      repaymentChainId = await this.clients.inventoryClient.determineRefundChainId(deposit);
-      if (!Object.keys(this.clients.spokePoolClients).includes(destinationChainId)) {
-        throw new Error("Fatal error! Repayment chain set to a chain that is not part of the defined sets of chains!");
-      }
-    } else {
-      this.logger.debug({ at: "Relayer", message: "Skipping repayment chain determination for partial fill" });
+      this.logger.debug({
+        at: "Relayer",
+        message: `Skipping repayment chain determination for partial fill on ${destinationChain}`,
+        deposit: { originChain, depositId, destinationChain, depositHash },
+      });
+      return destinationChainId;
     }
+
+    const preferredChainId = await inventoryClient.determineRefundChainId(deposit);
+    if (!sdkUtils.isUBA(version)) {
+      const { profitable } = profitClient.isFillProfitable(deposit, fillAmount, toBN(0), hubPoolToken);
+      return profitable ? preferredChainId : undefined;
+    }
+
+    // @todo: Filter refundChains by whether the token is supported on that chain.
+    const refundChainIds = this.config.relayerDestinationChains;
+
+    // Estimate the profitability of taking a refund on each candidate refundChainId.
+    const refundFees = this.computeRefundFees(version, fillAmount, refundChainIds, hubPoolToken.symbol);
+    const refundChainProfits = Object.fromEntries(
+      refundChainIds
+        .map((chainId) => profitClient.isFillProfitable(deposit, fillAmount, refundFees[chainId], hubPoolToken))
+        .map(({ profitable, netRelayerFeePct }, idx) => [refundChainIds[idx], { profitable, netRelayerFeePct }])
+    );
+
+    const refundChainsByProfit = refundChainIds.sort((chainA, chainB) =>
+      refundChainProfits[chainA].netRelayerFeePct.gte(refundChainProfits[chainB].netRelayerFeePct) ? 1 : -1
+    );
+
+    // If none of the preferred refund chains are profitable, take the refund wherever it's profitable.
+    // This may also produce no chainId, in which case the fill is truly unprofitable.
+    const repaymentChainId =
+      [preferredChainId, destinationChainId, hubPoolClient.chainId, ...refundChainsByProfit]
+        .find((chainId) => refundChainProfits[chainId].profitable)[0];
 
     return repaymentChainId;
   }
@@ -372,27 +401,27 @@ export class Relayer {
     return realizedLpFeePct;
   }
 
-  protected async computeRefundFee(
+  protected async computeRefundFees(
     version: number,
     unfilledAmount: BigNumber,
-    refundChainId: number,
+    chainIds: number[],
     symbol: string,
     hubPoolBlockNumber?: number
-  ): Promise<BigNumber | undefined> {
+  ): Promise<BigNumber[]> {
     if (!sdkUtils.isUBA(version)) {
-      return toBN(0);
+      return chainIds.map(() => toBN(0));
     }
 
     const { hubPoolClient, ubaClient } = this.clients;
-    const { balancingFee } = await ubaClient.computeBalancingFee(
+    const fees = await ubaClient.computeBalancingFees(
       symbol,
       unfilledAmount,
       hubPoolBlockNumber ?? hubPoolClient.latestBlockNumber,
-      refundChainId,
+      chainIds,
       UBAActionType.Refund
     );
 
-    return balancingFee;
+    return fees.map(({ balancingFee }) => balancingFee);
   }
 
   private handleTokenShortfall() {

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -79,14 +79,14 @@ function testProfitability(
   const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd.add(refundFeeUsd));
   const netRelayerFeePct = netRelayerFeeUsd.mul(fixedPoint).div(relayerCapitalUsd);
 
-  const fillProfitable = netRelayerFeeUsd.gte(minRelayerFeeUsd);
+  const profitable = netRelayerFeeUsd.gte(minRelayerFeeUsd);
 
   return {
     grossRelayerFeeUsd,
     netRelayerFeePct,
     relayerCapitalUsd,
     netRelayerFeeUsd,
-    fillProfitable,
+    profitable,
   } as FillProfit;
 }
 
@@ -283,24 +283,23 @@ describe("ProfitClient: Consider relay profit", async function () {
             const relayerFeePct = _relayerFeePct.gt(maxRelayerFeePct) ? maxRelayerFeePct : _relayerFeePct;
             const deposit = { relayerFeePct, destinationChainId } as Deposit;
 
-            const fill: FillProfit = testProfitability(deposit, fillAmountUsd, gasCostUsd, zeroRefundFee);
+            const expected = testProfitability(deposit, fillAmountUsd, gasCostUsd, zeroRefundFee);
             spyLogger.debug({
-              message: `Expect ${l1Token.symbol} deposit is ${fill.fillProfitable ? "" : "un"}profitable:`,
+              message: `Expect ${l1Token.symbol} deposit is ${expected.profitable ? "" : "un"}profitable:`,
               fillAmount,
               fillAmountUsd,
               gasCostUsd,
               grossRelayerFeePct: `${formatFeePct(relayerFeePct)} %`,
               gasCostPct: `${formatFeePct(gasCostPct)} %`,
-              relayerCapitalUsd: fill.relayerCapitalUsd,
+              relayerCapitalUsd: expected.relayerCapitalUsd,
               minRelayerFeePct: `${formatFeePct(minRelayerFeePct)} %`,
               minRelayerFeeUsd: minRelayerFeePct.mul(fillAmountUsd).div(fixedPoint),
-              netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)} %`,
-              netRelayerFeeUsd: fill.netRelayerFeeUsd,
+              netRelayerFeePct: `${formatFeePct(expected.netRelayerFeePct)} %`,
+              netRelayerFeeUsd: expected.netRelayerFeeUsd,
             });
 
-            expect(profitClient.isFillProfitable(deposit, nativeFillAmount, zeroRefundFee, l1Token)).to.equal(
-              fill.fillProfitable
-            );
+            const fill = profitClient.isFillProfitable(deposit, nativeFillAmount, zeroRefundFee, l1Token);
+            expect(fill?.profitable).to.equal(expected.profitable);
           });
         });
       });
@@ -334,9 +333,9 @@ describe("ProfitClient: Consider relay profit", async function () {
             const refundFee = fillAmount.mul(feeMultiplier).div(fixedPoint);
             const nativeRefundFee = nativeFillAmount.mul(feeMultiplier).div(fixedPoint);
             const refundFeeUsd = refundFee.mul(tokenPriceUsd).div(fixedPoint);
-            const fill: FillProfit = testProfitability(deposit, fillAmountUsd, gasCostUsd, refundFeeUsd);
+            const expected = testProfitability(deposit, fillAmountUsd, gasCostUsd, refundFeeUsd);
             spyLogger.debug({
-              message: `Expect ${l1Token.symbol} deposit is ${fill.fillProfitable ? "" : "un"}profitable:`,
+              message: `Expect ${l1Token.symbol} deposit is ${expected.profitable ? "" : "un"}profitable:`,
               tokenPrice: formatEther(tokenPriceUsd),
               fillAmount: formatEther(fillAmount),
               fillAmountUsd: formatEther(fillAmountUsd),
@@ -346,16 +345,15 @@ describe("ProfitClient: Consider relay profit", async function () {
               refundFeeUsd: formatEther(refundFeeUsd),
               grossRelayerFeePct: `${formatFeePct(relayerFeePct)} %`,
               gasCostPct: `${formatFeePct(gasCostPct)} %`,
-              relayerCapitalUsd: formatEther(fill.relayerCapitalUsd),
+              relayerCapitalUsd: formatEther(expected.relayerCapitalUsd),
               minRelayerFeePct: `${formatFeePct(minRelayerFeePct)} %`,
               minRelayerFeeUsd: formatEther(minRelayerFeePct.mul(fillAmountUsd).div(fixedPoint)),
-              netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)} %`,
-              netRelayerFeeUsd: formatEther(fill.netRelayerFeeUsd),
+              netRelayerFeePct: `${formatFeePct(expected.netRelayerFeePct)} %`,
+              netRelayerFeeUsd: formatEther(expected.netRelayerFeeUsd),
             });
 
-            expect(profitClient.isFillProfitable(deposit, nativeFillAmount, nativeRefundFee, l1Token)).to.equal(
-              fill.fillProfitable
-            );
+            const fill = profitClient.isFillProfitable(deposit, nativeFillAmount, nativeRefundFee, l1Token);
+            expect(fill?.profitable).to.equal(expected.profitable);
           });
         });
       });

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -298,8 +298,8 @@ describe("ProfitClient: Consider relay profit", async function () {
               netRelayerFeeUsd: expected.netRelayerFeeUsd,
             });
 
-            const fill = profitClient.isFillProfitable(deposit, nativeFillAmount, zeroRefundFee, l1Token);
-            expect(fill?.profitable).to.equal(expected.profitable);
+            const profitable = profitClient.isFillProfitable(deposit, nativeFillAmount, zeroRefundFee, l1Token);
+            expect(profitable).to.equal(expected.profitable);
           });
         });
       });
@@ -352,8 +352,8 @@ describe("ProfitClient: Consider relay profit", async function () {
               netRelayerFeeUsd: formatEther(expected.netRelayerFeeUsd),
             });
 
-            const fill = profitClient.isFillProfitable(deposit, nativeFillAmount, nativeRefundFee, l1Token);
-            expect(fill?.profitable).to.equal(expected.profitable);
+            const profitable = profitClient.isFillProfitable(deposit, nativeFillAmount, nativeRefundFee, l1Token);
+            expect(profitable).to.equal(expected.profitable);
           });
         });
       });


### PR DESCRIPTION
This implements the "Repayment Chain Choice Module" described in
ACX-977. It prefers to take refunds on the chainId suggested by the
Inventory Manager, then the destinationChainId, and then the HubPool
chainId, before reverting to an ordered list of the most profitable
refund chains. In each case, it must be profitable for the relayer to
take a refund there for it to use that chainId.

Some minor tweaks were needed in the ProfitClient to make this more
cohesive.

Closes ACX-977.