### PR TITLE
feat: encode sim mode to dataworker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,13 @@ NODE_MAX_CONCURRENCY=25
 # recommended to test with this before setting SEND_RELAYS to "true".
 SEND_RELAYS=false
 
+# Permit the Dataworker from submitting transactions to the RPC provider. This
+# is disabled by default and must be explicitly enabled for the dataworker to
+# execute the transactions that it generates. When SEND_DATAWORKER_TXS is not
+# set to "true", the bot will simulate making fills and will log the results,
+# but will not submit transactions to the RPC provider. It is recommended to
+# test with this before setting SEND_DATAWORKER_TXS to "true".
+SEND_DATAWORKER_TXS=false
 
 # List of destination chains to be supported by the relayer. If set to a
 # non-empty list, only transfers going to these chains will be filled. For

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -15,6 +15,9 @@ export class DataworkerConfig extends CommonConfig {
   readonly executorEnabled: boolean;
   readonly finalizerEnabled: boolean;
 
+  // Toggles whether or not the Dataworker should be able to send transactions on-chain.
+  readonly transactionExecutionsEnabled: boolean;
+
   // These variables can be toggled to choose whether the bot will submit transactions created
   // by each function. For example, setting `sendingDisputesEnabled=false` but `disputerEnabled=true`
   // means that the disputer logic will be run but won't send disputes on-chain.
@@ -48,9 +51,11 @@ export class DataworkerConfig extends CommonConfig {
       BUFFER_TO_PROPOSE,
       DATAWORKER_FAST_LOOKBACK_COUNT,
       DATAWORKER_FAST_START_BUNDLE,
+      SEND_DATAWORKER_TXS,
     } = env;
     super(env);
 
+    this.transactionExecutionsEnabled = SEND_DATAWORKER_TXS === "true";
     this.bufferToPropose = BUFFER_TO_PROPOSE ? Number(BUFFER_TO_PROPOSE) : (20 * 60) / 15; // 20 mins of blocks;
     // Should we assert that the leaf count caps are > 0?
     this.maxPoolRebalanceLeafSizeOverride = MAX_POOL_REBALANCE_LEAF_SIZE_OVERRIDE

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -162,7 +162,11 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
         logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Executor disabled" });
       }
 
+      // Execute a series of transactions to reflect the state changes from the above operations.
+      // This is done only if the sendingDataworkerTxsEnabled flag is set to true.
+      if (config.transactionExecutionsEnabled) {
       await clients.multiCallerClient.executeTransactionQueue();
+      }
 
       logger.debug({ at: "Dataworker#index", message: `Time to loop: ${(Date.now() - loopStart) / 1000}s` });
 

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -165,7 +165,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       // Execute a series of transactions to reflect the state changes from the above operations.
       // This is done only if the sendingDataworkerTxsEnabled flag is set to true.
       if (config.transactionExecutionsEnabled) {
-      await clients.multiCallerClient.executeTransactionQueue();
+        await clients.multiCallerClient.executeTransactionQueue();
       }
 
       logger.debug({ at: "Dataworker#index", message: `Time to loop: ${(Date.now() - loopStart) / 1000}s` });


### PR DESCRIPTION
This PR adds an explicit ENV flag to the dataworker so that it can be run safely in simulation mode.