### PR TITLE
refactor: Relocate getBlockForTimestamp()

### DIFF
--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -1,0 +1,57 @@
+import { BlockFinder } from "@uma/financial-templates-lib";
+import { Block, getProvider, getRedis, isDefined, setRedisKey, shouldCache } from "./";
+
+const blockFinders: { [chainId: number]: BlockFinder<Block> } = {};
+
+/**
+ * @notice Return block finder for chain. Loads from in memory blockFinder cache if this function was called before
+ * for this chain ID. Otherwise creates a new block finder and adds it to the cache.
+ * @param chainId
+ * @returns
+ */
+export async function getBlockFinder(chainId: number): Promise<BlockFinder<Block>> {
+  if (!isDefined(blockFinders[chainId])) {
+    const providerForChain = await getProvider(chainId);
+    blockFinders[chainId] = new BlockFinder<Block>(providerForChain.getBlock.bind(providerForChain), [], chainId);
+  }
+  return blockFinders[chainId];
+}
+
+/**
+ * @notice Get the block number for a given timestamp fresh from on-chain data if not found in redis cache.
+ * If redis cache is not available, then requests block from blockFinder.
+ * @param chainId Chain to load block finder for.
+ * @param blockFinder Caller can optionally pass in a block finder object to use instead of creating a new one
+ * or loading from cache. This is useful for testing primarily.
+ * @returns
+ */
+export async function getBlockForTimestamp(
+  hubPoolChainId: number,
+  chainId: number,
+  timestamp: number,
+  currentChainTime: number,
+  blockFinder?: BlockFinder<Block>
+): Promise<number> {
+  blockFinder ??= await getBlockFinder(chainId);
+  const redisClient = await getRedis();
+
+  // If no redis client, then request block from blockFinder. Otherwise try to load from redis cache.
+  if (redisClient === undefined) {
+    return (await blockFinder.getBlockForTimestamp(timestamp)).number;
+  }
+
+  // We already cache blocks in the ConfigStore on the HubPool chain so re-use that key if the chainId
+  // matches the HubPool's.
+  const key = chainId === hubPoolChainId ? `block_number_${timestamp}` : `${chainId}_block_number_${timestamp}`;
+  const result = await redisClient.get(key);
+  if (result === null) {
+    const blockNumber = (await blockFinder.getBlockForTimestamp(timestamp)).number;
+    // Expire key after 90 days.
+    if (shouldCache(timestamp, currentChainTime)) {
+      await setRedisKey(key, blockNumber.toString(), redisClient, 60 * 60 * 24 * 90);
+    }
+    return blockNumber;
+  } else {
+    return parseInt(result);
+  }
+}

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -1,6 +1,5 @@
-import { assert, Block, getProvider, toBN, BigNumberish } from ".";
+import { assert, toBN, BigNumberish } from "./";
 import { REDIS_URL_DEFAULT } from "../common/Constants";
-import { BlockFinder } from "@uma/financial-templates-lib";
 import { createClient } from "redis4";
 import winston from "winston";
 import { Deposit, Fill } from "../interfaces";
@@ -17,8 +16,6 @@ export const REDIS_URL = process.env.REDIS_URL || REDIS_URL_DEFAULT;
 
 // Make the redis client for a particular url essentially a singleton.
 const redisClients: { [url: string]: RedisClient } = {};
-
-const blockFinders: { [chainId: number]: BlockFinder<Block> } = {};
 
 export async function getRedis(logger?: winston.Logger, url = REDIS_URL): Promise<RedisClient | undefined> {
   if (!redisClients[url]) {
@@ -79,60 +76,6 @@ export async function getDeposit(key: string, redisClient: RedisClient): Promise
   const depositRaw = await redisClient.get(key);
   if (depositRaw) {
     return JSON.parse(depositRaw, objectWithBigNumberReviver);
-  }
-}
-
-/**
- * @notice Return block finder for chain. Loads from in memory blockFinder cache if this function was called before
- * for this chain ID. Otherwise creates a new block finder and adds it to the cache.
- * @param chainId
- * @returns
- */
-async function getBlockFinder(chainId: number): Promise<BlockFinder<Block>> {
-  if (!blockFinders[chainId]) {
-    const providerForChain = await getProvider(chainId);
-    blockFinders[chainId] = new BlockFinder<Block>(providerForChain.getBlock.bind(providerForChain), [], chainId);
-  }
-  return blockFinders[chainId];
-}
-
-/**
- * @notice Get the block number for a given timestamp fresh from on-chain data if not found in redis cache.
- * If redis cache is not available, then requests block from blockFinder.
- * @param chainId Chain to load block finder for.
- * @param blockFinder Caller can optionally pass in a block finder object to use instead of creating a new one
- * or loading from cache. This is useful for testing primarily.
- * @returns
- */
-export async function getBlockForTimestamp(
-  hubPoolChainId: number,
-  chainId: number,
-  timestamp: number,
-  currentChainTime: number,
-  blockFinder?: BlockFinder<Block>
-): Promise<number> {
-  if (blockFinder === undefined) {
-    blockFinder = await getBlockFinder(chainId);
-  }
-  const redisClient = await getRedis();
-
-  // If no redis client, then request block from blockFinder. Otherwise try to load from redis cache.
-  if (redisClient === undefined) {
-    return (await blockFinder.getBlockForTimestamp(timestamp)).number;
-  }
-  // We already cache blocks in the ConfigStore on the HubPool chain so re-use that key if the chainId
-  // matches the HubPool's.
-  const key = chainId === hubPoolChainId ? `block_number_${timestamp}` : `${chainId}_block_number_${timestamp}`;
-  const result = await redisClient.get(key);
-  if (result === null) {
-    const blockNumber = (await blockFinder.getBlockForTimestamp(timestamp)).number;
-    // Expire key after 90 days.
-    if (shouldCache(timestamp, currentChainTime)) {
-      await setRedisKey(key, blockNumber.toString(), redisClient, 60 * 60 * 24 * 90);
-    }
-    return blockNumber;
-  } else {
-    return parseInt(result);
   }
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,6 +15,7 @@ export { config } from "dotenv";
 export * from "./ProviderUtils";
 export * from "./SignerUtils";
 export * from "./DepositUtils";
+export * from "./BlockUtils";
 export * from "./EventUtils";
 export * from "./FillUtils";
 export * from "./ObjectUtils";


### PR DESCRIPTION
This function uses Redis in the back-end to cache block timestamps; it's not inherently a part of Redis utilities. Also, export getBlockFinder() so that it can be used directly.