### PR TITLE
improve: Don't trigger quorum fights on zkSync l1 fields

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -91,7 +91,11 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
     // JSON RPC spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getfilterchanges
     // Additional reference: https://github.com/ethers-io/ethers.js/issues/1721
     // 2023-08-31 Added blockHash because of upstream zkSync provider disagreements. Consider removing later.
-    return compareResultsAndFilterIgnoredKeys(["blockHash", "transactionLogIndex"], rpcResultA, rpcResultB);
+    return compareResultsAndFilterIgnoredKeys([
+      "l1BatchNumber",  // zkSync
+      "l1BatchTimestamp", // zkSync
+      "transactionLogIndex"
+    ], rpcResultA, rpcResultB);
   } else {
     return lodash.isEqual(rpcResultA, rpcResultB);
   }

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -91,11 +91,15 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
     // JSON RPC spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getfilterchanges
     // Additional reference: https://github.com/ethers-io/ethers.js/issues/1721
     // 2023-08-31 Added blockHash because of upstream zkSync provider disagreements. Consider removing later.
-    return compareResultsAndFilterIgnoredKeys([
-      "l1BatchNumber",  // zkSync
-      "l1BatchTimestamp", // zkSync
-      "transactionLogIndex"
-    ], rpcResultA, rpcResultB);
+    return compareResultsAndFilterIgnoredKeys(
+      [
+        "l1BatchNumber", // zkSync
+        "l1BatchTimestamp", // zkSync
+        "transactionLogIndex",
+      ],
+      rpcResultA,
+      rpcResultB
+    );
   } else {
     return lodash.isEqual(rpcResultA, rpcResultB);
   }


### PR DESCRIPTION
Testing shows that these fields can be updated shortly after the block has been produced.