### PR TITLE
chore: Bump SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/contracts-v2": "2.4.0",
     "@across-protocol/optimism-sdk": "2.1.3",
-    "@across-protocol/sdk-v2": "0.14.12",
+    "@across-protocol/sdk-v2": "0.14.13",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^2.1.0",

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -447,7 +447,7 @@ describe("Dataworker: Load data used in all functions", async function () {
     await updateAllClients();
     const data3 = await dataworkerInstance.clients.bundleDataClient.loadData(getDefaultBlockRange(3), spokePoolClients);
     expect(data3.unfilledDeposits)
-      .excludingEvery(["logIndex", "transactionHash", "transactionIndex"])
+      .excludingEvery(["blockTimestamp", "logIndex", "transactionHash", "transactionIndex"])
       .to.deep.equal([
         {
           unfilledAmount: amountToDeposit.sub(fill1.fillAmount),
@@ -488,6 +488,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         amountToDeposit
       )),
       blockNumber: await getLastBlockNumber(),
+      blockTimestamp: (await spokePool_2.provider.getBlock(await getLastBlockNumber())).timestamp,
     } as DepositWithBlock;
     deposit5.quoteBlockNumber = (await hubPoolClient.computeRealizedLpFeePct(deposit5, l1Token_1.address)).quoteBlock;
     const fill3 = await buildFill(spokePool_1, erc20_1, depositor, relayer, deposit5, 0.25);
@@ -532,7 +533,10 @@ describe("Dataworker: Load data used in all functions", async function () {
     );
 
     // Submit a valid fill.
-    const fill1 = await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit1, 0.5);
+    const fill1 = {
+      ...(await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit1, 0.5)),
+      blockTimestamp: (await spokePool_2.provider.getBlock(await getLastBlockNumber())).timestamp,
+    };
     await updateAllClients();
     const data1 = await dataworkerInstance.clients.bundleDataClient.loadData(getDefaultBlockRange(0), spokePoolClients);
     expect(data1.fillsToRefund).to.deep.equal({
@@ -589,11 +593,19 @@ describe("Dataworker: Load data used in all functions", async function () {
       originChainId,
       amountToDeposit
     );
-    const fill3 = await buildFill(spokePool_1, erc20_1, depositor, relayer, deposit3, 0.25);
+    const fill3 = {
+      ...(await buildFill(spokePool_1, erc20_1, depositor, relayer, deposit3, 0.25)),
+      blockTimestamp: (await spokePool_1.provider.getBlock(await getLastBlockNumber())).timestamp,
+    };
+
     const slowRelays = buildSlowRelayLeaves([deposit3]);
     const tree = await buildSlowRelayTree(slowRelays);
     await spokePool_1.relayRootBundle(tree.getHexRoot(), tree.getHexRoot());
-    const slowFill3 = await buildSlowFill(spokePool_1, fill3, depositor, []);
+    const slowFill3 = {
+      ...(await buildSlowFill(spokePool_1, fill3, depositor, [])),
+      blockTimestamp: (await spokePool_1.provider.getBlock(await getLastBlockNumber())).timestamp,
+    };
+
     await updateAllClients();
     const data5 = await dataworkerInstance.clients.bundleDataClient.loadData(getDefaultBlockRange(3), spokePoolClients);
     const expectedData5 = {
@@ -635,7 +647,10 @@ describe("Dataworker: Load data used in all functions", async function () {
     );
 
     // Submit valid full fill for different chain:
-    const fill1 = await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit1, 1, originChainId);
+    const fill1 = {
+      ...(await buildFill(spokePool_2, erc20_2, depositor, relayer, deposit1, 1, originChainId)),
+      blockTimestamp: (await spokePool_2.provider.getBlock(await getLastBlockNumber())).timestamp,
+    };
 
     // Normal mode should add to fills to refund to origin chain Id without a refund requested.
     await updateAllClients();
@@ -702,7 +717,8 @@ describe("Dataworker: Load data used in all functions", async function () {
       originChainId,
       amountToDeposit
     );
-    const originBlock = await spokePool_2.provider.getBlockNumber();
+    const blockNumber = await spokePool_2.provider.getBlockNumber();
+    const blockTimestamp = (await spokePool_2.provider.getBlock(blockNumber)).timestamp;
     const realizedLpFeePctData = await hubPoolClient.computeRealizedLpFeePct(deposit1, l1Token_1.address);
 
     // Should include all deposits, even those not matched by a relay
@@ -710,7 +726,7 @@ describe("Dataworker: Load data used in all functions", async function () {
     const data1 = await dataworkerInstance.clients.bundleDataClient.loadData(getDefaultBlockRange(5), spokePoolClients);
     expect(data1.deposits)
       .excludingEvery(["logIndex", "transactionHash", "transactionIndex"])
-      .to.deep.equal([{ ...deposit1, quoteBlockNumber: realizedLpFeePctData.quoteBlock, blockNumber: originBlock }]);
+      .to.deep.equal([{ ...deposit1, quoteBlockNumber: realizedLpFeePctData.quoteBlock, blockNumber, blockTimestamp }]);
 
     // If block range does not cover deposits, then they are not included
     expect(

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -42,6 +42,15 @@ let unfilledDeposits: RelayerUnfilledDeposit[] = [];
 let _getUnfilledDeposits: Promise<RelayerUnfilledDeposit[]>;
 
 describe("Relayer: Unfilled Deposits", async function () {
+  const sortableEventFields = [
+    "blockNumber",
+    "blockTimestamp",
+    "quoteBlockNumber",
+    "logIndex",
+    "transactionIndex",
+    "transactionHash",
+  ];
+
   beforeEach(async function () {
     [owner, depositor, relayer] = await ethers.getSigners();
     // Deploy the two spokePools and their associated tokens. Set the chainId to match to associated chainIds. The first
@@ -143,7 +152,7 @@ describe("Relayer: Unfilled Deposits", async function () {
 
     unfilledDeposits = await _getUnfilledDeposits();
     expect(unfilledDeposits)
-      .excludingEvery(["blockNumber", "quoteBlockNumber", "logIndex", "transactionIndex", "transactionHash"])
+      .excludingEvery(sortableEventFields)
       .to.deep.equal([
         {
           unfilledAmount: deposit1.amount,
@@ -212,7 +221,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     // Validate the relayer correctly computes the unfilled amount.
     unfilledDeposits = await _getUnfilledDeposits();
     expect(unfilledDeposits)
-      .excludingEvery(["blockNumber", "quoteBlockNumber", "logIndex", "transactionIndex", "transactionHash"])
+      .excludingEvery(sortableEventFields)
       .to.deep.equal([
         {
           unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
@@ -239,7 +248,7 @@ describe("Relayer: Unfilled Deposits", async function () {
 
     unfilledDeposits = await _getUnfilledDeposits();
     expect(unfilledDeposits)
-      .excludingEvery(["blockNumber", "quoteBlockNumber", "logIndex", "transactionIndex", "transactionHash"])
+      .excludingEvery(sortableEventFields)
       .to.deep.equal([
         {
           unfilledAmount: unfilledAmount,
@@ -264,7 +273,7 @@ describe("Relayer: Unfilled Deposits", async function () {
 
     unfilledDeposits = await _getUnfilledDeposits();
     expect(unfilledDeposits)
-      .excludingEvery(["blockNumber", "quoteBlockNumber", "logIndex", "transactionIndex", "transactionHash"])
+      .excludingEvery(sortableEventFields)
       .to.deep.equal([
         {
           unfilledAmount: deposit2Complete.amount,
@@ -288,7 +297,7 @@ describe("Relayer: Unfilled Deposits", async function () {
     // The deposit should show up as unfilled, since the fill was incorrectly applied to the wrong deposit.
     unfilledDeposits = await _getUnfilledDeposits();
     expect(unfilledDeposits)
-      .excludingEvery(["blockNumber", "quoteBlockNumber", "logIndex", "transactionIndex", "transactionHash"])
+      .excludingEvery(sortableEventFields)
       .to.deep.equal([
         {
           unfilledAmount: deposit1Complete.amount,
@@ -363,7 +372,7 @@ describe("Relayer: Unfilled Deposits", async function () {
 
     unfilledDeposits = await _getUnfilledDeposits();
     expect(unfilledDeposits)
-      .excludingEvery(["blockNumber", "quoteBlockNumber", "logIndex", "transactionIndex", "transactionHash"])
+      .excludingEvery(sortableEventFields)
       .to.deep.equal([
         {
           unfilledAmount: deposit1.amount.sub(fill1.fillAmount),
@@ -403,7 +412,7 @@ describe("Relayer: Unfilled Deposits", async function () {
 
     unfilledDeposits = await _getUnfilledDeposits();
     expect(unfilledDeposits)
-      .excludingEvery(["blockNumber", "quoteBlockNumber", "logIndex", "transactionIndex", "transactionHash"])
+      .excludingEvery(sortableEventFields)
       .to.deep.equal([
         {
           unfilledAmount: deposit1.amount.sub(fill1.fillAmount),

--- a/test/SpokePoolClient.RefundRequests.ts
+++ b/test/SpokePoolClient.RefundRequests.ts
@@ -71,6 +71,7 @@ describe("SpokePoolClient: Refund Requests", async function () {
       refundRequestEvents.push({
         ...spreadEventWithBlockNumber(testEvent),
         repaymentChainId,
+        blockTimestamp: (await testEvent.getBlock()).timestamp,
       } as RefundRequestWithBlock);
     }
     await spokePoolClient.update();

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -20,6 +20,15 @@ const destinationChainId2 = destinationChainId + 1;
 let spokePoolClient: SpokePoolClient;
 
 describe("SpokePoolClient: SpeedUp", async function () {
+  const ignoredFields = [
+    "blockNumber",
+    "blockTimestamp",
+    "logIndex",
+    "quoteBlockNumber",
+    "transactionHash",
+    "transactionIndex",
+  ];
+
   beforeEach(async function () {
     [, depositor] = await ethers.getSigners();
     ({ spokePool, erc20, destErc20, weth, deploymentBlock } = await deploySpokePoolWithToken(originChainId));
@@ -76,7 +85,7 @@ describe("SpokePoolClient: SpeedUp", async function () {
       deepEqualsWithBigNumber(
         spokePoolClient.getDepositsForDestinationChain(destinationChainId)[0],
         expectedDepositData,
-        ["blockNumber", "logIndex", "quoteBlockNumber", "transactionHash", "transactionIndex"]
+        ignoredFields
       )
     ).to.be.true;
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId).length).to.equal(1);
@@ -139,7 +148,7 @@ describe("SpokePoolClient: SpeedUp", async function () {
       deepEqualsWithBigNumber(
         spokePoolClient.getDepositsForDestinationChain(destinationChainId)[0],
         expectedDepositData,
-        ["blockNumber", "logIndex", "quoteBlockNumber", "transactionHash", "transactionIndex"]
+        ignoredFields
       )
     ).to.be.true;
   });
@@ -171,13 +180,11 @@ describe("SpokePoolClient: SpeedUp", async function () {
       deepEqualsWithBigNumber(spokePoolClient.appendMaxSpeedUpSignatureToDeposit(deposit as DepositWithBlock), deposit)
     ).to.be.true;
     expect(
-      deepEqualsWithBigNumber(spokePoolClient.getDepositsForDestinationChain(destinationChainId)[0], deposit, [
-        "quoteBlockNumber",
-        "logIndex",
-        "blockNumber",
-        "transactionHash",
-        "transactionIndex",
-      ])
+      deepEqualsWithBigNumber(
+        spokePoolClient.getDepositsForDestinationChain(destinationChainId)[0],
+        deposit,
+        ignoredFields
+      )
     ).to.be.true;
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId).length).to.equal(1);
     expect(spokePoolClient.getDeposits()[0].speedUpSignature).to.deep.equal(undefined);
@@ -238,7 +245,7 @@ describe("SpokePoolClient: SpeedUp", async function () {
       deepEqualsWithBigNumber(
         spokePoolClient.getDepositsForDestinationChain(destinationChainId)[0],
         expectedDepositData,
-        ["quoteBlockNumber", "logIndex", "blockNumber", "transactionHash", "transactionIndex"]
+        ignoredFields
       )
     ).to.be.true;
     expect(spokePoolClient.getDepositsForDestinationChain(destinationChainId).length).to.equal(1);

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -147,7 +147,7 @@ describe("SpokePoolClient: Fill Validation", async function () {
         realizedLpFeePct: toBN(0),
       })
     )
-      .excludingEvery(["logIndex", "transactionIndex", "transactionHash", "quoteBlockNumber"])
+      .excludingEvery(["blockTimestamp", "logIndex", "transactionIndex", "transactionHash", "quoteBlockNumber"])
       .to.deep.equal(expectedDeposit);
   });
 
@@ -501,7 +501,7 @@ describe("SpokePoolClient: Fill Validation", async function () {
         realizedLpFeePct: toBN(0),
       })
     )
-      .excludingEvery(["logIndex", "transactionIndex", "transactionHash", "quoteBlockNumber"])
+      .excludingEvery(["blockTimestamp", "logIndex", "transactionIndex", "transactionHash", "quoteBlockNumber"])
       .to.deep.equal(expectedDeposit);
     expect(
       spokePoolClientForDestinationChain.getDepositForFill({
@@ -510,7 +510,7 @@ describe("SpokePoolClient: Fill Validation", async function () {
         realizedLpFeePct: toBN(0),
       })
     )
-      .excludingEvery(["logIndex", "transactionIndex", "transactionHash", "quoteBlockNumber"])
+      .excludingEvery(["blockTimestamp", "logIndex", "transactionIndex", "transactionHash", "quoteBlockNumber"])
       .to.deep.equal(expectedDeposit);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,10 +49,10 @@
     merkletreejs "^0.2.27"
     rlp "^2.2.7"
 
-"@across-protocol/sdk-v2@0.14.12":
-  version "0.14.12"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.14.12.tgz#3274141f114df1edc227a8293b3cfed88fab2fcd"
-  integrity sha512-D+ttGgW8vcEF19iTrUMsMwKzz4ykFiAGQSowoOP0a07YwjY/ubPtlhtV5DyRvusWP7ebaViksbztq82NXreEIA==
+"@across-protocol/sdk-v2@0.14.13":
+  version "0.14.13"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.14.13.tgz#6aef7ce792c89cc7f7c8484c6728a36df61f14d9"
+  integrity sha512-qscXKYuGr0zkVxiqrPCEaVhFTNsVxDkcDy/Mi1Vgr+7jZdH7+xuxAhnk5Y+kp8WODtnjAB5dy92cAS/NhukxHg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/contracts-v2" "2.4.0"


### PR DESCRIPTION
Tests updated to reflect that a few `...WithBlock` objects now include a
`blockTimestamp` member.