### PR TITLE
feat: add cache agnostic redis cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/contracts-v2": "2.3.3",
     "@across-protocol/optimism-sdk": "2.1.3",
-    "@across-protocol/sdk-v2": "0.14.9",
+    "@across-protocol/sdk-v2": "0.14.12",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^2.1.0",

--- a/src/caching/RedisCache.ts
+++ b/src/caching/RedisCache.ts
@@ -4,7 +4,6 @@ import { RedisClient, getRedis, objectWithBigNumberReviver, setRedisKey, winston
 export class RedisCache implements interfaces.CachingMechanismInterface {
   private readonly logger: winston.Logger | undefined;
   private readonly redisUrl: string;
-  private isInstantiated: boolean;
   private redisClient: RedisClient | undefined;
 
   constructor(redisUrl: string, logger?: winston.Logger) {
@@ -14,7 +13,7 @@ export class RedisCache implements interfaces.CachingMechanismInterface {
   }
 
   public async instantiate(): Promise<void> {
-    if (!this.isInstantiated) {
+    if (!this.redisClient) {
       this.redisClient = await getRedis(this.logger, this.redisUrl);
     }
   }

--- a/src/caching/RedisCache.ts
+++ b/src/caching/RedisCache.ts
@@ -1,0 +1,39 @@
+import { interfaces } from "@across-protocol/sdk-v2";
+import { RedisClient, getRedis, objectWithBigNumberReviver, setRedisKey, winston } from "../utils";
+
+export class RedisCache implements interfaces.CachingMechanismInterface {
+  private readonly logger: winston.Logger | undefined;
+  private readonly redisUrl: string;
+  private isInstantiated: boolean;
+  private redisClient: RedisClient | undefined;
+
+  constructor(redisUrl: string, logger?: winston.Logger) {
+    this.logger = logger;
+    this.redisUrl = redisUrl;
+    this.redisClient = undefined;
+  }
+
+  public async instantiate(): Promise<void> {
+    if (!this.isInstantiated) {
+      this.redisClient = await getRedis(this.logger, this.redisUrl);
+    }
+  }
+
+  public async get<T>(key: string): Promise<T> {
+    if (!this.redisClient) {
+      throw new Error("Redis client not instantiated");
+    }
+    const result = await this.redisClient.get(key);
+    if (result) {
+      return JSON.parse(result, objectWithBigNumberReviver);
+    }
+  }
+
+  public async set<T>(key: string, value: T, ttl?: number): Promise<boolean> {
+    if (!this.redisClient) {
+      throw new Error("Redis client not instantiated");
+    }
+    await setRedisKey(key, JSON.stringify(value), this.redisClient, ttl);
+    return true;
+  }
+}

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -97,7 +97,7 @@ export function shouldCache(eventTimestamp: number, latestTime: number): boolean
 // JSON.stringify(object) ends up stringfying BigNumber objects as "{type:BigNumber,hex...}" so we can pass
 // this reviver function as the second arg to JSON.parse to instruct it to correctly revive a stringified
 // object with BigNumber values.
-function objectWithBigNumberReviver(_: string, value: { type: string; hex: BigNumberish }) {
+export function objectWithBigNumberReviver(_: string, value: { type: string; hex: BigNumberish }): unknown {
   if (typeof value !== "object" || value?.type !== "BigNumber") {
     return value;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,10 +65,10 @@
     merkletreejs "^0.2.27"
     rlp "^2.2.7"
 
-"@across-protocol/sdk-v2@0.14.9":
-  version "0.14.9"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.14.9.tgz#721814b125a9d826ca1692876da95e5eb4bfccc5"
-  integrity sha512-qKkGmQKJC3u8TZQPwYp310vEZEf5oExgN5lPSXCi86JTT/cFRZoHsKd9q+QNkOrPVneUM6VwAMTMGCQRmMDF3w==
+"@across-protocol/sdk-v2@0.14.12":
+  version "0.14.12"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.14.12.tgz#3274141f114df1edc227a8293b3cfed88fab2fcd"
+  integrity sha512-D+ttGgW8vcEF19iTrUMsMwKzz4ykFiAGQSowoOP0a07YwjY/ubPtlhtV5DyRvusWP7ebaViksbztq82NXreEIA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/contracts-v2" "2.4.0"


### PR DESCRIPTION
This PR uses the SDK-V2's agnostic caching interface to wrap a Redis client. We can now use an instance of this caching class in the SDK without the SDK needing to know anything about redis except that it can `set` and `get` keys of a specific type.