### PR TITLE
improve: Remove sneaky hardcoded chain ID

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -305,7 +305,7 @@ export class Dataworker {
     // to construct the potential next bundle block range.
     const blockRangesForProposal = this._getWidestPossibleBlockRangeForNextBundle(
       spokePoolClients,
-      hubPoolClient.latestBlockNumber - this.blockRangeEndBlockBuffer[1]
+      hubPoolClient.latestBlockNumber - this.blockRangeEndBlockBuffer[hubPoolClient.chainId]
     );
 
     // Exit early if spoke pool clients don't have early enough event data to satisfy block ranges for the


### PR DESCRIPTION
blockRangeEndBlockBuffer is a map that's addressed by chainId. These cases are otherwise tricky to spot, since we often lookup position 1 in an array of [startBlock, endBlock], and that is a valid case of hardcoding the index.