### PR TITLE
chore: Shadow MDC defaults for Base and Optimism

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -52,11 +52,11 @@ export const FINALIZER_TOKENBRIDGE_LOOKBACK = 14 * 24 * 60 * 60;
 // anything under 7 days.
 export const DEFAULT_MIN_DEPOSIT_CONFIRMATIONS = {
   1: 64, // Finalized block: https://www.alchemy.com/overviews/ethereum-commitment-levels
-  10: 0,
+  10: 60,
   137: 128, // Commonly used finality level for CEX's that accept Polygon deposits
   288: 0,
   324: 0,
-  8453: 0,
+  8453: 60,
   42161: 0,
   // Testnets:
   5: 0,


### PR DESCRIPTION
The default MDCs should reflect the most conservative block
confirmation requirements for the chain.