### PR TITLE
fix(opStackAdapter): WETH deposit initiated event filter fixes

### DIFF
--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -19,15 +19,12 @@ export class AdapterManager {
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     readonly hubPoolClient: HubPoolClient,
     readonly monitoredAddresses: string[],
-    // Optional sender address where the cross chain transfers originate from. This is useful for the use case of
-    // monitoring transfers from HubPool to SpokePools where the sender is HubPool.
-    readonly senderAddress?: string
   ) {
     if (!spokePoolClients) {
       return;
     }
     if (this.spokePoolClients[10] !== undefined) {
-      this.adapters[10] = new OptimismAdapter(logger, spokePoolClients, monitoredAddresses, senderAddress);
+      this.adapters[10] = new OptimismAdapter(logger, spokePoolClients, monitoredAddresses);
     }
     if (this.spokePoolClients[137] !== undefined) {
       this.adapters[137] = new PolygonAdapter(logger, spokePoolClients, monitoredAddresses);

--- a/src/clients/bridges/AdapterManager.ts
+++ b/src/clients/bridges/AdapterManager.ts
@@ -18,7 +18,7 @@ export class AdapterManager {
     readonly logger: winston.Logger,
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
     readonly hubPoolClient: HubPoolClient,
-    readonly monitoredAddresses: string[],
+    readonly monitoredAddresses: string[]
   ) {
     if (!spokePoolClients) {
       return;

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -56,7 +56,6 @@ export abstract class BaseAdapter {
 
   l1DepositInitiatedEvents: Events = {};
   l2DepositFinalizedEvents: Events = {};
-  l2DepositFinalizedEvents_DepositAdapter: Events = {};
 
   txnClient: TransactionClient;
 
@@ -183,20 +182,7 @@ export abstract class BaseAdapter {
         if (this.l2DepositFinalizedEvents[monitoredAddress][l1Token] === undefined) {
           this.l2DepositFinalizedEvents[monitoredAddress][l1Token] = [];
         }
-        let l2FinalizationSet = this.l2DepositFinalizedEvents[monitoredAddress][l1Token];
-        if (this.isWeth(l1Token)) {
-          let depositFinalizedEventsForL1 =
-            this.l2DepositFinalizedEvents_DepositAdapter[monitoredAddress]?.[l1Token] || [];
-          depositFinalizedEventsForL1 = depositFinalizedEventsForL1.filter((event) => event.to === monitoredAddress);
-          if (depositFinalizedEventsForL1.length > 0) {
-            // If this is WETH and there are atomic depositor events then consider the union as the full set of
-            // finalization events. We do this as the output event on L2 will show the Atomic depositor as the sender,
-            // not the original sender (monitored address).
-            l2FinalizationSet = [...l2FinalizationSet, ...depositFinalizedEventsForL1].sort(
-              (a, b) => a.blockNumber - b.blockNumber
-            );
-          }
-        }
+        const l2FinalizationSet = this.l2DepositFinalizedEvents[monitoredAddress][l1Token];
 
         // Match deposits and finalizations by amount. We're only doing a limited lookback of events so collisions
         // should be unlikely.

--- a/src/clients/bridges/op-stack/OpStackAdapter.ts
+++ b/src/clients/bridges/op-stack/OpStackAdapter.ts
@@ -83,11 +83,10 @@ export class OpStackAdapter extends BaseAdapter {
           l1Tokens.map(async (l1Token) => {
             const bridge = this.getBridge(l1Token);
 
-            const [depositInitiatedResults, depositFinalizedResults] =
-              await Promise.all([
-                bridge.queryL1BridgeInitiationEvents(l1Token, monitoredAddress, l1SearchConfig),
-                bridge.queryL2BridgeFinalizationEvents(l1Token, monitoredAddress, l2SearchConfig)
-              ]);
+            const [depositInitiatedResults, depositFinalizedResults] = await Promise.all([
+              bridge.queryL1BridgeInitiationEvents(l1Token, monitoredAddress, l1SearchConfig),
+              bridge.queryL2BridgeFinalizationEvents(l1Token, monitoredAddress, l2SearchConfig),
+            ]);
 
             assign(
               this.l1DepositInitiatedEvents,

--- a/src/clients/bridges/op-stack/OpStackAdapter.ts
+++ b/src/clients/bridges/op-stack/OpStackAdapter.ts
@@ -31,10 +31,7 @@ export class OpStackAdapter extends BaseAdapter {
     logger: winston.Logger,
     supportedTokens: string[],
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
-    monitoredAddresses: string[],
-    // Optional sender address where the cross chain transfers originate from. This is useful for the use case of
-    // monitoring transfers from HubPool to SpokePools where the sender is HubPool.
-    readonly senderAddress?: string
+    monitoredAddresses: string[]
   ) {
     super(spokePoolClients, chainId, monitoredAddresses, logger, supportedTokens);
     this.l2Gas = 200000;
@@ -86,16 +83,10 @@ export class OpStackAdapter extends BaseAdapter {
           l1Tokens.map(async (l1Token) => {
             const bridge = this.getBridge(l1Token);
 
-            const [depositInitiatedResults, depositFinalizedResults, depositFinalizedResults_DepositAdapter] =
+            const [depositInitiatedResults, depositFinalizedResults] =
               await Promise.all([
                 bridge.queryL1BridgeInitiationEvents(l1Token, monitoredAddress, l1SearchConfig),
-                bridge.queryL2BridgeFinalizationEvents(l1Token, monitoredAddress, l2SearchConfig),
-                // Transfers might have come from the monitored address itself or another sender address (if specified).
-                bridge.queryL2BridgeFinalizationEvents(
-                  l1Token,
-                  this.senderAddress || this.atomicDepositorAddress,
-                  l2SearchConfig
-                ),
+                bridge.queryL2BridgeFinalizationEvents(l1Token, monitoredAddress, l2SearchConfig)
               ]);
 
             assign(
@@ -107,11 +98,6 @@ export class OpStackAdapter extends BaseAdapter {
               this.l2DepositFinalizedEvents,
               [monitoredAddress, l1Token],
               depositFinalizedResults.map(processEvent)
-            );
-            assign(
-              this.l2DepositFinalizedEvents_DepositAdapter,
-              [monitoredAddress, l1Token],
-              depositFinalizedResults_DepositAdapter.map(processEvent)
             );
           })
         )

--- a/src/clients/bridges/op-stack/WethBridge.ts
+++ b/src/clients/bridges/op-stack/WethBridge.ts
@@ -50,7 +50,11 @@ export class WethBridge implements OpStackBridge {
     fromAddress: string,
     eventConfig: EventSearchConfig
   ): Promise<Event[]> {
-    return paginatedEventQuery(this.l1Bridge, this.l1Bridge.filters.ETHDepositInitiated(fromAddress), eventConfig);
+    return paginatedEventQuery(
+      this.l1Bridge,
+      this.l1Bridge.filters.ETHDepositInitiated(undefined, fromAddress),
+      eventConfig
+    );
   }
 
   queryL2BridgeFinalizationEvents(

--- a/src/clients/bridges/op-stack/WethBridge.ts
+++ b/src/clients/bridges/op-stack/WethBridge.ts
@@ -50,11 +50,7 @@ export class WethBridge implements OpStackBridge {
     fromAddress: string,
     eventConfig: EventSearchConfig
   ): Promise<Event[]> {
-    return paginatedEventQuery(
-      this.l1Bridge,
-      this.l1Bridge.filters.ETHDepositInitiated(undefined, fromAddress),
-      eventConfig
-    );
+    return paginatedEventQuery(this.l1Bridge, this.l1Bridge.filters.ETHDepositInitiated(fromAddress), eventConfig);
   }
 
   queryL2BridgeFinalizationEvents(

--- a/src/clients/bridges/op-stack/base/BaseChainAdapter.ts
+++ b/src/clients/bridges/op-stack/base/BaseChainAdapter.ts
@@ -7,10 +7,7 @@ export class BaseChainAdapter extends OpStackAdapter {
   constructor(
     logger: winston.Logger,
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
-    monitoredAddresses: string[],
-    // Optional sender address where the cross chain transfers originate from. This is useful for the use case of
-    // monitoring transfers from HubPool to SpokePools where the sender is HubPool.
-    readonly senderAddress?: string
+    monitoredAddresses: string[]
   ) {
     super(
       8453,
@@ -19,8 +16,7 @@ export class BaseChainAdapter extends OpStackAdapter {
       logger,
       ["BAL", "DAI", "ETH", "WETH", "USDC"],
       spokePoolClients,
-      monitoredAddresses,
-      senderAddress
+      monitoredAddresses
     );
   }
 }

--- a/src/clients/bridges/op-stack/optimism/OptimismAdapter.ts
+++ b/src/clients/bridges/op-stack/optimism/OptimismAdapter.ts
@@ -11,10 +11,7 @@ export class OptimismAdapter extends OpStackAdapter {
   constructor(
     logger: winston.Logger,
     readonly spokePoolClients: { [chainId: number]: SpokePoolClient },
-    monitoredAddresses: string[],
-    // Optional sender address where the cross chain transfers originate from. This is useful for the use case of
-    // monitoring transfers from HubPool to SpokePools where the sender is HubPool.
-    readonly senderAddress?: string
+    monitoredAddresses: string[]
   ) {
     const hubChainId = BaseAdapter.HUB_CHAIN_ID;
     const l2ChainId = 10;
@@ -31,8 +28,7 @@ export class OptimismAdapter extends OpStackAdapter {
       logger,
       ["DAI", "SNX", "USDC", "USDT", "WETH", "WBTC", "UMA", "BAL", "ACX", "POOL"],
       spokePoolClients,
-      monitoredAddresses,
-      senderAddress
+      monitoredAddresses
     );
   }
 }

--- a/src/clients/bridges/op-stack/optimism/SnxOptimismBridge.ts
+++ b/src/clients/bridges/op-stack/optimism/SnxOptimismBridge.ts
@@ -41,19 +41,21 @@ export class SnxOptimismBridge implements OpStackBridge {
     };
   }
 
-  queryL1BridgeInitiationEvents(
-    l1Token: string,
-    fromAddress: string,
-    eventConfig: EventSearchConfig
-  ): Promise<Event[]> {
-    return paginatedEventQuery(this.l1Bridge, this.l1Bridge.filters.DepositInitiated(fromAddress), eventConfig);
+  queryL1BridgeInitiationEvents(l1Token: string, toAddress: string, eventConfig: EventSearchConfig): Promise<Event[]> {
+    // @dev For the SnxBridge, only the `toAddress` is indexed on the L2 event so we treat the `fromAddress` as the
+    // toAddress when fetching the L1 event.
+    return paginatedEventQuery(
+      this.l1Bridge,
+      this.l1Bridge.filters.DepositInitiated(undefined, toAddress),
+      eventConfig
+    );
   }
 
   queryL2BridgeFinalizationEvents(
     l1Token: string,
-    fromAddress: string,
+    toAddress: string,
     eventConfig: EventSearchConfig
   ): Promise<Event[]> {
-    return paginatedEventQuery(this.l2Bridge, this.l2Bridge.filters.DepositFinalized(fromAddress), eventConfig);
+    return paginatedEventQuery(this.l2Bridge, this.l2Bridge.filters.DepositFinalized(toAddress), eventConfig);
   }
 }

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -47,12 +47,11 @@ export async function constructMonitorClients(
 
   // Need to update HubPoolClient to get latest tokens.
   const spokePoolAddresses = Object.values(spokePoolClients).map((client) => client.spokePool.address);
-  const adapterManager = new AdapterManager(
-    logger,
-    spokePoolClients,
-    commonClients.hubPoolClient,
-    [baseSigner.address, commonClients.hubPoolClient.hubPool.address, ...spokePoolAddresses]
-  );
+  const adapterManager = new AdapterManager(logger, spokePoolClients, commonClients.hubPoolClient, [
+    baseSigner.address,
+    commonClients.hubPoolClient.hubPool.address,
+    ...spokePoolAddresses,
+  ]);
   const spokePoolChains = Object.keys(spokePoolClients).map((chainId) => Number(chainId));
   const providerPerChain = Object.fromEntries(
     spokePoolChains.map((chainId) => [chainId, spokePoolClients[chainId].spokePool.provider])

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -47,6 +47,9 @@ export async function constructMonitorClients(
 
   // Need to update HubPoolClient to get latest tokens.
   const spokePoolAddresses = Object.values(spokePoolClients).map((client) => client.spokePool.address);
+
+  // Cross-chain transfers will originate from the HubPool's address and target SpokePool addresses, so
+  // track both.
   const adapterManager = new AdapterManager(logger, spokePoolClients, commonClients.hubPoolClient, [
     baseSigner.address,
     commonClients.hubPoolClient.hubPool.address,

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -51,8 +51,7 @@ export async function constructMonitorClients(
     logger,
     spokePoolClients,
     commonClients.hubPoolClient,
-    [baseSigner.address, ...spokePoolAddresses],
-    commonClients.hubPoolClient.hubPool.address
+    [baseSigner.address, commonClients.hubPoolClient.hubPool.address, ...spokePoolAddresses]
   );
   const spokePoolChains = Object.keys(spokePoolClients).map((chainId) => Number(chainId));
   const providerPerChain = Object.fromEntries(

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -4,7 +4,7 @@ import { Wallet } from "../utils";
 import { TokenClient, ProfitClient, BundleDataClient, InventoryClient, AcrossApiClient, UBAClient } from "../clients";
 import { AdapterManager, CrossChainTransferClient } from "../clients/bridges";
 import { RelayerConfig } from "./RelayerConfig";
-import { Clients, constructClients, updateClients, updateSpokePoolClients } from "../common";
+import { CONTRACT_ADDRESSES, Clients, constructClients, updateClients, updateSpokePoolClients } from "../common";
 import { SpokePoolClientsByChain } from "../interfaces";
 import { constructSpokePoolClientsWithLookback } from "../common";
 
@@ -76,8 +76,11 @@ export async function constructRelayerClients(
   );
   await profitClient.update();
 
+  // The relayer will originate cross chain rebalances from both its own EOA address and the atomic depositor address
+  // so we should track both for accurate cross-chain inventory management.
   const adapterManager = new AdapterManager(logger, spokePoolClients, commonClients.hubPoolClient, [
     baseSigner.address,
+    CONTRACT_ADDRESSES[commonClients.hubPoolClient.chainId].atomicDepositor.address,
   ]);
 
   const bundleDataClient = new BundleDataClient(


### PR DESCRIPTION
## Integration tests I performed

I tracked the following deposits which the current production `monitor` is alerting on and this branch does not warn on it:

- Example L1 deposit initiated transaction
<img width="1183" alt="Screenshot 2023-08-22 at 21 09 14" src="https://github.com/across-protocol/relayer-v2/assets/9457025/b94a6994-5b5e-44f5-8d4d-d93ae03826b8">

- Log index 95 here: https://etherscan.io/tx/0x2d59cbf45b78f9bd0a936d3826e112d0147c02f66c971b0ddcc010438c81cbbb#eventlog
- Example L2 finalization
https://basescan.org/tx/0xdc232909267c0290ffeef37d27047b8c1632c912e333cf05e0962fedc065d060#eventlog

## Resolution
We should be tracking the hub pool's address in both events but the `AdapterManager` uses the spoke pool addresses instead. So I resolve this by adding hub pool address to list of monitored addresses.

Additionally, the EthDepositInitiated doesn't set the `fromAddress` to the correct event parameter. 