### PR TITLE
fix(dataworker): Add changes found after integration testing Dataworker

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@across-protocol/contracts-v2": "2.4.0",
-    "@across-protocol/sdk-v2": "0.15.8",
+    "@across-protocol/sdk-v2": "0.15.9",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -52,14 +52,7 @@ export class BundleDataClient {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     readonly chainIdListForBundleEvaluationBlockNumbers: number[],
     readonly blockRangeEndBlockBuffer: { [chainId: number]: number } = {}
-  ) {
-    logger.debug({
-      at: "BundleDataClient",
-      message: "Initialized BundleDataClient",
-      chainIdListForBundleEvaluationBlockNumbers,
-      spokePoolClientChains: Object.keys(spokePoolClients),
-    });
-  }
+  ) {}
 
   // This should be called whenever it's possible that the loadData information for a block range could have changed.
   // For instance, if the spoke or hub clients have been updated, it probably makes sense to clear this to be safe.

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -52,7 +52,14 @@ export class BundleDataClient {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     readonly chainIdListForBundleEvaluationBlockNumbers: number[],
     readonly blockRangeEndBlockBuffer: { [chainId: number]: number } = {}
-  ) {}
+  ) {
+    logger.debug({
+      at: "BundleDataClient",
+      message: "Initialized BundleDataClient",
+      chainIdListForBundleEvaluationBlockNumbers,
+      spokePoolClientChains: Object.keys(spokePoolClients),
+    });
+  }
 
   // This should be called whenever it's possible that the loadData information for a block range could have changed.
   // For instance, if the spoke or hub clients have been updated, it probably makes sense to clear this to be safe.
@@ -210,9 +217,9 @@ export class BundleDataClient {
       throw new Error("HubPoolClient not updated");
     }
 
