### PR TITLE
fix: use group feature in dependabot to open a single PR weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,17 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      # Create a group of dependencies to be updated together in one pull request
+    groups:
+       # Specify a name for the group, which will be used in pull request titles
+       # and branch names
+       all-dependencies:
+          # Define patterns to include dependencies in the group (based on
+          # dependency name)
+          patterns:
+            - "*"       # A wildcard that matches all dependencies in the packages


### PR DESCRIPTION
The idea is to reduce the overwhelming number of PRs and only have one open at any given time.