### PR TITLE
fix: Ignore block hash in eth_getLogs responses

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -90,7 +90,7 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
     // We've seen some RPC's like QuickNode add in transactionLogIndex which isn't in the
     // JSON RPC spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getfilterchanges
     // Additional reference: https://github.com/ethers-io/ethers.js/issues/1721
-    return compareResultsAndFilterIgnoredKeys(["transactionLogIndex"], rpcResultA, rpcResultB);
+    return compareResultsAndFilterIgnoredKeys(["blockHash", "transactionLogIndex"], rpcResultA, rpcResultB);
   } else {
     return lodash.isEqual(rpcResultA, rpcResultB);
   }

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -90,6 +90,7 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
     // We've seen some RPC's like QuickNode add in transactionLogIndex which isn't in the
     // JSON RPC spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getfilterchanges
     // Additional reference: https://github.com/ethers-io/ethers.js/issues/1721
+    // 2023-08-31 Added blockHash because of upstream zkSync provider disagreements. Consider removing later.
     return compareResultsAndFilterIgnoredKeys(["blockHash", "transactionLogIndex"], rpcResultA, rpcResultB);
   } else {
     return lodash.isEqual(rpcResultA, rpcResultB);


### PR DESCRIPTION
We don't _directly_ depend on the block hash, so if all of the other fields in the response agree then don't discard the response simply because the of the blockHash field. This is introduced now because there are upstream disagreements from various providers as to which blockHash applies to the current set of events.

Fixes ACX-1515