### PR TITLE
chore: bump sdk-v2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@across-protocol/contracts-v2": "2.4.3",
-    "@across-protocol/sdk-v2": "0.15.20",
+    "@across-protocol/sdk-v2": "0.15.21",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,10 +37,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.15.20":
-  version "0.15.20"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.15.20.tgz#35e3faf01069bb6e82522efecef8c97ad8863462"
-  integrity sha512-LjnL9lwEoCA80XpOh6JwBPYys1aI7HP7XhDe3vkzBU7u86P7MY2oMDc4p2AErr7w+iR0mkUD727eYCSl10zfRg==
+"@across-protocol/sdk-v2@0.15.21":
+  version "0.15.21"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.15.21.tgz#da6de385c36c947a724ea2e02fed455ba21c7605"
+  integrity sha512-+3cudHaDaPryjXIO/fRZ9J+VUE9pzS57ySMbxso0uxUYgNHX/rncaxza6KA/MPxr9yVraPbxgQGdxT38ZAmdcA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/contracts-v2" "^2.4.3"


### PR DESCRIPTION
This change is motivated by a need to properly map `0xdead....` (raw ETH address) to WETH. This issue is resolved in the newest SDK revision.