### PR TITLE
feat: Allow configuration of max supported config version

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -13,7 +13,6 @@ import {
 import { HubPoolClient, MultiCallerClient, ConfigStoreClient, SpokePoolClient } from "../clients";
 import { CommonConfig } from "./Config";
 import { SpokePoolClientsByChain } from "../interfaces";
-import { CONFIG_STORE_VERSION } from "./";
 
 export interface Clients {
   hubPoolClient: HubPoolClient;
@@ -226,7 +225,7 @@ export async function constructClients(
     logger,
     configStore,
     rateModelClientSearchSettings,
-    CONFIG_STORE_VERSION,
+    config.maxConfigVersion,
     config.chainIdListIndices
   );
 

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -17,6 +17,7 @@ export class CommonConfig {
   readonly maxRelayerLookBack: number;
   readonly multiCallChunkSize: { [chainId: number]: number };
   readonly version: string;
+  readonly maxConfigVersion: number;
   readonly blockRangeEndBlockBuffer: { [chainId: number]: number };
   readonly toBlockOverride: Record<number, number> = {};
   readonly chainIdListIndices: number[];
@@ -34,6 +35,7 @@ export class CommonConfig {
       SPOKE_POOL_CHAINS_OVERRIDE,
       CHAIN_ID_LIST_OVERRIDE,
       ACROSS_BOT_VERSION,
+      ACROSS_MAX_CONFIG_VERSION,
     } = env;
 
     this.chainIdListIndices = CHAIN_ID_LIST_OVERRIDE
@@ -41,6 +43,12 @@ export class CommonConfig {
       : Constants.CHAIN_ID_LIST_INDICES;
 
     this.version = ACROSS_BOT_VERSION ?? "unknown";
+
+    // Maximum version of the Across ConfigStore version that is supported.
+    // Operators should normally use the defaults here, but it can be overridden for testing.
+    // Warning: Possible loss of funds if this is misconfigured.
+    this.maxConfigVersion = Number(ACROSS_MAX_CONFIG_VERSION ?? Constants.CONFIG_STORE_VERSION);
+    assert(!isNaN(this.maxConfigVersion), `Invalid maximum config version: ${this.maxConfigVersion}`);
 
     this.blockRangeEndBlockBuffer = BLOCK_RANGE_END_BLOCK_BUFFER
       ? JSON.parse(BLOCK_RANGE_END_BLOCK_BUFFER)

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1914,8 +1914,7 @@ export class Dataworker {
     submitExecution = true,
     earliestBlocksInSpokePoolClients: { [chainId: number]: number } = {}
   ): Promise<void> {
-    const { bundleDataClient, configStoreClient, hubPoolClient } = this.clients;
-    const hubPoolChainId = hubPoolClient.chainId;
+    const { configStoreClient, hubPoolClient } = this.clients;
     this.logger.debug({ at: "Dataworker#executeRelayerRefundLeaves", message: "Executing relayer refund leaves" });
 
     let latestRootBundles = sortEventsDescending(hubPoolClient.getValidatedRootBundles());
@@ -2002,7 +2001,7 @@ export class Dataworker {
 
         const mainnetBundleStartBlock = getBlockRangeForChain(
           blockNumberRanges,
-          hubPoolChainId,
+          hubPoolClient.chainId,
           this.chainIdListForBundleEvaluationBlockNumbers
         )[0];
         const version = this.clients.configStoreClient.getConfigStoreVersionForBlock(mainnetBundleStartBlock);

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -32,7 +32,6 @@ import { PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
 import { createDataworker } from "../dataworker";
 import { getBlockForChain, getEndBlockBuffers } from "../dataworker/DataworkerUtils";
-import { CONFIG_STORE_VERSION } from "../common";
 
 config();
 let logger: winston.Logger;
@@ -78,7 +77,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
     logger.error({
       at: "Dataworker#validate",
       message: "Cannot validate because missing updated ConfigStore version. Update to latest code.",
-      latestVersionSupported: CONFIG_STORE_VERSION,
+      latestVersionSupported: clients.configStoreClient.configStoreVersion,
       latestInConfigStore: clients.configStoreClient.getConfigStoreVersionForTimestamp(),
     });
     return;


### PR DESCRIPTION
This allows individual operators to opt in to UBA pricing in advance of the default supported version being incremented.

This commit includes some very minor refactoring as a result of dereferencing a couple of objects adjacent to the configStoreClient within the CommonClients instance. 

Note that this doesn't change the active version - that's still read from the ConfigStore.