### PR TITLE
fix(dataworker): Add ETH to list of tokens we should request balance allocations for

### DIFF
--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -383,6 +383,9 @@ export const CONTRACT_ADDRESSES: {
         },
       ],
     },
+    eth: {
+      address: "0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000",
+    },
   },
   137: {
     withdrawableErc20: {

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -61,7 +61,7 @@ type RootBundle = {
   tree: MerkleTree<SlowFillLeaf>;
 };
 
-const ovmWethTokens = [CONTRACT_ADDRESSES[10].weth.address];
+const ovmWethTokens = [CONTRACT_ADDRESSES[10].weth.address, CONTRACT_ADDRESSES[10].eth.address];
 
 export type PoolRebalanceRoot = {
   runningBalances: RunningBalances;


### PR DESCRIPTION
When executing OVM SpokePool leaves we need to request both ETH and WETH balances together

Alternative implementation to #785 