### PR TITLE
feat: add support for POOL token

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "node": ">=16.18.0"
   },
   "dependencies": {
-    "@across-protocol/contracts-v2": "2.3.0",
-    "@arbitrum/sdk": "^3.1.3",
+    "@across-protocol/contracts-v2": "2.3.3",
     "@across-protocol/optimism-sdk": "2.1.3",
-    "@across-protocol/sdk-v2": "0.10.3",
+    "@across-protocol/sdk-v2": "0.10.4",
+    "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^2.1.0",
     "@ethersproject/abi": "^5.7.0",

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -85,6 +85,13 @@ const tokenToBridge = {
     l1AmountProp: "amount",
     l2AmountProp: "value",
   }, // ACX
+  [TOKEN_SYMBOLS_MAP.POOL.addresses[CHAIN_IDs.MAINNET]]: {
+    l1BridgeAddress: "0x40ec5B33f54e0E8A33A975908C5BA1c14e5BbbDf",
+    l2TokenAddress: TOKEN_SYMBOLS_MAP.POOL.addresses[CHAIN_IDs.POLYGON],
+    l1Method: "LockedERC20",
+    l1AmountProp: "amount",
+    l2AmountProp: "value",
+  }, // POOL
   [TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.MAINNET]]: {
     l1BridgeAddress: "0x8484Ef722627bf18ca5Ae6BcF031c23E6e922B30",
     l2TokenAddress: TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.POLYGON],

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -221,7 +221,12 @@ export class Relayer {
       if (tokenClient.hasBalanceForFill(deposit, unfilledAmount)) {
         // The pre-computed realizedLpFeePct is for the pre-UBA fee model. Update it to the UBA fee model if necessary.
         // The SpokePool guarantees the sum of the fees is <= 100% of the deposit amount.
-        deposit.realizedLpFeePct = await this.computeRealizedLpFeePct(version, deposit, l1Token.symbol);
+        deposit.realizedLpFeePct = await this.computeRealizedLpFeePct(
+          version,
+          deposit,
+          l1Token.symbol,
+          l1Token.address
+        );
 
         const repaymentChainId = await this.resolveRepaymentChain(deposit, unfilledAmount);
         // @todo: For UBA, compute the anticipated refund fee(s) for *all* candidate refund chain(s).
@@ -367,6 +372,7 @@ export class Relayer {
     version: number,
     deposit: Deposit,
     symbol: string,
+    hubPoolTokenAddress: string,
     hubPoolBlockNumber?: number
   ): Promise<BigNumber> {
     if (!sdkUtils.isUBA(version)) {
@@ -381,7 +387,14 @@ export class Relayer {
       lpFee,
       depositBalancingFee: depositFee,
       systemFee: realizedLpFeePct,
-    } = await ubaClient.computeSystemFee(originChainId, destinationChainId, symbol, amount, hubPoolBlockNumber);
+    } = await ubaClient.computeSystemFee(
+      originChainId,
+      destinationChainId,
+      symbol,
+      hubPoolTokenAddress,
+      amount,
+      hubPoolBlockNumber
+    );
 
     const chain = getNetworkName(deposit.originChainId);
     this.logger.debug({

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,25 +11,10 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/contracts-v2@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.3.0.tgz#ebd246717fd4d38ea2d12de4ec22c3ecfec83989"
-  integrity sha512-ZGA3s/YM9PUs3OiTULHZYfIGVnaINGbQ7mRqw32YG74HWsppYJJJwYBdaXJEqgZGz0B/lAaP0ad1OSCbGE8Q9Q==
-  dependencies:
-    "@defi-wonderland/smock" "^2.3.4"
-    "@eth-optimism/contracts" "^0.5.40"
-    "@ethersproject/abstract-provider" "5.7.0"
-    "@ethersproject/abstract-signer" "5.7.0"
-    "@openzeppelin/contracts" "4.8.3"
-    "@openzeppelin/contracts-upgradeable" "4.8.3"
-    "@uma/common" "^2.29.0"
-    "@uma/contracts-node" "^0.3.18"
-    "@uma/core" "^2.41.0"
-
-"@across-protocol/contracts-v2@2.3.2":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.3.2.tgz#f89167a8617db5ffbf097bc7a4026de08e10ea43"
-  integrity sha512-GPRTgu0ESVWPZ1D68DV7UCxW7KXDdht73xKgceEtW1addBjiTVYfr8ag1R/Fj3ljASwl/zERYZdFNQSlunao7w==
+"@across-protocol/contracts-v2@2.3.3":
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.3.3.tgz#7581872e3baa7ed1e2a01b09ca0cda13df5461e9"
+  integrity sha512-ei3MvryADWaC33Fn+hu6GAaXTGOoovYkfHAEv1tEF/ULLhjIZ6uhAtQ7cmSiva73zVwaOx15WXunnbn6kV4siQ==
   dependencies:
     "@defi-wonderland/smock" "^2.3.4"
     "@eth-optimism/contracts" "^0.5.40"
@@ -63,13 +48,13 @@
     merkletreejs "^0.2.27"
     rlp "^2.2.7"
 
-"@across-protocol/sdk-v2@0.10.3":
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.10.3.tgz#31ae4483b4a7964a710dc0507222a1bfc892a3c0"
-  integrity sha512-9/HRYflUZz+YLvjeKG2pVAGMY1KNTleIpgcR+WtYFl27jjpRtuzG+LS98koaB9ABGYyXGqofiYuIt3F0n+0Npg==
+"@across-protocol/sdk-v2@0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.10.4.tgz#dc4b89f84ff453142bb1a2ad22be3d8ddec59b8a"
+  integrity sha512-x+jGXKHBGcpJkXYG3W826MIinne5bpkCm/1P7aFDrSs0PRzqAgpSvpmoW2Z968ucJiPGt4mrIDiCLZ55shimXw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
-    "@across-protocol/contracts-v2" "2.3.2"
+    "@across-protocol/contracts-v2" "2.3.3"
     "@eth-optimism/sdk" "^2.1.0"
     "@uma/sdk" "^0.34.1"
     axios "^0.27.2"


### PR DESCRIPTION
Bumps contracts-v2 and sdk-v2 to latest version with fixed POOL token addresses. Also, add support for POOL in `PolygonAdapter`.

There was a breaking change in `@across-protocol/sdk-v2@0.10.4`. The fix is here https://github.com/across-protocol/relayer-v2/pull/779/commits/661ad21aaab448d1839515b461a110ebbde7ca56. Let me know if this is not correct