### PR TITLE
feat: enable linting for floating promises.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaVersion: 12,
+    project: "./tsconfig.eslint.json",
   },
   rules: {
     "prettier/prettier": ["warn"],
@@ -35,6 +36,8 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true }],
     "chai-expect/missing-assertion": 2,
     "no-duplicate-imports": "error",
+    //    "require-await": "error",
+    "@typescript-eslint/no-floating-promises": ["error"],
   },
   settings: {
     node: {

--- a/src/clients/bridges/op-stack/OpStackBridgeInterface.ts
+++ b/src/clients/bridges/op-stack/OpStackBridgeInterface.ts
@@ -3,7 +3,7 @@ import { Contract, BigNumber, Event, EventSearchConfig } from "../../../utils";
 export interface BridgeTransactionDetails {
   readonly contract: Contract;
   readonly method: string;
-  readonly args: any[];
+  readonly args: unknown[];
 }
 
 export interface OpStackBridge {

--- a/src/scripts/testUBAClient.ts
+++ b/src/scripts/testUBAClient.ts
@@ -146,4 +146,4 @@ export async function run(_logger: winston.Logger): Promise<void> {
 }
 
 // eslint-disable-next-line no-process-exit
-run(Logger).then(async () => process.exit(0));
+void run(Logger).then(async () => process.exit(0));

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -207,4 +207,4 @@ export async function run(_logger: winston.Logger): Promise<void> {
 }
 
 // eslint-disable-next-line no-process-exit
-run(Logger).then(async () => process.exit(0));
+void run(Logger).then(async () => process.exit(0));

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -456,4 +456,4 @@ export async function run(_logger: winston.Logger): Promise<void> {
 }
 
 // eslint-disable-next-line no-process-exit
-run(Logger).then(() => process.exit(0));
+void run(Logger).then(() => process.exit(0));

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -84,7 +84,7 @@ export async function disconnectRedisClient(logger?: winston.Logger): Promise<vo
   if (redisClient !== undefined) {
     // todo understand why redisClient isn't GCed automagically.
     logger.debug("Disconnecting from redis server.");
-    redisClient.disconnect();
+    await redisClient.disconnect();
   }
 }
 

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -50,7 +50,7 @@ class DummyMultiCallerClient extends MockedMultiCallerClient {
 }
 
 // encodeFunctionData is called from within MultiCallerClient.buildMultiCallBundle.
-function encodeFunctionData(_method: string, args: ReadonlyArray<any> = []): string {
+function encodeFunctionData(_method: string, args: ReadonlyArray<unknown> = []): string {
   return args.join(" ");
 }
 

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -343,7 +343,7 @@ describe("MultiCallerClient", async function () {
     const multicallerWithMultisend = new DummyMultiCallerClient(spyLogger, {}, fakeMultisender as unknown as Contract);
 
     // Can't pass any transactions to multisender bundler that are permissioned or different chains:
-    assertPromiseError(
+    void assertPromiseError(
       multicallerWithMultisend.buildMultiSenderBundle([
         {
           chainId: 1,
@@ -358,7 +358,7 @@ describe("MultiCallerClient", async function () {
       ] as AugmentedTransaction[]),
       "Multisender bundle data mismatch"
     );
-    assertPromiseError(
+    void assertPromiseError(
       multicallerWithMultisend.buildMultiSenderBundle([
         {
           chainId: 1,

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -99,8 +99,8 @@ describe("SpokePoolClient: Fill Validation", async function () {
       spokePool2DeploymentBlock
     );
 
-    await setupTokensForWallet(spokePool_1, depositor, [erc20_1], null, 10);
-    await setupTokensForWallet(spokePool_2, relayer, [erc20_2], null, 10);
+    await setupTokensForWallet(spokePool_1, depositor, [erc20_1], undefined, 10);
+    await setupTokensForWallet(spokePool_2, relayer, [erc20_2], undefined, 10);
 
     // Set the spokePool's time to the provider time. This is done to enable the block utility time finder identify a
     // "reasonable" block number based off the block time when looking at quote timestamps. We only need to do
@@ -255,7 +255,7 @@ describe("SpokePoolClient: Fill Validation", async function () {
     expect(searchRange2.low).to.be.lessThanOrEqual(deposit1Block);
 
     // Searching for deposit ID 3 that doesn't exist yet should throw.
-    assertPromiseError(
+    void assertPromiseError(
       spokePoolClient1._getBlockRangeForDepositId(3, spokePool1DeploymentBlock, spokePoolClient1.latestBlockNumber, 10),
       "Failed to find deposit ID"
     );

--- a/test/UBAClient.validateFlow.ts
+++ b/test/UBAClient.validateFlow.ts
@@ -422,11 +422,11 @@ describe("UBAClient: Flow validation", function () {
           // Don't add inflow to uba bundle state.
 
           // Throws errors if inflow is before, after, or in same bundle as outflow.
-          assertPromiseError(ubaClient.validateFlow(outflow), "Could not find matched deposit in same bundle");
+          void assertPromiseError(ubaClient.validateFlow(outflow), "Could not find matched deposit in same bundle");
           outflow.matchedDeposit.blockNumber = expectedBlockRanges[originChainId][0].start - 1;
-          assertPromiseError(ubaClient.validateFlow(outflow), "Could not find bundle block range containing flow");
+          void assertPromiseError(ubaClient.validateFlow(outflow), "Could not find bundle block range containing flow");
           outflow.matchedDeposit.blockNumber = expectedBlockRanges[originChainId][0].end + 1;
-          assertPromiseError(ubaClient.validateFlow(outflow), "Could not find bundle block range containing flow");
+          void assertPromiseError(ubaClient.validateFlow(outflow), "Could not find bundle block range containing flow");
         });
       });
     });

--- a/test/UBAClientUtilities.ts
+++ b/test/UBAClientUtilities.ts
@@ -383,7 +383,7 @@ describe("UBAClientUtilities", function () {
       spokePoolClient.addEvent(event);
       await spokePoolClient.update();
 
-      assertPromiseError(
+      void assertPromiseError(
         clients.getUBAFlows(tokenSymbol, chainId, spokePoolClients, hubPoolClient),
         "Found a UBA deposit with a defined realizedLpFeePct"
       );

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./src",
+    "index.ts",
+    "./scripts",
+    "./test",
+    ".eslintrc.js" // ESLint's config must be included
+  ]
+}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,10 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "include": [
-    "./src",
-    "index.ts",
-    "./scripts",
-    "./test",
-    ".eslintrc.js" // ESLint's config must be included
-  ]
+  "include": [".eslintrc.js", "index.ts", "./src", "./scripts", "./test", "./deploy", "./tasks"],
+  "exclude": ["artifacts", "cache", "dist", "node_modules"],
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "strictNullChecks": false,
     "noImplicitAny": false
   },
-  "include": ["./src", "index.ts", "./scripts", "./test"],
+  "include": ["./src", "index.ts", "./scripts"],
   "files": ["./hardhat.config.ts"],
   "watchOptions": {
     "watchFile": "useFsEventsOnParentDirectory",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-  },
+  "compilerOptions": {},
   "include": ["./test", "./src"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "strict": false
   },
   "include": ["./test", "./src"]
 }


### PR DESCRIPTION
This PR adds ESLinting for floating promises. Floating promises are defined as any function that resolves an unhandled promise. A handled promise can either be returned directly, awaited, then/catch'd, or voided.

This change would have immediately solved https://github.com/across-protocol/relayer-v2/commit/723bdcfae365051fcb05a089ebf4e6fc998bb2b0. We can now enforce that un-awaited promises will never be uncaught again.