### PR TITLE
improve: Consolidate RetryProvider cast in RPCUtils

### DIFF
--- a/src/clients/bridges/ZKSyncAdapter.ts
+++ b/src/clients/bridges/ZKSyncAdapter.ts
@@ -18,7 +18,7 @@ import { CONTRACT_ADDRESSES } from "../../common";
 import { TOKEN_SYMBOLS_MAP } from "@across-protocol/contracts-v2";
 import { isDefined } from "../../utils/TypeGuards";
 import { gasPriceOracle, utils } from "@across-protocol/sdk-v2";
-import { convertEthersRPCToZKSyncRPC } from "../../utils/RPCUtils";
+import { zkSync as zkSyncUtils } from "../../utils/chains";
 import { BigNumberish } from "../../utils/FormattingUtils";
 
 /**
@@ -145,9 +145,9 @@ export class ZKSyncAdapter extends BaseAdapter {
     // Next, load estimated executed L1 gas price of the message transaction and the L2 gas limit.
     const l1Provider = this.getProvider(this.hubChainId);
     const l2Provider = this.spokePoolClients[this.chainId].spokePool.provider;
-    let zkProvider;
+    let zkProvider: zksync.Provider;
     try {
-      zkProvider = convertEthersRPCToZKSyncRPC(l2Provider);
+      zkProvider = zkSyncUtils.convertEthersRPCToZKSyncRPC(l2Provider);
     } catch (error) {
       this.logger.warn({
         at: "ZkSyncClient#sendTokenToTargetChain",
@@ -157,7 +157,7 @@ export class ZKSyncAdapter extends BaseAdapter {
     }
     // If zkSync provider can't be created for some reason, default to a very conservative 2mil L2 gas limit
     // which should be sufficient for this transaction.
-    const l2GasLimit = (await isDefined(zkProvider))
+    const l2GasLimit = isDefined(zkProvider)
       ? await zksync.utils.estimateDefaultBridgeDepositL2Gas(
           l1Provider,
           zkProvider,

--- a/src/clients/bridges/ZKSyncAdapter.ts
+++ b/src/clients/bridges/ZKSyncAdapter.ts
@@ -8,7 +8,6 @@ import {
   spreadEventWithBlockNumber,
   assign,
   Event,
-  RetryProvider,
   ZERO_ADDRESS,
   getTokenAddress,
 } from "../../utils";
@@ -148,7 +147,7 @@ export class ZKSyncAdapter extends BaseAdapter {
     const l2Provider = this.spokePoolClients[this.chainId].spokePool.provider;
     let zkProvider;
     try {
-      zkProvider = convertEthersRPCToZKSyncRPC(l2Provider as RetryProvider);
+      zkProvider = convertEthersRPCToZKSyncRPC(l2Provider);
     } catch (error) {
       this.logger.warn({
         at: "ZkSyncClient#sendTokenToTargetChain",

--- a/src/utils/RPCUtils.ts
+++ b/src/utils/RPCUtils.ts
@@ -1,7 +1,8 @@
 import assert from "assert";
+import { providers as ethersProviders } from "ethers";
 import { Provider as ZKSyncProvider } from "zksync-web3";
-import { isDefined } from "./TypeGuards";
 import { RetryProvider } from "./ProviderUtils";
+import { isDefined } from "./TypeGuards";
 
 /**
  * Converts a valid Ethers Provider into a ZKSync Provider
@@ -9,8 +10,8 @@ import { RetryProvider } from "./ProviderUtils";
  * @returns A ZKSync Provider
  * @throws If the provider is not a valid JsonRpcProvider
  */
-export function convertEthersRPCToZKSyncRPC(ethersProvider: RetryProvider): ZKSyncProvider {
+export function convertEthersRPCToZKSyncRPC(ethersProvider: ethersProviders.Provider): ZKSyncProvider {
   const url = (ethersProvider as RetryProvider).providers[0].connection.url;
-  assert(isDefined(url), "Provider must be of type JsonRpcProvider");
+  assert(isDefined(url), "Provider must be of type RetryProvider");
   return new ZKSyncProvider(url);
 }

--- a/src/utils/chains/index.ts
+++ b/src/utils/chains/index.ts
@@ -1,1 +1,1 @@
-export * as zkSync from "./zkSync"
+export * as zkSync from "./zkSync";

--- a/src/utils/chains/index.ts
+++ b/src/utils/chains/index.ts
@@ -1,0 +1,1 @@
+export * as zkSync from "./zkSync"

--- a/src/utils/chains/zkSync.ts
+++ b/src/utils/chains/zkSync.ts
@@ -1,8 +1,8 @@
 import assert from "assert";
 import { providers as ethersProviders } from "ethers";
 import { Provider as ZKSyncProvider } from "zksync-web3";
-import { RetryProvider } from "./ProviderUtils";
-import { isDefined } from "./TypeGuards";
+import { RetryProvider } from "../ProviderUtils";
+import { isDefined } from "../TypeGuards";
 
 /**
  * Converts a valid Ethers Provider into a ZKSync Provider

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -11,6 +11,7 @@ export type { Block, TransactionResponse, TransactionReceipt, Provider } from "@
 export { config } from "dotenv";
 
 // Utils specifically for this bot.
+export * from "./chains";
 export * from "./ProviderUtils";
 export * from "./SignerUtils";
 export * from "./DepositUtils";
@@ -23,7 +24,6 @@ export * from "./TransactionPropBuilder";
 export * from "./ContractUtils";
 export * from "./ExecutionUtils";
 export * from "./NetworkUtils";
-export * from "./RPCUtils";
 export * from "./TransactionUtils";
 export * from "./MerkleTreeUtils";
 export * from "./AddressUtils";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -23,6 +23,7 @@ export * from "./TransactionPropBuilder";
 export * from "./ContractUtils";
 export * from "./ExecutionUtils";
 export * from "./NetworkUtils";
+export * from "./RPCUtils";
 export * from "./TransactionUtils";
 export * from "./MerkleTreeUtils";
 export * from "./AddressUtils";


### PR DESCRIPTION
Makes it easier to use the `convertEthersRPCToZKSyncRPC()` helper.