### PR TITLE
improve(BalanceAllocator): Allow caller to specify fungible tokens

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -383,6 +383,9 @@ export const CONTRACT_ADDRESSES: {
         },
       ],
     },
+    eth: {
+      address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+    },
   },
   137: {
     withdrawableErc20: {
@@ -410,6 +413,43 @@ export const CONTRACT_ADDRESSES: {
           type: "event",
         },
       ],
+    },
+  },
+  288: {
+    weth: {
+      address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+      abi: [
+        {
+          constant: false,
+          inputs: [{ name: "wad", type: "uint256" }],
+          name: "withdraw",
+          outputs: [],
+          payable: false,
+          stateMutability: "nonpayable",
+          type: "function",
+        },
+        {
+          constant: false,
+          inputs: [],
+          name: "deposit",
+          outputs: [],
+          payable: true,
+          stateMutability: "payable",
+          type: "function",
+        },
+        {
+          constant: true,
+          inputs: [{ name: "", type: "address" }],
+          name: "balanceOf",
+          outputs: [{ name: "", type: "uint256" }],
+          payable: false,
+          stateMutability: "view",
+          type: "function",
+        },
+      ],
+    },
+    eth: {
+      address: "0x4200000000000000000000000000000000000006",
     },
   },
   42161: {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -61,8 +61,6 @@ type RootBundle = {
   tree: MerkleTree<SlowFillLeaf>;
 };
 
-const ovmWethTokens = [CONTRACT_ADDRESSES[10].weth.address];
-
 export type PoolRebalanceRoot = {
   runningBalances: RunningBalances;
   realizedLpFees: RunningBalances;
@@ -1074,8 +1072,15 @@ export class Dataworker {
           // Note: the getRefund function just happens to perform the same math we need.
           // A refund is the total fill amount minus LP fees, which is the same as the payout for a slow relay!
           const amountRequired = getRefund(relayData.amount.sub(amountFilled), relayData.realizedLpFeePct);
+          const ovmWethTokens = [
+            CONTRACT_ADDRESSES[relayData.destinationChainId].weth.address,
+            CONTRACT_ADDRESSES[relayData.destinationChainId].eth.address,
+          ];
           const success = await balanceAllocator.requestBalanceAllocation(
             relayData.destinationChainId,
+            // If OVM chain, treat ETH and WETH balances on SpokePool as interchangeable. Importantly make sure WETH
+            // comes first in the `tokens` list passed to `requestBalanceAllocation` so that the WETH balance is used for accounting purposes.
+            // Although it doesn't matter, its more accurate since ETH should be swept up into WETH.
             isOvmChain(relayData.destinationChainId) && ovmWethTokens.includes(relayData.destinationToken)
               ? ovmWethTokens
               : [relayData.destinationToken],
@@ -1674,6 +1679,13 @@ export class Dataworker {
           const l1TokenInfo = this.clients.hubPoolClient.getL1TokenInfoForL2Token(leaf.l2TokenAddress, chainId);
           const refundSum = leaf.refundAmounts.reduce((acc, curr) => acc.add(curr), BigNumber.from(0));
           const totalSent = refundSum.add(leaf.amountToReturn.gte(0) ? leaf.amountToReturn : BigNumber.from(0));
+          const ovmWethTokens = [
+            CONTRACT_ADDRESSES[leaf.chainId].weth.address,
+            CONTRACT_ADDRESSES[leaf.chainId].eth.address,
+          ];
+          // If OVM chain, treat ETH and WETH balances on SpokePool as interchangeable. Importantly make sure WETH
+          // comes first in the `tokens` list passed to `requestBalanceAllocation` so that the WETH balance is used for accounting purposes.
+          // Although it doesn't matter, its more accurate since ETH should be swept up into WETH.
           const success = await balanceAllocator.requestBalanceAllocation(
             leaf.chainId,
             isOvmChain(leaf.chainId) && ovmWethTokens.includes(leaf.l2TokenAddress)

--- a/test/BalanceAllocator.ts
+++ b/test/BalanceAllocator.ts
@@ -105,7 +105,21 @@ describe("BalanceAllocator", async function () {
         { chainId: 1, tokens: [testToken1, testToken2], holder: testAccount1, amount: BigNumber.from(50) },
       ])
     ).to.be.true;
-    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(99));
-    expect(balanceAllocator.getUsed(1, testToken2, testAccount1)).to.equal(BigNumber.from(1));
+    expect(await balanceAllocator.getBalance(1, testToken1, testAccount1)).to.equal(BigNumber.from(198));
+    expect(await balanceAllocator.getBalance(1, testToken2, testAccount1)).to.equal(BigNumber.from(0));
+    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(100));
+    expect(balanceAllocator.getUsed(1, testToken2, testAccount1)).to.equal(BigNumber.from(0));
+  });
+
+  it("Combined request, multiple tokens per request, succeeds even if amount is more than either individual value", async function () {
+    balanceAllocator.setMockBalances(1, testToken1, testAccount1, BigNumber.from(50));
+    balanceAllocator.setMockBalances(1, testToken2, testAccount1, BigNumber.from(50));
+    expect(
+      await balanceAllocator.requestBalanceAllocations([
+        { chainId: 1, tokens: [testToken1, testToken2], holder: testAccount1, amount: BigNumber.from(75) },
+      ])
+    ).to.be.true;
+    expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(75));
+    expect(balanceAllocator.getUsed(1, testToken2, testAccount1)).to.equal(BigNumber.from(0));
   });
 });


### PR DESCRIPTION
This feature simplifies the BalanceAllocator logic by treating fungible `tokens` passed into `requestBalanceAllocations` as the same 
token (arbitrarily keyed by the first token in the list). This makes accounting of the `balances` and `used` dictionaries simpler.

The tradeoff is that the caller has more responsibility to only pass in truly fungible tokens whose balances are collapsed in reality. 
If the caller doesn't actually combine token0 and token1, for example, then the next call to the BalanceAllocator would be using 
inaccurate numbers.

I think this is a fine tradeoff as the BalanceAllocator is shared only amongst dataworker-executor functions which correctly collapse 
WETH and ETH, the two fungible tokens on OVM chains.

Signed-off-by: nicholaspai <npai.nyc@gmail.com>
