### PR TITLE
improve(relayer): Simplify deposit version filtering

### DIFF
--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -299,18 +299,5 @@ export async function getUnfilledDeposits(
     }
   }
 
-  // If the config store version is up to date, then we can return the unfilled deposits as is. Otherwise, we need to
-  // make sure we have a high enough version for each deposit.
-  if (hubPoolClient.configStoreClient.hasLatestConfigStoreVersion) {
-    return unfilledDeposits;
-  } else {
-    return unfilledDeposits.map((unfilledDeposit) => {
-      return {
-        ...unfilledDeposit,
-        requiresNewConfigStoreVersion: !hubPoolClient.configStoreClient.hasValidConfigStoreVersionForTimestamp(
-          unfilledDeposit.deposit.quoteTimestamp
-        ),
-      };
-    });
-  }
+  return unfilledDeposits;
 }


### PR DESCRIPTION
The version-filtered array of unfilled deposits was not subsequently used when deriving the confirmedUnfilledDeposits array that is ultimately used to make fills. This was fortunately not a showstopper for the relayer because we still had an old check in `getUnfilledDeposits()`. This PR removes that and implements a test for specific version-based filtering.

In order to make it harder to trip over this in future, factor out the version determination so that there are fewer overall variables to track in the checkForUnfilledDepositsAndFill() method. This also makes it easy to add a specific unit test.

Closes ACX-1346