### PR TITLE
feat: add new opt-in env variable to test parallel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -115,6 +115,17 @@ PRIORITY_FEE_SCALER_10=0.1
 # consult the #relayers channel within the Across Discord server before making
 # any changes to this section. See https://discord.across.to.
 
+# The default behavior of the Dataworker is to run the Disputer, Proposer, 
+# and executor in sequential order. However, there are some use-cases, where
+# the dataworker can run each of these components in parallel. This can be
+# enabled by setting the following variable to true. By default, this is set
+# to false.
+#
+# Note: this is primarily used to test how the Dataworker performs when
+#       these components are run in parallel to test for race conditions and
+#       to better simulate how the Risk Labs dataworker operates.
+PARALLELIZE_DATAWORKER_COMPONENTS=false
+
 
 # A Redis in-memory DB can drastically speed up the performance of the bot.
 # This is technically not required, but can reduce the instance of repeated

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -27,6 +27,9 @@ export class DataworkerConfig extends CommonConfig {
   readonly dataworkerFastLookbackCount: number;
   readonly dataworkerFastStartBundle: number | string;
 
+  // Used to determine whether or not the dataworker's components will be run in sequence or in parallel.
+  readonly parallelizeDataworkerComponents: boolean;
+
   readonly bufferToPropose: number;
 
   constructor(env: ProcessEnv) {
@@ -46,6 +49,7 @@ export class DataworkerConfig extends CommonConfig {
       BUFFER_TO_PROPOSE,
       DATAWORKER_FAST_LOOKBACK_COUNT,
       DATAWORKER_FAST_START_BUNDLE,
+      PARALLELIZE_DATAWORKER_COMPONENTS,
     } = env;
     super(env);
 
@@ -83,6 +87,8 @@ export class DataworkerConfig extends CommonConfig {
     this.sendingProposalsEnabled = SEND_PROPOSALS === "true";
     this.sendingExecutionsEnabled = SEND_EXECUTIONS === "true";
     this.finalizerEnabled = FINALIZER_ENABLED === "true";
+
+    this.parallelizeDataworkerComponents = PARALLELIZE_DATAWORKER_COMPONENTS === "true";
 
     // `dataworkerFastLookbackCount` affects how far we fetch events from, modifying the search config's 'fromBlock'.
     // Set to 0 to load all events, but be careful as this will cause the Dataworker to take 30+ minutes to complete.

--- a/src/utils/ExecutionUtils.ts
+++ b/src/utils/ExecutionUtils.ts
@@ -48,3 +48,21 @@ export function rejectAfterDelay(seconds: number, message = ""): Promise<never> 
     });
   });
 }
+
+/**
+ * Run a batch of async functions in parallel or sequentially.
+ * @param asyncFunctions The async functions to run.
+ * @param sequential Whether to run the functions sequentially or in parallel.
+ */
+export async function runBatchAsyncFunctions(
+  asyncFunctions: Array<() => Promise<unknown>>,
+  sequential = false
+): Promise<void> {
+  if (sequential) {
+    for (const fn of asyncFunctions) {
+      await fn();
+    }
+  } else {
+    await Promise.all(asyncFunctions.map((fn) => fn()));
+  }
+}


### PR DESCRIPTION
This feature provides an _opt-in_ variable to simulate how the official Risk Labs Dataworker handles running its core components in parallel.