### PR TITLE
fix: Avoid logging entire Error object

### DIFF
--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -96,7 +96,9 @@ export class TransactionClient {
           at: "TransactionClient#submit",
           message: `Transaction ${idx + 1} submission on ${networkName} failed or timed out.`,
           mrkdwn,
-          error: isError(error) ? (error as Error).message : "Unknown error",
+          // @dev `error` _sometimes_ doesn't decode correctly (especially on Polygon), so fish for the reason.
+          errorMessage: isError(error) ? (error as Error).message : undefined,
+          error,
           notificationPath: "across-error",
         });
         return txnResponses;

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { utils as sdkUtils } from "@across-protocol/sdk-v2";
+import { utils as sdkUtils, typeguards } from "@across-protocol/sdk-v2";
 import {
   winston,
   getNetworkName,
@@ -29,6 +29,7 @@ export interface AugmentedTransaction {
 }
 
 const { fixedPointAdjustment: fixedPoint } = sdkUtils;
+const { isError } = typeguards;
 
 const DEFAULT_GASLIMIT_MULTIPLIER = 1.0;
 
@@ -95,7 +96,7 @@ export class TransactionClient {
           at: "TransactionClient#submit",
           message: `Transaction ${idx + 1} submission on ${networkName} failed or timed out.`,
           mrkdwn,
-          error,
+          error: isError(error) ? (error as Error).message : "Unknown error",
           notificationPath: "across-error",
         });
         return txnResponses;


### PR DESCRIPTION
The logging subsystem doesn't handle Error objects properly.