### PR TITLE
improve(TransactionClient): Simulation on undefined gasLimit

### DIFF
--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -77,8 +77,11 @@ export class TransactionClient {
       }
 
       if (!isDefined(txn.gasLimit)) {
-        const { transaction: simResult }  = (await this.simulate([txn]))[0];
-        txn.gasLimit = simResult.gasLimit;
+        const { succeed, transaction: txnSim, reason }  = (await this.simulate([txn]))[0];
+        if (!succeed) {
+          throw new Error(`Unable to simulate chain ${chainId} ${txn.method} transaction (${reason})`);
+        }
+        txn.gasLimit = txnSim.gasLimit;
       }
 
       // @dev It's assumed that nobody ever wants to discount the gasLimit.

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -77,7 +77,7 @@ export class TransactionClient {
       }
 
       if (!isDefined(txn.gasLimit)) {
-        const { succeed, transaction: txnSim, reason }  = (await this.simulate([txn]))[0];
+        const { succeed, transaction: txnSim, reason } = (await this.simulate([txn]))[0];
         if (!succeed) {
           throw new Error(`Unable to simulate chain ${chainId} ${txn.method} transaction (${reason})`);
         }

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import {
+  isDefined,
   winston,
   getNetworkName,
   Contract,
@@ -73,6 +74,11 @@ export class TransactionClient {
 
       if (nonce !== null) {
         this.logger.debug({ at: "TransactionClient#submit", message: `Using nonce ${nonce}.` });
+      }
+
+      if (!isDefined(txn.gasLimit)) {
+        const { transaction: simResult }  = (await this.simulate([txn]))[0];
+        txn.gasLimit = simResult.gasLimit;
       }
 
       // @dev It's assumed that nobody ever wants to discount the gasLimit.


### PR DESCRIPTION
If the transaction gasLimit is undefined, simulate it before submission. This saves the caller from having to call simulate() before submit().