-    if (blockRangesForChains.length !== this.chainIdListForBundleEvaluationBlockNumbers.length) {
+    if (blockRangesForChains.length > this.chainIdListForBundleEvaluationBlockNumbers.length) {
       throw new Error(
-        `Unexpected block range list length of ${blockRangesForChains.length}, should be ${this.chainIdListForBundleEvaluationBlockNumbers.length}`
+        `Unexpected block range list length of ${blockRangesForChains.length}, should be <= ${this.chainIdListForBundleEvaluationBlockNumbers.length}`
       );
     }
 
@@ -298,7 +305,10 @@ export class BundleDataClient {
       return isChainDisabled(blockRangeForChain);
     };
 
-    const allChainIds = Object.keys(spokePoolClients).map(Number);
+    // Infer chain ID's to load from number of block ranges passed in.
+    const allChainIds = blockRangesForChains.map(
+      (_blockRange, index) => this.chainIdListForBundleEvaluationBlockNumbers[index]
+    );
 
     const validateRefundRequestAndSaveData = async (refundRequest: RefundRequestWithBlock): Promise<void> => {
       const result = await refundRequestIsValid(spokePoolClients, this.clients.hubPoolClient, refundRequest);

--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -37,6 +37,14 @@ export class AdapterManager {
     }
   }
 
+  /**
+   * @notice Returns list of chains we have adapters for
+   * @returns list of chain IDs we have adapters for
+   */
+  supportedChains(): number[] {
+    return Object.keys(this.adapters).map((chainId) => Number(chainId));
+  }
+
   async getOutstandingCrossChainTokenTransferAmount(
     chainId: number,
     l1Tokens: string[]

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -9,6 +9,7 @@ import {
   getBlockForTimestamp,
   getCurrentTime,
   SpokePool,
+  isDefined,
 } from "../utils";
 import { HubPoolClient, MultiCallerClient, ConfigStoreClient, SpokePoolClient } from "../clients";
 import { CommonConfig } from "./Config";
@@ -182,6 +183,13 @@ export function getSpokePoolClientsForContract(
 ): SpokePoolClientsByChain {
   const spokePoolClients: SpokePoolClientsByChain = {};
   spokePools.forEach(({ chainId, contract, registrationBlock }) => {
+    if (!isDefined(fromBlocks[chainId])) {
+      logger.debug({
+        at: "ClientHelper#getSpokePoolClientsForContract",
+        message: `No fromBlock set for spoke pool client ${chainId}, setting from block to registration block`,
+        registrationBlock,
+      });
+    }
     const spokePoolClientSearchSettings = {
       fromBlock: fromBlocks[chainId] ? Math.max(fromBlocks[chainId], registrationBlock) : registrationBlock,
       toBlock: toBlocks[chainId] ? toBlocks[chainId] : undefined,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -35,7 +35,6 @@ import { SpokePoolClient, UBAClient } from "../clients";
 import * as PoolRebalanceUtils from "./PoolRebalanceUtils";
 import {
   blockRangesAreInvalidForSpokeClients,
-  getBlockForChain,
   getBlockRangeForChain,
   getImpliedBundleBlockRanges,
 } from "../dataworker/DataworkerUtils";
@@ -300,11 +299,14 @@ export class Dataworker {
     // Construct a list of ending block ranges for each chain that we want to include
     // relay events for. The ending block numbers for these ranges will be added to a "bundleEvaluationBlockNumbers"
     // list, and the order of chain ID's is hardcoded in the ConfigStore client.
-    // Pass in `latest` for the mainnet bundle end block because we want to use the latest disabled chains list
-    // to construct the potential next bundle block range.
+    const nextBundleMainnetStartBlock = hubPoolClient.getNextBundleStartBlockNumber(
+      this.chainIdListForBundleEvaluationBlockNumbers,
+      hubPoolClient.latestBlockNumber,
+      hubPoolClient.chainId
+    );
     const blockRangesForProposal = this._getWidestPossibleBlockRangeForNextBundle(
       spokePoolClients,
-      hubPoolClient.latestBlockNumber - this.blockRangeEndBlockBuffer[hubPoolClient.chainId]
+      nextBundleMainnetStartBlock
     );
 
     // Exit early if spoke pool clients don't have early enough event data to satisfy block ranges for the
@@ -888,14 +890,16 @@ export class Dataworker {
       return;
     }
 
-    const mainnetBundleEndBlockForPendingRootBundle = getBlockForChain(
-      pendingRootBundle.bundleEvaluationBlockNumbers,
-      this.clients.hubPoolClient.chainId,
-      this.chainIdListForBundleEvaluationBlockNumbers
+    const pendingBundleBlockRanges = getImpliedBundleBlockRanges(
+      this.clients.hubPoolClient,
+      this.clients.configStoreClient,
+      // If there is a pending bundle, then the latest proposed bundle is the pending one.
+      this.clients.hubPoolClient.getProposedRootBundles().at(-1)
     );
     const widestPossibleExpectedBlockRange = this._getWidestPossibleBlockRangeForNextBundle(
       spokePoolClients,
-      mainnetBundleEndBlockForPendingRootBundle
+      // Mainnet bundle start block for pending bundle is the first entry in the first entry.
+      pendingBundleBlockRanges[0][0]
     );
     const { valid, reason } = await this.validateRootBundle(
       hubPoolChainId,
@@ -1623,14 +1627,16 @@ export class Dataworker {
       pendingRootBundle,
     });
 
-    const mainnetBundleEndBlockForPendingRootBundle = getBlockForChain(
-      pendingRootBundle.bundleEvaluationBlockNumbers,
-      hubPoolChainId,
-      this.chainIdListForBundleEvaluationBlockNumbers
+    const pendingBundleBlockRanges = getImpliedBundleBlockRanges(
+      this.clients.hubPoolClient,
+      this.clients.configStoreClient,
+      // If there is a pending bundle, then the latest proposed bundle is the pending one.
+      this.clients.hubPoolClient.getProposedRootBundles().at(-1)
     );
     const widestPossibleExpectedBlockRange = this._getWidestPossibleBlockRangeForNextBundle(
       spokePoolClients,
-      mainnetBundleEndBlockForPendingRootBundle
+      // Mainnet bundle start block for pending bundle is the first entry in the first entry.
+      pendingBundleBlockRanges[0][0]
     );
     const { valid, reason, expectedTrees } = await this.validateRootBundle(
       hubPoolChainId,
@@ -1640,6 +1646,27 @@ export class Dataworker {
       earliestBlocksInSpokePoolClients,
       ubaClient
     );
+
+    if (!valid) {
+      this.logger.error({
+        at: "Dataworke#executePoolRebalanceLeaves",
+        message: "Found invalid proposal after challenge period!",
+        reason,
+        notificationPath: "across-error",
+      });
+      return;
+    }
+
+    if (valid && !expectedTrees) {
+      this.logger.error({
+        at: "Dataworke#executePoolRebalanceLeaves",
+        message:
+          "Found valid proposal, but no trees could be generated. This probably means that the proposal was never evaluated during liveness due to an odd block range!",
+        reason,
+        notificationPath: "across-error",
+      });
+      return;
+    }
 
     // Call `exchangeRateCurrent` on the HubPool before accumulating fees from the executed bundle leaves and before
     // exiting early if challenge period isn't passed. This ensures that there is a maximum amount of time between
@@ -1664,27 +1691,6 @@ export class Dataworker {
         at: "Dataworke#executePoolRebalanceLeaves",
         message: `Challenge period not passed, cannot execute until ${pendingRootBundle.challengePeriodEndTimestamp}`,
         expirationTime: pendingRootBundle.challengePeriodEndTimestamp,
-      });
-      return;
-    }
-
-    if (!valid) {
-      this.logger.error({
-        at: "Dataworke#executePoolRebalanceLeaves",
-        message: "Found invalid proposal after challenge period!",
-        reason,
-        notificationPath: "across-error",
-      });
-      return;
-    }
-
-    if (valid && !expectedTrees) {
-      this.logger.error({
-        at: "Dataworke#executePoolRebalanceLeaves",
-        message:
-          "Found valid proposal, but no trees could be generated. This probably means that the proposal was never evaluated during liveness due to an odd block range!",
-        reason,
-        notificationPath: "across-error",
       });
       return;
     }
@@ -2290,24 +2296,24 @@ export class Dataworker {
    * Returns widest possible block range for next bundle.
    * @param spokePoolClients SpokePool clients to query. If one is undefined then the chain ID will be treated as
    * disabled.
-   * @param mainnetBundleEndBlock Passed in to determine which disabled chain list to use (i.e. the list that is live
+   * @param mainnetBundleStartBlock Passed in to determine which disabled chain list to use (i.e. the list that is live
    * at the time of this block). Also used to determine which chain ID indices list to use which is the max
    * set of chains we can return block ranges for.
    * @returns [number, number]: [startBlock, endBlock]
    */
   _getWidestPossibleBlockRangeForNextBundle(
     spokePoolClients: SpokePoolClientsByChain,
-    mainnetBundleEndBlock: number
+    mainnetBundleStartBlock: number
   ): number[][] {
     return PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
-      // We only want as many block ranges as there are chains enabled at the time of the bundle end block.
-      this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleEndBlock),
+      // We only want as many block ranges as there are chains enabled at the time of the bundle start block.
+      this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleStartBlock),
       spokePoolClients,
       getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockNumber,
       // We only want to count enabled chains at the same time that we are loading chain ID indices.
-      this.clients.configStoreClient.getEnabledChains(mainnetBundleEndBlock)
+      this.clients.configStoreClient.getEnabledChains(mainnetBundleStartBlock)
     );
   }
 }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -890,16 +890,15 @@ export class Dataworker {
       return;
     }
 
-    const pendingBundleBlockRanges = getImpliedBundleBlockRanges(
-      this.clients.hubPoolClient,
-      this.clients.configStoreClient,
-      // If there is a pending bundle, then the latest proposed bundle is the pending one.
-      this.clients.hubPoolClient.getProposedRootBundles().at(-1)
+    const nextBundleMainnetStartBlock = this.clients.hubPoolClient.getNextBundleStartBlockNumber(
+      this.chainIdListForBundleEvaluationBlockNumbers,
+      this.clients.hubPoolClient.latestBlockNumber,
+      this.clients.hubPoolClient.chainId
     );
     const widestPossibleExpectedBlockRange = this._getWidestPossibleBlockRangeForNextBundle(
       spokePoolClients,
       // Mainnet bundle start block for pending bundle is the first entry in the first entry.
-      pendingBundleBlockRanges[0][0]
+      nextBundleMainnetStartBlock
     );
     const { valid, reason } = await this.validateRootBundle(
       hubPoolChainId,
@@ -1627,16 +1626,14 @@ export class Dataworker {
       pendingRootBundle,
     });
 
-    const pendingBundleBlockRanges = getImpliedBundleBlockRanges(
-      this.clients.hubPoolClient,
-      this.clients.configStoreClient,
-      // If there is a pending bundle, then the latest proposed bundle is the pending one.
-      this.clients.hubPoolClient.getProposedRootBundles().at(-1)
+    const nextBundleMainnetStartBlock = this.clients.hubPoolClient.getNextBundleStartBlockNumber(
+      this.chainIdListForBundleEvaluationBlockNumbers,
+      this.clients.hubPoolClient.latestBlockNumber,
+      this.clients.hubPoolClient.chainId
     );
     const widestPossibleExpectedBlockRange = this._getWidestPossibleBlockRangeForNextBundle(
       spokePoolClients,
-      // Mainnet bundle start block for pending bundle is the first entry in the first entry.
-      pendingBundleBlockRanges[0][0]
+      nextBundleMainnetStartBlock
     );
     const { valid, reason, expectedTrees } = await this.validateRootBundle(
       hubPoolChainId,

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -2,7 +2,6 @@ import winston from "winston";
 import { DataworkerConfig } from "./DataworkerConfig";
 import {
   Clients,
-  CommonConfig,
   constructClients,
   constructSpokePoolClientsWithStartBlocks,
   updateClients,
@@ -23,12 +22,19 @@ export interface DataworkerClients extends Clients {
 export async function constructDataworkerClients(
   logger: winston.Logger,
   config: DataworkerConfig,
-  baseSigner: Wallet
+  baseSigner: Wallet,
+  setAllowances = true
 ): Promise<DataworkerClients> {
   const commonClients = await constructClients(logger, config, baseSigner);
+  await updateClients(commonClients, config);
 
   // We don't pass any spoke pool clients to token client since data worker doesn't need to set approvals for L2 tokens.
   const tokenClient = new TokenClient(logger, baseSigner.address, {}, commonClients.hubPoolClient);
+  await tokenClient.update();
+  // Run approval on hub pool.
+  if (setAllowances) {
+    await tokenClient.setBondTokenAllowance();
+  }
 
   // TODO: Remove need to pass in spokePoolClients into BundleDataClient since we pass in empty {} here and pass in
   // clients for each class level call we make. Its more of a static class.
@@ -46,35 +52,19 @@ export async function constructDataworkerClients(
     ? new ProfitClient(logger, commonClients.hubPoolClient, {}, [])
     : undefined;
 
+  // Must come after hubPoolClient.
+  // TODO: This should be refactored to check if the hubpool client has had one previous update run such that it has
+  // L1 tokens within it.If it has we dont need to make it sequential like this.
+  if (profitClient) {
+    await profitClient.update();
+  }
+
   return {
     ...commonClients,
     bundleDataClient,
     tokenClient,
     profitClient,
   };
-}
-
-export async function updateDataworkerClients(
-  clients: DataworkerClients,
-  config: CommonConfig,
-  setAllowances = true
-): Promise<void> {
-  await updateClients(clients, config);
-
-  // Token client needs updated hub pool client to pull bond token data.
-  await clients.tokenClient.update();
-
-  // Run approval on hub pool.
-  if (setAllowances) {
-    await clients.tokenClient.setBondTokenAllowance();
-  }
-
-  // Must come after hubPoolClient.
-  // TODO: This should be refactored to check if the hubpool client has had one previous update run such that it has
-  // L1 tokens within it.If it has we dont need to make it sequential like this.
-  if (clients.profitClient) {
-    await clients.profitClient.update();
-  }
 }
 
 // Constructs spoke pool clients with short lookback and validates that the Dataworker can use the data
@@ -130,9 +120,16 @@ export function getSpokePoolClientEventSearchConfigsForFastDataworker(
     toBundle === undefined
       ? {}
       : Object.fromEntries(
-          dataworker.chainIdListForBundleEvaluationBlockNumbers.map((chainId) => {
+          dataworker.chainIdListForBundleEvaluationBlockNumbers.map((chainId, i) => {
+            // If block for chainId doesn't exist in bundleEvaluationBlockNumbers, then leave undefined which will
+            // result in querying until the latest block.
+            if (i >= toBundle.bundleEvaluationBlockNumbers.length) {
+              return [chainId, undefined];
+            }
             return [
               chainId,
+              // TODO: I think this has a bug for disabled chains where we don't want to +1 if the chain is disabled
+              // at the time of this bundle.
               getBlockForChain(
                 toBundle.bundleEvaluationBlockNumbers.map((x) => x.toNumber()),
                 chainId,
@@ -145,9 +142,16 @@ export function getSpokePoolClientEventSearchConfigsForFastDataworker(
     fromBundle === undefined
       ? {}
       : Object.fromEntries(
-          dataworker.chainIdListForBundleEvaluationBlockNumbers.map((chainId) => {
+          dataworker.chainIdListForBundleEvaluationBlockNumbers.map((chainId, i) => {
+            // If block for chainId doesn't exist in bundleEvaluationBlockNumbers, then leave undefined which
+            // will reuslt in querying from the spoke activation block.
+            if (i >= fromBundle.bundleEvaluationBlockNumbers.length) {
+              return [chainId, undefined];
+            }
             return [
               chainId,
+              // TODO: I think this has a bug for disabled chains where we don't want to +1 if the chain is disabled
+              // at the time of this bundle.
               getBlockForChain(
                 fromBundle.bundleEvaluationBlockNumbers.map((x) => x.toNumber()),
                 chainId,

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -22,8 +22,7 @@ export interface DataworkerClients extends Clients {
 export async function constructDataworkerClients(
   logger: winston.Logger,
   config: DataworkerConfig,
-  baseSigner: Wallet,
-  setAllowances = true
+  baseSigner: Wallet
 ): Promise<DataworkerClients> {
   const commonClients = await constructClients(logger, config, baseSigner);
   await updateClients(commonClients, config);
@@ -32,7 +31,7 @@ export async function constructDataworkerClients(
   const tokenClient = new TokenClient(logger, baseSigner.address, {}, commonClients.hubPoolClient);
   await tokenClient.update();
   // Run approval on hub pool.
-  if (setAllowances) {
+  if (config.sendingTransactionsEnabled) {
     await tokenClient.setBondTokenAllowance();
   }
 

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -539,7 +539,8 @@ export function generateMarkdownForRootBundle(
 ): string {
   // Create helpful logs to send to slack transport
   let bundleBlockRangePretty = "";
-  chainIdListForBundleEvaluationBlockNumbers.forEach((chainId, index) => {
+  bundleBlockRange.forEach((_blockRange, index) => {
+    const chainId = chainIdListForBundleEvaluationBlockNumbers[index];
     bundleBlockRangePretty += `\n\t\t${chainId}: ${JSON.stringify(bundleBlockRange[index])}${
       isChainDisabled(bundleBlockRange[index]) ? " 🥶" : ""
     }`;

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -17,15 +17,14 @@ let logger: winston.Logger;
 
 export async function createDataworker(
   _logger: winston.Logger,
-  baseSigner: Wallet,
-  sendAllowances = false
+  baseSigner: Wallet
 ): Promise<{
   config: DataworkerConfig;
   clients: DataworkerClients;
   dataworker: Dataworker;
 }> {
   const config = new DataworkerConfig(process.env);
-  const clients = await constructDataworkerClients(_logger, config, baseSigner, sendAllowances);
+  const clients = await constructDataworkerClients(_logger, config, baseSigner);
 
   const dataworker = new Dataworker(
     _logger,

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -71,12 +71,17 @@ export class Monitor {
     readonly clients: MonitorClients
   ) {
     const adapterSupportedChains = clients.crossChainTransferClient.adapterManager.supportedChains();
-    this.monitorChains = Object.keys(clients.spokePoolClients)
-      .map((chainId) => Number(chainId))
+    this.monitorChains = Object.values(clients.spokePoolClients)
+      .map(({ chainId }) => chainId)
       .filter((x) => adapterSupportedChains.includes(x));
     for (const chainId of this.monitorChains) {
       this.spokePoolsBlocks[chainId] = { startingBlock: undefined, endingBlock: undefined };
     }
+    logger.debug({
+      at: "Monitor#constructor",
+      message: "Initialized monitor",
+      monitorChains: this.monitorChains,
+    });
     this.balanceAllocator = new BalanceAllocator(spokePoolClientsToProviders(clients.spokePoolClients));
   }
 

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -58,7 +58,10 @@ export async function constructMonitorClients(
   const spokePoolChains = Object.keys(spokePoolClients)
     .map((chainId) => Number(chainId))
     .filter((chainId) => adapterSupportedChains.includes(chainId));
-  // We can only pass in providers for chain and spoke pool chains for chains that are supported in the adapter manager.
+  // The TokenTransferClient and CrossChainTransferClient are dependent on having adapters for all passed in chains
+  // so we need to filter out any chains that don't have adapters. This means limiting the chains we keep in
+  // `providerPerChain` when constructing the TokenTransferClient and limiting `spokePoolChains` when constructing
+  // the CrossChainTransferClient.
   const providerPerChain = Object.fromEntries(
     spokePoolChains.map((chainId) => [chainId, spokePoolClients[chainId].spokePool.provider])
   );

--- a/src/scripts/testUBAClient.ts
+++ b/src/scripts/testUBAClient.ts
@@ -42,7 +42,6 @@ export async function testUBAClient(_logger: winston.Logger, baseSigner: Wallet)
   process.env.DATAWORKER_FAST_LOOKBACK_COUNT = "16";
   process.env.SPOKE_ROOTS_LOOKBACK_COUNT = "1";
   const { clients, dataworker, config } = await createDataworker(_logger, baseSigner);
-  await updateClients(clients, config);
 
   const { configStoreClient } = clients;
   let ubaActivationBlock: number;
@@ -51,7 +50,6 @@ export async function testUBAClient(_logger: winston.Logger, baseSigner: Wallet)
     logger.debug({
       at: "UBAClientDemo",
       message: `UBA activation block is ${ubaActivationBlock}`,
-      ubaActivationBundleStartBlocks: sdk.clients.getUbaActivationBundleStartBlocks(clients.hubPoolClient),
     });
   } catch (err) {
     logger.debug({

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -26,7 +26,6 @@ import {
 import {
   constructSpokePoolClientsForFastDataworker,
   getSpokePoolClientEventSearchConfigsForFastDataworker,
-  updateDataworkerClients,
 } from "../dataworker/DataworkerClientHelper";
 import { PendingRootBundle, ProposedRootBundle } from "../interfaces";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
@@ -71,7 +70,6 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
   // in the same block. This also handles the edge case where multiple disputes and proposals are in the
   // same block.
   const dvm = await getDvmContract(clients.configStoreClient.configStore.provider);
-  await updateDataworkerClients(clients, config, false);
 
   if (!clients.configStoreClient.hasLatestConfigStoreVersion) {
     logger.error({
@@ -176,7 +174,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
 
   // Get widest possible block range that could be used at time of root bundle proposal.
   const widestPossibleBlockRanges = await getWidestPossibleExpectedBlockRange(
-    dataworker.chainIdListForBundleEvaluationBlockNumbers,
+    clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleEndBlock),
     spokePoolClients,
     getEndBlockBuffers(dataworker.chainIdListForBundleEvaluationBlockNumbers, dataworker.blockRangeEndBlockBuffer),
     clients,

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -37,7 +37,6 @@ import {
   getRefund,
   disconnectRedisClient,
 } from "../utils";
-import { updateDataworkerClients } from "../dataworker/DataworkerClientHelper";
 import { createDataworker } from "../dataworker";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
 import { getBlockForChain, getEndBlockBuffers } from "../dataworker/DataworkerUtils";
@@ -54,7 +53,6 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
   logger = _logger;
 
   const { clients, dataworker, config } = await createDataworker(logger, baseSigner);
-  await updateDataworkerClients(clients, config, false);
 
   // Throw out most recent bundle as its leaves might not have executed.
   const validatedBundles = sortEventsDescending(clients.hubPoolClient.getValidatedRootBundles()).slice(1);
@@ -66,7 +64,12 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
   const oldestBundleToLookupEventsFor = validatedBundles[bundlesToValidate + 4];
   const _oldestBundleEndBlocks = oldestBundleToLookupEventsFor.bundleEvaluationBlockNumbers.map((x) => x.toNumber());
   const oldestBundleEndBlocks = Object.fromEntries(
-    dataworker.chainIdListForBundleEvaluationBlockNumbers.map((chainId) => {
+    dataworker.chainIdListForBundleEvaluationBlockNumbers.map((chainId, i) => {
+      // If chain wasn't active at time of the bundle, set from block to undefined which will set from blocks to the
+      // spoke pool registration block this chain.
+      if (i >= oldestBundleToLookupEventsFor.bundleEvaluationBlockNumbers.length) {
+        return [chainId, undefined];
+      }
       return [
         chainId,
         getBlockForChain(_oldestBundleEndBlocks, chainId, dataworker.chainIdListForBundleEvaluationBlockNumbers),
@@ -358,7 +361,13 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
   ): Promise<{ slowFills: SlowFillLeaf[]; bundleSpokePoolClients: SpokePoolClientsByChain }> {
     // Construct custom spoke pool clients to query events needed to build slow roots.
     const spokeClientFromBlocks = Object.fromEntries(
-      Object.keys(spokePoolClients).map((chainId) => {
+      dataworker.chainIdListForBundleEvaluationBlockNumbers.map((chainId, i) => {
+        // If chain was not active at the time of the older bundle, then set from blocks to undefined
+        // which will load events since the registration block for the chain.
+        console.log("olderBundle", olderBundle, chainId, i);
+        if (i >= olderBundle.bundleEvaluationBlockNumbers.length) {
+          return [chainId, undefined];
+        }
         return [
           chainId,
           getBlockForChain(
@@ -370,7 +379,12 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
       })
     );
     const spokeClientToBlocks = Object.fromEntries(
-      Object.keys(spokePoolClients).map((chainId) => {
+      dataworker.chainIdListForBundleEvaluationBlockNumbers.map((chainId, i) => {
+        // If chain was not active at the time of the future bundle, then set to blocks to undefined
+        // which will load events until latest
+        if (i >= futureBundle.bundleEvaluationBlockNumbers.length) {
+          return [chainId, undefined];
+        }
         return [
           chainId,
           getBlockForChain(
@@ -403,7 +417,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
         dataworker.chainIdListForBundleEvaluationBlockNumbers
       );
       const widestPossibleExpectedBlockRange = getWidestPossibleExpectedBlockRange(
-        dataworker.chainIdListForBundleEvaluationBlockNumbers,
+        clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleEndBlock),
         spokePoolClientsForBundle,
         getEndBlockBuffers(dataworker.chainIdListForBundleEvaluationBlockNumbers, dataworker.blockRangeEndBlockBuffer),
         clients,

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -112,6 +112,7 @@ describe("Monitor", async function () {
     tokenTransferClient = new TokenTransferClient(spyLogger, providers, [depositor.address]);
 
     adapterManager = new MockAdapterManager(null, null, null, null);
+    adapterManager.setSupportedChains(chainIds);
     crossChainTransferClient = new CrossChainTransferClient(spyLogger, chainIds, adapterManager);
     monitorInstance = new Monitor(spyLogger, monitorConfig, {
       bundleDataClient,

--- a/test/UBAClientUtilities.ts
+++ b/test/UBAClientUtilities.ts
@@ -127,22 +127,22 @@ describe("UBAClientUtilities", function () {
         Array(chainIds.length).fill(0)
       );
     });
-    it("If chain not active in bundle, returns 0 as start block", async function() {
+    it("If chain not active in bundle, returns 0 as start block", async function () {
       const expectedBlockRanges = await _publishValidatedBundles(3);
 
-            // Set UBA activation block to block right after first bundle was proposed.
-            const proposalBlocks = hubPoolClient.getProposedRootBundles().map((bundle) => bundle.blockNumber);
-            configStoreClient.setUBAActivationBlock(proposalBlocks[0] + 1);
-      
+      // Set UBA activation block to block right after first bundle was proposed.
+      const proposalBlocks = hubPoolClient.getProposedRootBundles().map((bundle) => bundle.blockNumber);
+      configStoreClient.setUBAActivationBlock(proposalBlocks[0] + 1);
+
       // Add extra chain to index list.
       const newChainIds = [...chainIds, 99];
-      configStoreClient.setAvailableChains(newChainIds)
+      configStoreClient.setAvailableChains(newChainIds);
       const result = getUbaActivationBundleStartBlocks(hubPoolClient);
       deepEqualsWithBigNumber(
         result,
-        newChainIds.map((chainId) => chainIds.includes(chainId) ? expectedBlockRanges[chainId][1].start : 0)
+        newChainIds.map((chainId) => (chainIds.includes(chainId) ? expectedBlockRanges[chainId][1].start : 0))
       );
-    })
+    });
   });
   describe("getMostRecentBundleBlockRanges", function () {
     it("Request maxBundleState 0", async function () {
@@ -178,20 +178,23 @@ describe("UBAClientUtilities", function () {
         deepEqualsWithBigNumber(result, expectedBlockRanges[chainId].slice(1));
       }
     });
-    it("If chain not active in bundle, returns a single range", async function() {
+    it("If chain not active in bundle, returns a single range", async function () {
       await _publishValidatedBundles(3);
-      
+
       // Add extra chain to index list.
       const newChainIds = [...chainIds, 99];
-      configStoreClient.setAvailableChains(newChainIds)
+      configStoreClient.setAvailableChains(newChainIds);
 
       // Get 2 most recent bundles. Should return single range with start equal to UBA activation block
       // and end equal to latest block searched for spoke pool client. Override the spoke pool clients
       // mapping to make sure that the new chain's "latestBlockSearched" is > 0.
       const spokePoolClientForNewChain = spokePoolClients[chainIds[0]];
-      const result = getMostRecentBundleBlockRanges(99, 2, hubPoolClient, {...spokePoolClients, [99]: spokePoolClientForNewChain});
+      const result = getMostRecentBundleBlockRanges(99, 2, hubPoolClient, {
+        ...spokePoolClients,
+        [99]: spokePoolClientForNewChain,
+      });
       deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockSearched }]);
-    })
+    });
   });
   describe("getOpeningRunningBalances", function () {
     it("No valid bundles", async function () {
@@ -255,12 +258,12 @@ describe("UBAClientUtilities", function () {
         }
       }
     });
-    it("If chain not active in bundle, returns zero", async function() {
+    it("If chain not active in bundle, returns zero", async function () {
       await _publishValidatedBundles(3);
-      
+
       // Add extra chain to index list.
       const newChainIds = [...chainIds, 99];
-      configStoreClient.setAvailableChains(newChainIds)
+      configStoreClient.setAvailableChains(newChainIds);
 
       const result = getOpeningRunningBalanceForEvent(
         hubPoolClient,
@@ -273,7 +276,7 @@ describe("UBAClientUtilities", function () {
       );
       expect(result.runningBalance).to.equal(0);
       expect(result.incentiveBalance).to.equal(0);
-})
+    });
   });
   describe("getUBAFlows", function () {
     let deposit: DepositWithBlock, fill: FillWithBlock, refund: RefundRequestWithBlock;

--- a/test/UBAClientUtilities.ts
+++ b/test/UBAClientUtilities.ts
@@ -127,6 +127,22 @@ describe("UBAClientUtilities", function () {
         Array(chainIds.length).fill(0)
       );
     });
+    it("If chain not active in bundle, returns 0 as start block", async function() {
+      const expectedBlockRanges = await _publishValidatedBundles(3);
+
+            // Set UBA activation block to block right after first bundle was proposed.
+            const proposalBlocks = hubPoolClient.getProposedRootBundles().map((bundle) => bundle.blockNumber);
+            configStoreClient.setUBAActivationBlock(proposalBlocks[0] + 1);
+      
+      // Add extra chain to index list.
+      const newChainIds = [...chainIds, 99];
+      configStoreClient.setAvailableChains(newChainIds)
+      const result = getUbaActivationBundleStartBlocks(hubPoolClient);
+      deepEqualsWithBigNumber(
+        result,
+        newChainIds.map((chainId) => chainIds.includes(chainId) ? expectedBlockRanges[chainId][1].start : 0)
+      );
+    })
   });
   describe("getMostRecentBundleBlockRanges", function () {
     it("Request maxBundleState 0", async function () {
@@ -162,6 +178,20 @@ describe("UBAClientUtilities", function () {
         deepEqualsWithBigNumber(result, expectedBlockRanges[chainId].slice(1));
       }
     });
+    it("If chain not active in bundle, returns a single range", async function() {
+      await _publishValidatedBundles(3);
+      
+      // Add extra chain to index list.
+      const newChainIds = [...chainIds, 99];
+      configStoreClient.setAvailableChains(newChainIds)
+
+      // Get 2 most recent bundles. Should return single range with start equal to UBA activation block
+      // and end equal to latest block searched for spoke pool client. Override the spoke pool clients
+      // mapping to make sure that the new chain's "latestBlockSearched" is > 0.
+      const spokePoolClientForNewChain = spokePoolClients[chainIds[0]];
+      const result = getMostRecentBundleBlockRanges(99, 2, hubPoolClient, {...spokePoolClients, [99]: spokePoolClientForNewChain});
+      deepEqualsWithBigNumber(result, [{ start: 0, end: spokePoolClientForNewChain.latestBlockSearched }]);
+    })
   });
   describe("getOpeningRunningBalances", function () {
     it("No valid bundles", async function () {
@@ -225,6 +255,25 @@ describe("UBAClientUtilities", function () {
         }
       }
     });
+    it("If chain not active in bundle, returns zero", async function() {
+      await _publishValidatedBundles(3);
+      
+      // Add extra chain to index list.
+      const newChainIds = [...chainIds, 99];
+      configStoreClient.setAvailableChains(newChainIds)
+
+      const result = getOpeningRunningBalanceForEvent(
+        hubPoolClient,
+        // High number for all activated chains should return latest running balances. But this chain
+        // is not in the bundle evaluation block numbers so it should default to 0
+        Number.MAX_SAFE_INTEGER,
+        99,
+        l1Tokens[0],
+        Number.MAX_SAFE_INTEGER
+      );
+      expect(result.runningBalance).to.equal(0);
+      expect(result.incentiveBalance).to.equal(0);
+})
   });
   describe("getUBAFlows", function () {
     let deposit: DepositWithBlock, fill: FillWithBlock, refund: RefundRequestWithBlock;

--- a/test/mocks/MockAdapterManager.ts
+++ b/test/mocks/MockAdapterManager.ts
@@ -5,6 +5,7 @@ import { createRandomBytes32 } from "../utils";
 import { OutstandingTransfers } from "../../src/interfaces";
 
 export class MockAdapterManager extends AdapterManager {
+  public adapterChains: number[] | undefined;
   public tokensSentCrossChain: {
     [chainId: number]: { [l1Token: string]: { amount: BigNumber; hash: string } };
   } = {};
@@ -17,6 +18,13 @@ export class MockAdapterManager extends AdapterManager {
     const hash = createRandomBytes32();
     this.tokensSentCrossChain[chainId][l1Token] = { amount, hash };
     return { hash } as TransactionResponse;
+  }
+
+  setSupportedChains(chains: number[]): void {
+    this.adapterChains = chains;
+  }
+  supportedChains(): number[] {
+    return this.adapterChains ?? super.supportedChains();
   }
 
   override async getOutstandingCrossChainTokenTransferAmount(

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,10 +54,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.15.8":
-  version "0.15.8"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.15.8.tgz#9987662ed43244ad0cc07253136bc4d2a33a2239"
-  integrity sha512-v8jN8IN9hd+Hq8RlleRKEnfMrLTcDxrcH5xTciERMX89nOHD+wwpHjRSFVZ3p/1Wd7DAcGu8j4wG4Ex6A394iw==
+"@across-protocol/sdk-v2@0.15.9":
+  version "0.15.9"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.15.9.tgz#01b67063974b8102cf7b7ad5f45dde2de76bb9e5"
+  integrity sha512-M0ZG1P4OxoiKifRVpmt06Vr2M67bOtQ8MpDZvyGXTs21T0+p1qDAu81C/jReOs/6361hvcc/ppMx/S7wY/bMPg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/contracts-v2" "^2.4.2"


### PR DESCRIPTION
- We need to update the config store client before constructing BundleDataClient
- We need to handle the fact that BundleDataClient and Dataworker might have a longer chainIdIndices list than the actual number of block ranges they will handle

## Fixes
- Fix logic in `blockRangesAreInvalidForSpokeClients` that assumed that `chainIdIndices` length is always equal to `blockRanges` length

## Bots integration tested:
- [x] Dataworker (propose, validate, execute)
- [x] `validateRunningBalances` script used to make sure there are no excesses or deficits created by subtle dataworker running balance compuation bugs. 
- [x] `validateRootBundle` script used to evaluate an UMA dispute over an Across bundle proposal 
- [x] Monitor
- [x] Relayer