### PR TITLE
improve(relayer): Permit ignoring origin chains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,9 +70,12 @@ NODE_MAX_CONCURRENCY=25
 SEND_RELAYS=false
 
 
-# List of destination chains to be supported by the relayer. If set to a
-# non-empty list, only transfers going to these chains will be filled. For
-# example, if set to [1], only transfers destined for Ethereum will be filled.
+# List of origin and destination chains to be supported by the relayer. If set
+# to a non-empty list, only transfers complying with the specified origin and
+# destination chains will be filled. For example:
+# RELAYER_ORIGIN_CHAINS=[1]  # Only fill deposits that were placed on Optimism.
+# RELAYER_DESTINATION_CHAINS=[10] # Only fill deposits destined for Ethereum.
+RELAYER_ORIGIN_CHAINS=[1,10,137,324,42161]
 RELAYER_DESTINATION_CHAINS=[1,10,137,42161]
 
 

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -14,7 +14,8 @@ export class RelayerConfig extends CommonConfig {
   readonly sendingSlowRelaysEnabled: boolean;
   readonly sendingRefundRequestsEnabled: boolean;
   readonly relayerTokens: string[];
-  readonly relayerDestinationChains: number[];
+  readonly relayerOriginChains: number[] = [];
+  readonly relayerDestinationChains: number[] = [];
   readonly relayerGasMultiplier: BigNumber;
   readonly minRelayerFeePct: BigNumber;
   readonly acceptInvalidFills: boolean;
@@ -35,6 +36,7 @@ export class RelayerConfig extends CommonConfig {
 
   constructor(env: ProcessEnv) {
     const {
+      RELAYER_ORIGIN_CHAINS,
       RELAYER_DESTINATION_CHAINS,
       SLOW_DEPOSITORS,
       DEBUG_PROFITABILITY,
@@ -53,7 +55,9 @@ export class RelayerConfig extends CommonConfig {
     super(env);
 
     // Empty means all chains.
-    this.relayerDestinationChains = RELAYER_DESTINATION_CHAINS ? JSON.parse(RELAYER_DESTINATION_CHAINS) : [];
+    this.relayerOriginChains = JSON.parse(RELAYER_ORIGIN_CHAINS ?? "[]");
+    this.relayerDestinationChains = JSON.parse(RELAYER_DESTINATION_CHAINS ?? "[]");
+
     // Empty means all tokens.
     this.relayerTokens = RELAYER_TOKENS
       ? JSON.parse(RELAYER_TOKENS).map((token) => ethers.utils.getAddress(token))

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -37,6 +37,7 @@ import {
   expect,
   getLastBlockTime,
   lastSpyLogIncludes,
+  spyLogIncludes,
   originChainId,
   setupTokensForWallet,
   sinon,
@@ -459,7 +460,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     await deposit(spokePool_1, erc20_1, depositor, depositor, destinationChainId);
     await updateAllClients();
     await relayerInstance.checkForUnfilledDepositsAndFill();
-    expect(lastSpyLogIncludes(spy, "Skipping deposit for unsupported origin or destination chain")).to.be.true;
+    expect(spyLogIncludes(spy, -3, "Skipping 1 deposits from or to disabled chains.")).to.be.true;
   });
 
   it("UBA: Doesn't crash if client cannot support version bump", async function () {

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -154,7 +154,6 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       },
       {
         relayerTokens: [],
-        relayerDestinationChains: [originChainId, destinationChainId],
         minDepositConfirmations: defaultMinDepositConfirmations,
         quoteTimeBuffer: 0,
       } as unknown as RelayerConfig
@@ -233,7 +232,6 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       },
       {
         relayerTokens: [],
-        relayerDestinationChains: [originChainId, destinationChainId],
         minDepositConfirmations: {
           default: { [originChainId]: 10 }, // This needs to be set large enough such that the deposit is ignored.
         },
@@ -270,7 +268,6 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       },
       {
         relayerTokens: [],
-        relayerDestinationChains: [originChainId, destinationChainId],
         minDepositConfirmations: defaultMinDepositConfirmations,
         quoteTimeBuffer: 100,
         sendingRelaysEnabled: false,
@@ -421,7 +418,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     expect(multiCallerClient.transactionCount()).to.equal(1); // no Transactions to send.
   });
 
-  it("Skip unwhitelisted chains", async function () {
+  it("Respects configured relayer routes", async function () {
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,
@@ -438,20 +435,31 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       },
       {
         relayerTokens: [],
+        relayerOriginChains: [destinationChainId],
         relayerDestinationChains: [originChainId],
         minDepositConfirmations: defaultMinDepositConfirmations,
         quoteTimeBuffer: 0,
       } as unknown as RelayerConfig
     );
 
+    // Test the underlying route validation logic.
+    const routes = [
+      { from: originChainId, to: destinationChainId, enabled: false },
+      { from: originChainId, to: originChainId, enabled: false },
+      { from: destinationChainId, to: originChainId, enabled: true },
+      { from: destinationChainId, to: destinationChainId, enabled: false },
+    ];
+    routes.forEach(({ from, to, enabled }) => expect(relayerInstance.routeEnabled(from, to)).to.equal(enabled));
+
+    // Verify that the relayer adheres to route validation.
     // Deposit is not on a whitelisted destination chain so relayer shouldn't fill it.
     await spokePool_1.setCurrentTime(await getLastBlockTime(spokePool_1.provider));
-    await deposit(spokePool_1, erc20_1, depositor, depositor, destinationChainId);
 
-    // Check that no transaction was sent.
+    // Deposit on originChainId, destined for destinationChainId => expect ignored.
+    await deposit(spokePool_1, erc20_1, depositor, depositor, destinationChainId);
     await updateAllClients();
     await relayerInstance.checkForUnfilledDepositsAndFill();
-    expect(lastSpyLogIncludes(spy, "Skipping deposit for unsupported destination chain")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "Skipping deposit for unsupported origin or destination chain")).to.be.true;
   });
 
   it("UBA: Doesn't crash if client cannot support version bump", async function () {


### PR DESCRIPTION
This is a simple relayer-specific config to permit ignoring deposits based on their origin chain ID.

Note: This is implemented at the relayer level because the anticipated UBA rollout will require relayers to validate events on _all_ supported chains, not only the ones they wish to support.

Closes ACX-1516