### PR TITLE
feat(finalizer): Upgrade eth-optimism/sdk version to take advantage of updated cross-chain messenger

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,10 @@
   },
   "dependencies": {
     "@across-protocol/contracts-v2": "2.4.0",
-    "@across-protocol/optimism-sdk": "2.1.3",
     "@across-protocol/sdk-v2": "0.15.0",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
-    "@eth-optimism/sdk": "^2.1.0",
+    "@eth-optimism/sdk": "^3.1.0",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/abstract-signer": "^5.7.0",

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -172,8 +172,8 @@ export async function finalize(
     try {
       // Note: We might want to slice these up in the future but I don't forsee us including enough events
       // to approach the block gas limit.
-      const txn = await (await multicall2.estimateGas.aggregate(finalizationsToBatch.callData));
-      console.log(txn)
+      const txn = await await multicall2.estimateGas.aggregate(finalizationsToBatch.callData);
+      console.log(txn);
       return;
       // finalizationsToBatch.withdrawals.forEach((withdrawal) => {
       //   logger.info({

--- a/src/finalizer/utils/optimism.ts
+++ b/src/finalizer/utils/optimism.ts
@@ -1,4 +1,4 @@
-import * as optimismSDK from "@across-protocol/optimism-sdk";
+import * as optimismSDK from "@eth-optimism/sdk";
 import { Withdrawal } from "..";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
 import { L1Token, TokensBridged } from "../../interfaces";
@@ -151,6 +151,7 @@ export async function finalizeOptimismMessage(
 ): Promise<Multicall2Call> {
   const callData = await (crossChainMessenger as optimismSDK.CrossChainMessenger).populateTransaction.finalizeMessage(
     message.message as optimismSDK.MessageLike,
+    undefined,
     logIndex
   );
   return {
@@ -167,6 +168,7 @@ export async function proveOptimismMessage(
 ): Promise<Multicall2Call> {
   const callData = await (crossChainMessenger as optimismSDK.CrossChainMessenger).populateTransaction.proveMessage(
     message.message as optimismSDK.MessageLike,
+    undefined,
     logIndex
   );
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,18 +37,6 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/optimism-sdk@2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@across-protocol/optimism-sdk/-/optimism-sdk-2.1.3.tgz#d03e61ee62cfdade932b4b616ccc88720ea435c3"
-  integrity sha512-cjEr5+deePV632MMezI9fxMZI+BBsi55Sm7RkaSrY13igsCvkERleXPSHTtT8srT9lVcIZWsxNE3O9GtE1R83g==
-  dependencies:
-    "@eth-optimism/contracts" "0.6.0"
-    "@eth-optimism/contracts-bedrock" "0.14.0"
-    "@eth-optimism/core-utils" "0.12.0"
-    lodash "^4.17.21"
-    merkletreejs "^0.2.27"
-    rlp "^2.2.7"
-
 "@across-protocol/sdk-v2@0.15.0":
   version "0.15.0"
   resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.15.0.tgz#f5a716964321513c2217c6316e7588a3878f3ae4"
@@ -427,6 +415,16 @@
     "@openzeppelin/contracts-upgradeable" "4.7.3"
     ethers "^5.7.0"
 
+"@eth-optimism/contracts-bedrock@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts-bedrock/-/contracts-bedrock-0.16.0.tgz#531cb81529ad3f895be538c1d8762eace6241a95"
+  integrity sha512-MfHJdeQ/BzHgkoHnA+NGb1hU8CH0OFsp4ylmFi0uwYh3xPJxcHt9qhy1g4MGGMUGAPIUmlBPaqhwbBlQkaeFrA==
+  dependencies:
+    "@openzeppelin/contracts" "4.7.3"
+    "@openzeppelin/contracts-upgradeable" "4.7.3"
+    "@rari-capital/solmate" "github:transmissions11/solmate#8f9b23f8838670afda0fd8983f2c41e8037ae6bc"
+    clones-with-immutable-args "github:Saw-mon-and-Natalie/clones-with-immutable-args#105efee1b9127ed7f6fedf139e1fc796ce8791f2"
+
 "@eth-optimism/contracts@0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.6.0.tgz#15ae76222a9b4d958a550cafb1960923af613a31"
@@ -467,6 +465,26 @@
     bufio "^1.0.7"
     chai "^4.3.4"
 
+"@eth-optimism/core-utils@0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.12.2.tgz#cacf8c488e8c9bf75b193a08763043294a4882fa"
+  integrity sha512-rJjsRF//hegpfeWzcWRVO+SJ7XK+uwpidUGECQ5/aGfO+o0/J0kaiRhvGtUvJHsY5D2+gThqQkkx+ZwlGuBeuQ==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/contracts" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+    chai "^4.3.4"
+    ethers "^5.7.0"
+    node-fetch "^2.6.7"
+
 "@eth-optimism/core-utils@^0.7.7":
   version "0.7.7"
   resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.7.7.tgz#c993d45d2be7a1956284621ad18129a88880c658"
@@ -488,6 +506,18 @@
     "@eth-optimism/contracts" "0.6.0"
     "@eth-optimism/contracts-bedrock" "0.14.0"
     "@eth-optimism/core-utils" "0.12.0"
+    lodash "^4.17.21"
+    merkletreejs "^0.2.27"
+    rlp "^2.2.7"
+
+"@eth-optimism/sdk@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-3.1.0.tgz#c0c48d1111375c0bc2b80457cbde455e69079c0a"
+  integrity sha512-E1/Tk145Aln1qGxFcbEugtjzTJTnZgmTt8AUe4g9ghC7+6r1YOVav+KZuoMoyR+nF6/FbKdmVq0wqYilZOLq3w==
+  dependencies:
+    "@eth-optimism/contracts" "0.6.0"
+    "@eth-optimism/contracts-bedrock" "0.16.0"
+    "@eth-optimism/core-utils" "0.12.2"
     lodash "^4.17.21"
     merkletreejs "^0.2.27"
     rlp "^2.2.7"
@@ -2156,6 +2186,10 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
+"@rari-capital/solmate@github:transmissions11/solmate#8f9b23f8838670afda0fd8983f2c41e8037ae6bc":
+  version "7.0.0-alpha.3"
+  resolved "https://codeload.github.com/transmissions11/solmate/tar.gz/8f9b23f8838670afda0fd8983f2c41e8037ae6bc"
 
 "@redis/bloom@1.0.2":
   version "1.0.2"
@@ -4644,6 +4678,10 @@ clone@^2.0.0, clone@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
+
+"clones-with-immutable-args@github:Saw-mon-and-Natalie/clones-with-immutable-args#105efee1b9127ed7f6fedf139e1fc796ce8791f2":
+  version "2.0.0"
+  resolved "https://codeload.github.com/Saw-mon-and-Natalie/clones-with-immutable-args/tar.gz/105efee1b9127ed7f6fedf139e1fc796ce8791f2"
 
 cluster-key-slot@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This PR removes the dependency on a cloned version of the `@eth-optimism/sdk-2.1.3` repo that added a bug fix to handle multiple withdrawal messages in the same L2 transaction post-bedrock.

The `eth-optimism/sdk` as of version 3.1 now includes this logic

Resolves ACX-1203