### PR TITLE
feat: add base finalizer

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -123,7 +123,7 @@ export async function finalize(
       );
       finalizationsToBatch.callData.push(...finalizations.callData);
       finalizationsToBatch.withdrawals.push(...finalizations.withdrawals);
-    } else if (chainId === 10) {
+    } else if (chainId === 10 || chainId === 8453) {
       const crossChainMessenger = getOptimismClient(chainId, hubSigner);
       const firstBlockToFinalize = await getBlockForTimestamp(
         chainId,

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -187,7 +187,9 @@ export async function finalize(
       finalizationsToBatch.optimismL1Proofs.forEach((withdrawal) => {
         logger.info({
           at: "Finalizer",
-          message: `Submitted L1 proof for Optimism and thereby initiating withdrawal for ${withdrawal.amount} of ${withdrawal.l1TokenSymbol} 🔜`,
+          message: `Submitted L1 proof for ${getNetworkName(
+            withdrawal.l2ChainId
+          )} and thereby initiating withdrawal for ${withdrawal.amount} of ${withdrawal.l1TokenSymbol} 🔜`,
           transactionHash: etherscanLink(txn.transactionHash, hubChainId),
         });
       });

--- a/src/finalizer/utils/index.ts
+++ b/src/finalizer/utils/index.ts
@@ -1,3 +1,3 @@
 export * from "./polygon";
 export * from "./arbitrum";
-export * from "./optimism";
+export * from "./opStack";

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -5,7 +5,7 @@ import { L1Token, TokensBridged } from "../../interfaces";
 import { BigNumber, convertFromWei, getCachedProvider, groupObjectCountsByProp, Wallet, winston } from "../../utils";
 import { Multicall2Call } from "../../common";
 
-type OVM_CHAIN_ID = 10;
+type OVM_CHAIN_ID = 10 | 8453;
 type OVM_CROSS_CHAIN_MESSENGER = optimismSDK.CrossChainMessenger;
 
 export function getOptimismClient(chainId: OVM_CHAIN_ID, hubSigner: Wallet): OVM_CROSS_CHAIN_MESSENGER {
@@ -14,7 +14,7 @@ export function getOptimismClient(chainId: OVM_CHAIN_ID, hubSigner: Wallet): OVM
     l1ChainId: 1,
     l2ChainId: chainId,
     l1SignerOrProvider: hubSigner.connect(getCachedProvider(1, true)),
-    l2SignerOrProvider: hubSigner.connect(getCachedProvider(10, true)),
+    l2SignerOrProvider: hubSigner.connect(getCachedProvider(chainId, true)),
   });
 }
 


### PR DESCRIPTION
This modifies the optimism finalizer to support base. Changes are very simple. Will modify the client slightly to test on goerli to ensure this works as expected.

I've verified that the version of @eth-optimism/sdk is [3.1.0](https://github.com/across-protocol/relayer-v2/blob/f83e9ee6c9ca4e20c224cbd45601784c220e0996/package.json#L17), which includes base support in the optimism sdk.