### PR TITLE
refactor: Use local delay function

### DIFF
--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -1,7 +1,6 @@
 import { Result } from "@ethersproject/abi";
-import { delay } from "@uma/financial-templates-lib";
 import { SortableEvent } from "../interfaces";
-import { Contract, Event, EventFilter } from "./";
+import { Contract, delay, Event, EventFilter } from "./";
 
 const maxRetries = 3;
 const retrySleepTime = 10;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,7 @@ import winston from "winston";
 import assert from "assert";
 import fetch from "node-fetch";
 export { winston, assert, fetch };
-export { delay, Logger } from "@uma/financial-templates-lib";
+export { Logger } from "@uma/financial-templates-lib";
 
 export { BigNumber, Signer, Contract, ContractFactory, Transaction, BigNumberish } from "ethers";
 export { utils, EventFilter, BaseContract, Event, Wallet } from "ethers";


### PR DESCRIPTION
delay() exists in src/utils/TimeUtils.ts and was already exported via src/utils/index.ts.