### PR TITLE
chore: bump sdk-v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/contracts-v2": "2.3.3",
     "@across-protocol/optimism-sdk": "2.1.3",
-    "@across-protocol/sdk-v2": "0.12.1",
+    "@across-protocol/sdk-v2": "0.12.3",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     merkletreejs "^0.2.27"
     rlp "^2.2.7"
 
-"@across-protocol/sdk-v2@0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.12.1.tgz#53e537349186c2279596dd6852bd8ca860af02fa"
-  integrity sha512-uOTDEME7YgCFyEU/g84qRfZXw9+TMrqDpkfFuHabGD3za6aIPsONgq+0moerOWd5cPgp0J9rz++D4bClxUOmhA==
+"@across-protocol/sdk-v2@0.12.3":
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.12.3.tgz#32498c6d018416dbf9fff5ce855cbebf8a6ba5e8"
+  integrity sha512-npR2pDSayYGmAKz7+V81VTRufVVb6AiRGRiriTtYHLv+Cl5Vrwpfb84DCO0HhtXnL3BFPE0fJBk53q3hMhNKFw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/contracts-v2" "2.3.3"


### PR DESCRIPTION
This change bumps the SDK-V2 to v0.12.3