### PR TITLE
feat: enforce async functions to have await

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,7 @@ module.exports = {
     "@typescript-eslint/no-unused-vars": ["error", { ignoreRestSiblings: true }],
     "chai-expect/missing-assertion": 2,
     "no-duplicate-imports": "error",
-    //    "require-await": "error",
+    "require-await": "error",
     "@typescript-eslint/no-floating-promises": ["error"],
   },
   settings: {

--- a/scripts/constructEmergencyRoot.ts
+++ b/scripts/constructEmergencyRoot.ts
@@ -95,11 +95,11 @@ export async function run(): Promise<void> {
 
 if (require.main === module) {
   run()
-    .then(async () => {
+    .then(() => {
       // eslint-disable-next-line no-process-exit
       process.exit(0);
     })
-    .catch(async (error) => {
+    .catch((error) => {
       console.error("Process exited with", error);
       // eslint-disable-next-line no-process-exit
       process.exit(1);

--- a/scripts/disableDepositRoutes.ts
+++ b/scripts/disableDepositRoutes.ts
@@ -104,10 +104,10 @@ export async function run(logger: winston.Logger): Promise<void> {
 
 if (require.main === module) {
   run(Logger)
-    .then(async () => {
+    .then(() => {
       process.exit(0);
     })
-    .catch(async (error) => {
+    .catch((error) => {
       console.error("Process exited with", error);
       process.exit(1);
     });

--- a/scripts/hubpool.ts
+++ b/scripts/hubpool.ts
@@ -264,10 +264,10 @@ async function run(argv: string[]): Promise<number> {
 
 if (require.main === module) {
   run(process.argv.slice(2))
-    .then(async (result) => {
+    .then((result) => {
       process.exitCode = result;
     })
-    .catch(async (error) => {
+    .catch((error) => {
       console.error("Process exited with", error);
       process.exitCode = NODE_APP_ERR;
     });

--- a/scripts/sendTokens.ts
+++ b/scripts/sendTokens.ts
@@ -69,11 +69,11 @@ export async function run(): Promise<void> {
 
 if (require.main === module) {
   run()
-    .then(async () => {
+    .then(() => {
       // eslint-disable-next-line no-process-exit
       process.exit(0);
     })
-    .catch(async (error) => {
+    .catch((error) => {
       console.error("Process exited with", error);
       // eslint-disable-next-line no-process-exit
       process.exit(1);

--- a/scripts/spokepool.ts
+++ b/scripts/spokepool.ts
@@ -261,11 +261,11 @@ async function run(argv: string[]): Promise<boolean> {
 
 if (require.main === module) {
   run(process.argv.slice(2))
-    .then(async () => {
+    .then(() => {
       // eslint-disable-next-line no-process-exit
       process.exit(0);
     })
-    .catch(async (error) => {
+    .catch((error) => {
       console.error("Process exited with", error);
       // eslint-disable-next-line no-process-exit
       process.exit(1);

--- a/scripts/unwrapWeth.ts
+++ b/scripts/unwrapWeth.ts
@@ -88,11 +88,11 @@ export async function run(): Promise<void> {
 
 if (require.main === module) {
   run()
-    .then(async () => {
+    .then(() => {
       // eslint-disable-next-line no-process-exit
       process.exit(0);
     })
-    .catch(async (error) => {
+    .catch((error) => {
       console.error("Process exited with", error);
       // eslint-disable-next-line no-process-exit
       process.exit(1);

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -19,7 +19,7 @@ const fallbackProviders: { [chainId: number]: string } = {
   5: "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
 };
 
-async function askQuestion(query: string) {
+function askQuestion(query: string) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
   return new Promise((resolve) =>

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -115,7 +115,7 @@ export function resolveHubChainId(spokeChainId: number): number {
  * @param contractName Name of the deployed contract.
  * @returns ethers Contract instance.
  */
-export async function getContract(chainId: number, contractName: string): Promise<Contract> {
+export function getContract(chainId: number, contractName: string): Contract {
   const contract = getDeployedContract(contractName, chainId);
   const provider = new ethers.providers.StaticJsonRpcProvider(getProviderUrl(chainId));
   return contract.connect(provider);

--- a/scripts/zkSyncDemo.ts
+++ b/scripts/zkSyncDemo.ts
@@ -175,11 +175,11 @@ export async function run(): Promise<void> {
 
 if (require.main === module) {
   run()
-    .then(async () => {
+    .then(() => {
       // eslint-disable-next-line no-process-exit
       process.exit(0);
     })
-    .catch(async (error) => {
+    .catch((error) => {
       console.error("Process exited with", error);
       // eslint-disable-next-line no-process-exit
       process.exit(1);

--- a/src/clients/BalanceAllocator.ts
+++ b/src/clients/BalanceAllocator.ts
@@ -88,12 +88,7 @@ export class BalanceAllocator {
     return true;
   }
 
-  async requestBalanceAllocation(
-    chainId: number,
-    tokens: string[],
-    holder: string,
-    amount: BigNumber
-  ): Promise<boolean> {
+  requestBalanceAllocation(chainId: number, tokens: string[], holder: string, amount: BigNumber): Promise<boolean> {
     return this.requestBalanceAllocations([{ chainId, tokens, holder, amount }]);
   }
 

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -168,7 +168,7 @@ export class BundleDataClient {
   // Common data re-formatting logic shared across all data worker public functions.
   // User must pass in spoke pool to search event data against. This allows the user to refund relays and fill deposits
   // on deprecated spoke pools.
-  async loadData(
+  loadData(
     blockRangesForChains: number[][],
     spokePoolClients: { [chainId: number]: SpokePoolClient },
     logData = true
@@ -409,7 +409,7 @@ export class BundleDataClient {
           this.chainIdListForBundleEvaluationBlockNumbers
         );
         const refundRequests = originClient.getRefundRequests(blockRangeForChain[0], blockRangeForChain[1]);
-        await Promise.all(refundRequests.map(async (refundRequest) => validateRefundRequestAndSaveData(refundRequest)));
+        await Promise.all(refundRequests.map((refundRequest) => validateRefundRequestAndSaveData(refundRequest)));
       }
     }
 

--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -47,7 +47,7 @@ export class TransactionClient {
     return Promise.all(txns.map((txn: AugmentedTransaction) => this._simulate(txn)));
   }
 
-  protected async _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
+  protected _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
     const { contract, method, args, value, gasLimit } = txn;
     return runTransaction(this.logger, contract, method, args, value, gasLimit, nonce);
   }

--- a/src/clients/UBAClient.ts
+++ b/src/clients/UBAClient.ts
@@ -16,11 +16,11 @@ export class UBAClient extends clients.UBAClient {
     super(clientConfig, tokenSymbols, hubPoolClient, spokePoolClients);
   }
 
-  async getFills(chainId: number, filter: SpokePoolFillFilter = {}): Promise<FillWithBlock[]> {
+  getFills(chainId: number, filter: SpokePoolFillFilter = {}): Promise<FillWithBlock[]> {
     return getValidFillCandidates(chainId, this.spokePoolClients, filter);
   }
 
-  async getRefundRequests(chainId: number, filter: SpokePoolFillFilter = {}): Promise<RefundRequestWithBlock[]> {
+  getRefundRequests(chainId: number, filter: SpokePoolFillFilter = {}): Promise<RefundRequestWithBlock[]> {
     return getValidRefundCandidates(chainId, this.hubPoolClient, this.spokePoolClients, filter);
   }
 }

--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -195,7 +195,7 @@ export class ArbitrumAdapter extends BaseAdapter {
     );
   }
 
-  async wrapEthIfAboveThreshold(): Promise<TransactionResponse | null> {
+  wrapEthIfAboveThreshold(): Promise<TransactionResponse | null> {
     throw new Error("Unnecessary to wrap ETH on Arbitrum");
   }
 

--- a/src/clients/bridges/PolygonAdapter.ts
+++ b/src/clients/bridges/PolygonAdapter.ts
@@ -288,7 +288,7 @@ export class PolygonAdapter extends BaseAdapter {
     );
   }
 
-  async wrapEthIfAboveThreshold(): Promise<TransactionResponse | null> {
+  wrapEthIfAboveThreshold(): Promise<TransactionResponse | null> {
     throw new Error("Unneccessary to wrap ETH on Polygon");
   }
 }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1874,7 +1874,7 @@ export class Dataworker {
     });
   }
 
-  async _updateExchangeRates(l1Tokens: string[], submitExecution: boolean): Promise<void> {
+  _updateExchangeRates(l1Tokens: string[], submitExecution: boolean): void {
     const syncedL1Tokens: string[] = [];
     l1Tokens.forEach((l1Token) => {
       // Exit early if we already synced this l1 token on this loop

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -204,7 +204,7 @@ async function prepareFinalizations(
   const l1ERC20Bridge = getL1ERC20Bridge(l1ChainId);
   const ethAddr = getEthAddressForChain(l2ChainId);
 
-  return await sdkUtils.mapAsync(withdrawalParams, async (withdrawal) =>
+  return await sdkUtils.mapAsync(withdrawalParams, (withdrawal) =>
     prepareFinalization(withdrawal, ethAddr, l1Mailbox, l1ERC20Bridge)
   );
 }

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -142,7 +142,7 @@ export class Monitor {
     }
   }
 
-  async checkUnknownRootBundleCallers(): Promise<void> {
+  checkUnknownRootBundleCallers(): void {
     this.logger.debug({ at: "Monitor#RootBundleCallers", message: "Checking for unknown root bundle callers" });
 
     const proposedBundles = this.clients.hubPoolClient.getProposedRootBundlesInBlockRange(
@@ -169,7 +169,7 @@ export class Monitor {
     }
   }
 
-  async checkUnknownRelayers(): Promise<void> {
+  checkUnknownRelayers(): void {
     const chainIds = this.monitorChains;
     this.logger.debug({ at: "Monitor#checkUnknownRelayers", message: "Checking for unknown relayers", chainIds });
     for (const chainId of chainIds) {
@@ -509,7 +509,7 @@ export class Monitor {
   // transfers stuck for longer than 1 bundle and the current time is within the last bundle execution + grace period.
   // But this should be okay as we should address any stuck transactions immediately so realistically no transfers
   // should stay unstuck for longer than one bundle.
-  async checkStuckRebalances(): Promise<void> {
+  checkStuckRebalances(): void {
     const hubPoolClient = this.clients.hubPoolClient;
     const lastFullyExecutedBundle = hubPoolClient.getLatestFullyExecutedRootBundle(hubPoolClient.latestBlockNumber);
     // This case shouldn't happen outside of tests as Across V2 has already launched.

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -565,7 +565,7 @@ export class Relayer {
     return profitable ? preferredChainId : undefined;
   }
 
-  protected async computeRealizedLpFeePct(version: number, deposit: DepositWithBlock): Promise<BigNumber> {
+  protected computeRealizedLpFeePct(version: number, deposit: DepositWithBlock): BigNumber {
     if (!sdkUtils.isUBA(version)) {
       if (deposit.realizedLpFeePct === undefined) {
         throw new Error(`Deposit ${deposit.depositId} is missing realizedLpFeePct`);

--- a/src/scripts/testUBAClient.ts
+++ b/src/scripts/testUBAClient.ts
@@ -146,4 +146,4 @@ export async function run(_logger: winston.Logger): Promise<void> {
 }
 
 // eslint-disable-next-line no-process-exit
-void run(Logger).then(async () => process.exit(0));
+void run(Logger).then(() => process.exit(0));

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -207,4 +207,4 @@ export async function run(_logger: winston.Logger): Promise<void> {
 }
 
 // eslint-disable-next-line no-process-exit
-void run(Logger).then(async () => process.exit(0));
+void run(Logger).then(() => process.exit(0));

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -444,7 +444,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
    * @dev Clients are only created for chains not on disabled chain list.
    * @returns A dictionary of chain ID to SpokePoolClient.
    */
-  async function _createSpokePoolClients(fromBlocks: { [chainId: number]: number }) {
+  function _createSpokePoolClients(fromBlocks: { [chainId: number]: number }) {
     return constructSpokePoolClientsWithStartBlocks(logger, clients.hubPoolClient, config, baseSigner, fromBlocks, {});
   }
 }

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -57,7 +57,7 @@ class RateLimitedProvider extends ethers.providers.StaticJsonRpcProvider {
     }, maxConcurrency);
   }
 
-  override async send(method: string, params: Array<any>): Promise<any> {
+  override send(method: string, params: Array<any>): Promise<any> {
     // This simply creates a promise and adds the arguments and resolve and reject handlers to the task.
     return new Promise<any>((resolve, reject) => {
       const task: RateLimitTask = {
@@ -200,7 +200,7 @@ class CacheProvider extends RateLimitedProvider {
         throw new Error("CacheProvider::shouldCache toBlock cannot be smaller than fromBlock.");
       }
 
-      return this.canCacheInformationFromBlock(toBlock);
+      return await this.canCacheInformationFromBlock(toBlock);
     } else if ("eth_call" === method || "eth_getBlockByNumber" === method) {
       // Pull out the block tag from params. Its position in params is dependent on the method.
       // We are only interested in numeric block tags, which would be hex-encoded strings.
@@ -213,7 +213,7 @@ class CacheProvider extends RateLimitedProvider {
       }
 
       // If the block is old enough to cache, cache the call.
-      return this.canCacheInformationFromBlock(blockNumber);
+      return await this.canCacheInformationFromBlock(blockNumber);
     } else {
       return false;
     }

--- a/test/AdapterManager.SendTokensCrossChain.ts
+++ b/test/AdapterManager.SendTokensCrossChain.ts
@@ -64,7 +64,7 @@ const addAttrib = (obj: unknown) =>
     transactionSubmissionData: number;
   };
 
-describe("AdapterManager: Send tokens cross-chain", async function () {
+describe("AdapterManager: Send tokens cross-chain", function () {
   beforeEach(async function () {
     [relayer, owner] = await ethers.getSigners();
     ({ spyLogger } = createSpyLogger());

--- a/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
+++ b/test/AdapterManager.getOutstandingCrossChainTokenTransferAmount.ts
@@ -46,8 +46,8 @@ class TestAdapter extends BaseAdapter {
 }
 
 let adapter: TestAdapter;
-describe("AdapterManager: Get outstanding cross chain token transfer amounts", async function () {
-  beforeEach(async function () {
+describe("AdapterManager: Get outstanding cross chain token transfer amounts", function () {
+  beforeEach(function () {
     adapter = new TestAdapter();
   });
 

--- a/test/BalanceAllocator.ts
+++ b/test/BalanceAllocator.ts
@@ -32,14 +32,14 @@ class TestBalanceAllocator extends BalanceAllocator {
   }
 }
 
-describe("BalanceAllocator", async function () {
+describe("BalanceAllocator", function () {
   let balanceAllocator: TestBalanceAllocator;
   const testToken1 = randomAddress();
   const testToken2 = randomAddress();
 
   const testAccount1 = randomAddress();
 
-  beforeEach(async function () {
+  beforeEach(function () {
     balanceAllocator = new TestBalanceAllocator();
   });
 
@@ -49,7 +49,7 @@ describe("BalanceAllocator", async function () {
     expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(0));
   });
 
-  it("Add used", async function () {
+  it("Add used", function () {
     balanceAllocator.addUsed(1, testToken1, testAccount1, BigNumber.from(100));
     expect(balanceAllocator.getUsed(1, testToken1, testAccount1)).to.equal(BigNumber.from(100));
   });

--- a/test/BaseClass.isUpdated.ts
+++ b/test/BaseClass.isUpdated.ts
@@ -44,7 +44,7 @@ describe("BaseAbstractClient.isUpdated", () => {
       await ubaClient.update();
       expect(ubaClient.isUpdated).to.be.true;
     });
-    it("should return false if the client is not updated", async () => {
+    it("should return false if the client is not updated", () => {
       expect(ubaClient.isUpdated).to.be.false;
     });
   });

--- a/test/ConfigStoreClient.ts
+++ b/test/ConfigStoreClient.ts
@@ -61,7 +61,7 @@ const tokenConfigToUpdate = JSON.stringify({
   spokeTargetBalances: sampleSpokeTargetBalances,
 });
 
-describe("AcrossConfigStoreClient", async function () {
+describe("AcrossConfigStoreClient", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
     ({ dai: l1Token, weth: l2Token } = await hubPoolFixture());

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -15,7 +15,7 @@ let spokePoolClients: { [chainId: number]: SpokePoolClient };
 let hubPoolClient: HubPoolClient;
 let updateAllClients: () => Promise<void>;
 
-describe("Dataworker block range-related utility methods", async function () {
+describe("Dataworker block range-related utility methods", function () {
   beforeEach(async function () {
     ({ dataworkerClients, spokePoolClients, updateAllClients, hubPoolClient } = await setupDataworker(
       ethers,
@@ -26,7 +26,7 @@ describe("Dataworker block range-related utility methods", async function () {
     ));
     await updateAllClients();
   });
-  it("DataworkerUtils.getEndBlockBuffers", async function () {
+  it("DataworkerUtils.getEndBlockBuffers", function () {
     const defaultBuffer = {
       2: 2,
       3: 3,
@@ -96,7 +96,7 @@ describe("Dataworker block range-related utility methods", async function () {
     );
     expect(zeroRange).to.deep.equal(latestBlocks.map(() => [0, 0]));
   });
-  it("PoolRebalanceUtils.getWidestPossibleExpectedBlockRange: chain is paused", async function () {
+  it("PoolRebalanceUtils.getWidestPossibleExpectedBlockRange: chain is paused", function () {
     const mockHubPoolClient = new MockHubPoolClient(
       hubPoolClient.logger,
       hubPoolClient.hubPool,
@@ -155,7 +155,7 @@ describe("Dataworker block range-related utility methods", async function () {
       ])
     );
   });
-  it("DataworkerUtils.blockRangesAreInvalidForSpokeClients", async function () {
+  it("DataworkerUtils.blockRangesAreInvalidForSpokeClients", function () {
     const chainId = hubPoolClient.chainId;
 
     // Only use public chain IDs because getDeploymentBlockNumber will only work for real chain ID's. This is a hack

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -299,7 +299,7 @@ describe("Dataworker: Build merkle roots", async function () {
           poolRebalanceRoot1.runningBalances
         )
       ).tree;
-      const expectedMerkleRoot1 = await buildRelayerRefundTreeWithUnassignedLeafIds([leaf1]);
+      const expectedMerkleRoot1 = buildRelayerRefundTreeWithUnassignedLeafIds([leaf1]);
       expect(merkleRoot1.getHexRoot()).to.equal(expectedMerkleRoot1.getHexRoot());
 
       // Submit fills for multiple repayment chains. Note: Send the fills for destination tokens in the

--- a/test/Dataworker.buildRoots.ts
+++ b/test/Dataworker.buildRoots.ts
@@ -66,7 +66,7 @@ let spy: sinon.SinonSpy;
 
 let updateAllClients: () => Promise<void>;
 
-describe("Dataworker: Build merkle roots", async function () {
+describe("Dataworker: Build merkle roots", function () {
   beforeEach(async function () {
     const fastDataworkerResult = await setupFastDataworker(ethers);
     configStoreClient = fastDataworkerResult.configStoreClient as unknown as ConfigStoreClient;
@@ -1440,7 +1440,7 @@ describe("Dataworker: Build merkle roots", async function () {
       ubaClient = new MockUBAClient([l1TokenSymbol], hubPoolClient, spokePoolClients);
     });
     describe("Build pool rebalance root", function () {
-      it("> 0 flows", async function () {
+      it("> 0 flows", function () {
         // Test that the running balance, incentive balance, and the net running balance adjustment of only
         // the latest flow are used, since these values are accumulated by the UBA client. So, add two
         // flows.
@@ -1495,7 +1495,7 @@ describe("Dataworker: Build merkle roots", async function () {
           })
         ).to.be.true;
       });
-      it("0 flows", async function () {
+      it("0 flows", function () {
         const blockRanges = dataworkerInstance._getNextProposalBlockRanges(spokePoolClients);
         if (!blockRanges) {
           throw new Error("Can't propose new bundle");

--- a/test/Dataworker.customSpokePoolClients.ts
+++ b/test/Dataworker.customSpokePoolClients.ts
@@ -24,7 +24,7 @@ let spokePoolClients: { [chainId: number]: SpokePoolClient };
 
 let updateAllClients: () => Promise<void>;
 
-describe("Dataworker: Using SpokePool clients with short lookback windows", async function () {
+describe("Dataworker: Using SpokePool clients with short lookback windows", function () {
   beforeEach(async function () {
     ({ hubPool, l1Token_1, dataworkerInstance, spokePoolClients, multiCallerClient, updateAllClients, spy } =
       await setupFastDataworker(

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -27,7 +27,7 @@ let spokePoolClients: { [chainId: number]: SpokePoolClient };
 
 let updateAllClients: () => Promise<void>;
 
-describe("Dataworker: Execute pool rebalances", async function () {
+describe("Dataworker: Execute pool rebalances", function () {
   beforeEach(async function () {
     ({
       hubPool,

--- a/test/Dataworker.executeRelayerRefunds.ts
+++ b/test/Dataworker.executeRelayerRefunds.ts
@@ -24,7 +24,7 @@ let spokePoolClients: { [chainId: number]: SpokePoolClient };
 
 let updateAllClients: () => Promise<void>;
 
-describe("Dataworker: Execute relayer refunds", async function () {
+describe("Dataworker: Execute relayer refunds", function () {
   beforeEach(async function () {
     ({
       hubPool,

--- a/test/Dataworker.executeSlowRelay.ts
+++ b/test/Dataworker.executeSlowRelay.ts
@@ -24,7 +24,7 @@ let spokePoolClients: { [chainId: number]: SpokePoolClient };
 
 let updateAllClients: () => Promise<void>;
 
-describe("Dataworker: Execute slow relays", async function () {
+describe("Dataworker: Execute slow relays", function () {
   beforeEach(async function () {
     ({
       hubPool,

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -57,7 +57,7 @@ let updateAllClients: () => Promise<void>;
 const ignoredDepositParams = ["logIndex", "transactionHash", "transactionIndex", "blockTimestamp"];
 
 // TODO: Rename this file to BundleDataClient
-describe("Dataworker: Load data used in all functions", async function () {
+describe("Dataworker: Load data used in all functions", function () {
   beforeEach(async function () {
     ({
       hubPool,

--- a/test/Dataworker.proposeRootBundle.ts
+++ b/test/Dataworker.proposeRootBundle.ts
@@ -31,7 +31,7 @@ let spokePoolClients: { [chainId: number]: SpokePoolClient };
 
 let updateAllClients: () => Promise<void>;
 
-describe("Dataworker: Propose root bundle", async function () {
+describe("Dataworker: Propose root bundle", function () {
   beforeEach(async function () {
     ({
       hubPool,
@@ -55,11 +55,15 @@ describe("Dataworker: Propose root bundle", async function () {
   it("Simple lifecycle", async function () {
     await updateAllClients();
 
-    const getMostRecentLog = (_spy: sinon.SinonSpy, message: string) => {
-      return spy
-        .getCalls()
-        .sort((logA: unknown, logB: unknown) => logB["callId"] - logA["callId"]) // Sort by callId in descending order
-        .find((log: unknown) => log["lastArg"]["message"].includes(message)).lastArg;
+    const getMostRecentLog = (spy: sinon.SinonSpy, message: string) => {
+      const calls = spy.getCalls();
+      const matchingLog = calls
+        .sort((logA: sinon.SinonSpyCall, logB: sinon.SinonSpyCall) => logB["callId"] - logA["callId"])
+        .find((log: sinon.SinonSpyCall) => log.lastArg?.message?.includes(message));
+      if (matchingLog) {
+        return matchingLog.lastArg;
+      }
+      return null;
     };
 
     // TEST 1:

--- a/test/Dataworker.validateRootBundle.ts
+++ b/test/Dataworker.validateRootBundle.ts
@@ -39,7 +39,7 @@ let spokePoolClients: { [chainId: number]: SpokePoolClient };
 
 let updateAllClients: () => Promise<void>;
 
-describe("Dataworker: Validate pending root bundle", async function () {
+describe("Dataworker: Validate pending root bundle", function () {
   beforeEach(async function () {
     ({
       hubPool,

--- a/test/EventUtils.ts
+++ b/test/EventUtils.ts
@@ -3,8 +3,8 @@ import { expect } from "./utils";
 // Tested
 import { getPaginatedBlockRanges } from "../src/utils/EventUtils";
 
-describe("EventUtils", async function () {
-  it("getPaginatedBlockRanges", async function () {
+describe("EventUtils", function () {
+  it("getPaginatedBlockRanges", function () {
     // Undefined lookback returns full range
     expect(getPaginatedBlockRanges({ fromBlock: 0, toBlock: 4, maxBlockLookBack: undefined })).to.deep.equal([[0, 4]]);
 

--- a/test/HubPoolClient.DepositToDestinationToken.ts
+++ b/test/HubPoolClient.DepositToDestinationToken.ts
@@ -24,7 +24,7 @@ let hubPool: Contract, lpTokenFactory: Contract, mockAdapter: Contract;
 let owner: SignerWithAddress;
 let hubPoolClient: HubPoolClient;
 
-describe("HubPoolClient: Deposit to Destination Token", async function () {
+describe("HubPoolClient: Deposit to Destination Token", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
 

--- a/test/HubPoolClient.L1Tokens.ts
+++ b/test/HubPoolClient.L1Tokens.ts
@@ -15,7 +15,7 @@ let hubPool: Contract, lpTokenFactory: Contract;
 let owner: SignerWithAddress;
 let hubPoolClient: HubPoolClient;
 
-describe("HubPoolClient: L1Tokens", async function () {
+describe("HubPoolClient: L1Tokens", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
 

--- a/test/HubPoolClient.RootBundleEvents.ts
+++ b/test/HubPoolClient.RootBundleEvents.ts
@@ -46,7 +46,7 @@ async function constructSimpleTree(runningBalance: BigNumber) {
   return { leaves, tree };
 }
 
-describe("HubPoolClient: RootBundle Events", async function () {
+describe("HubPoolClient: RootBundle Events", function () {
   beforeEach(async function () {
     ({ hubPool, l1Token_1, l1Token_2, dataworker, timer, owner } = await setupDataworker(
       ethers,
@@ -427,7 +427,7 @@ describe("HubPoolClient: RootBundle Events", async function () {
     );
   });
 
-  describe("HubPoolClient: UBA-specific runningBalances tests", async function () {
+  describe("HubPoolClient: UBA-specific runningBalances tests", function () {
     const hubPoolChainId = 1;
     const chainIds = [10, 137, 42161];
     const maxConfigStoreVersion = UBA_MIN_CONFIG_STORE_VERSION + 1;
@@ -514,10 +514,10 @@ describe("HubPoolClient: RootBundle Events", async function () {
           expect(leafEvent).to.not.be.undefined;
 
           // Must truncate runningBalances under UBA.
-          const expectedRunningBalances =
+          const expectedRunningBalances: constants.BigNumber[] =
             version < UBA_MIN_CONFIG_STORE_VERSION
-              ? leafEvent?.args["runningBalances"]
-              : leafEvent?.args["runningBalances"].slice(0, leafEvent.args["l1Tokens"].length);
+              ? leafEvent?.args?.["runningBalances"]
+              : leafEvent?.args?.["runningBalances"].slice(0, leafEvent.args["l1Tokens"].length);
           expectedRunningBalances.forEach((balance, idx) => expect(balance.eq(runningBalances[idx])).to.be.true);
 
           // Must generate 0 incentiveBalances pre-UBA.

--- a/test/HubPoolClient.Utilization.ts
+++ b/test/HubPoolClient.Utilization.ts
@@ -66,7 +66,7 @@ const tokenConfigToUpdate = JSON.stringify({
   spokeTargetBalances: sampleSpokeTargetBalances,
 });
 
-describe("HubPool Utilization", async function () {
+describe("HubPool Utilization", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
     const getNetwork = owner?.provider?.getNetwork();

--- a/test/InventoryClient.InventoryRebalance.ts
+++ b/test/InventoryClient.InventoryRebalance.ts
@@ -15,7 +15,7 @@ import {
   winston,
 } from "./utils";
 
-import { ConfigStoreClient, InventoryClient } from "../src/clients"; // Tested
+import { ConfigStoreClient, InventoryClient, MultiCallerClient } from "../src/clients"; // Tested
 import { CrossChainTransferClient } from "../src/clients/bridges";
 import { InventoryConfig } from "../src/interfaces";
 import { MockAdapterManager, MockBundleDataClient, MockHubPoolClient, MockTokenClient } from "./mocks/";
@@ -71,7 +71,7 @@ const initialWethTotal = toWei(140); // Sum over all 4 chains is 140
 const initialUsdcTotal = toMegaWei(14000); // Sum over all 4 chains is 14000
 const initialTotals = { [mainnetWeth]: initialWethTotal, [mainnetUsdc]: initialUsdcTotal };
 
-describe("InventoryClient: Rebalancing inventory", async function () {
+describe("InventoryClient: Rebalancing inventory", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
     ({ spy, spyLogger } = createSpyLogger());
@@ -85,9 +85,14 @@ describe("InventoryClient: Rebalancing inventory", async function () {
     hubPoolClient = new MockHubPoolClient(spyLogger, hubPool, configStoreClient);
     await hubPoolClient.update();
 
-    adapterManager = new MockAdapterManager(null, null, null, null);
-    tokenClient = new MockTokenClient(null, null, null, null);
-    bundleDataClient = new MockBundleDataClient(null, null, null, null);
+    adapterManager = new MockAdapterManager(spyLogger, {}, hubPoolClient, []);
+    tokenClient = new MockTokenClient(spyLogger, "", {}, hubPoolClient);
+    bundleDataClient = new MockBundleDataClient(
+      spyLogger,
+      { hubPoolClient, configStoreClient, multiCallerClient: null as unknown as MultiCallerClient },
+      {},
+      []
+    );
 
     crossChainTransferClient = new CrossChainTransferClient(spyLogger, enabledChainIds, adapterManager);
 
@@ -106,7 +111,7 @@ describe("InventoryClient: Rebalancing inventory", async function () {
     seedMocks(initialAllocation);
   });
 
-  it("Accessors work as expected", async function () {
+  it("Accessors work as expected", function () {
     expect(inventoryClient.getEnabledChains()).to.deep.equal(enabledChainIds);
     expect(inventoryClient.getL1Tokens()).to.deep.equal(Object.keys(inventoryConfig.tokenConfig));
     expect(inventoryClient.getEnabledL2Chains()).to.deep.equal([10, 137, 42161]);

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -55,7 +55,7 @@ const TEST_NETWORK_NAMES = ["Hardhat1", "Hardhat2", "unknown", ALL_CHAINS_NAME];
 
 let defaultMonitorEnvVars;
 
-describe("Monitor", async function () {
+describe("Monitor", function () {
   beforeEach(async function () {
     ({
       configStoreClient,
@@ -98,7 +98,7 @@ describe("Monitor", async function () {
     // @dev: Force maxRelayerLookBack to undefined to skip lookback block resolution.
     // This overrules the readonly property for MonitorConfig.maxRelayerLookBack (...bodge!!).
     // @todo: Relocate getUnfilledDeposits() into a class to permit it to be overridden in test.
-    (monitorConfig as unknown)["maxRelayerLookBack"] = undefined;
+    (monitorConfig as unknown as Record<string, unknown>)["maxRelayerLookBack"] = undefined;
 
     // Set the config store version to 0 to match the default version in the ConfigStoreClient.
     process.env.CONFIG_STORE_VERSION = "0";
@@ -120,7 +120,7 @@ describe("Monitor", async function () {
     );
     tokenTransferClient = new TokenTransferClient(spyLogger, providers, [depositor.address]);
 
-    adapterManager = new MockAdapterManager(null, null, null, null);
+    adapterManager = new MockAdapterManager(spyLogger, {}, hubPoolClient, []);
     adapterManager.setSupportedChains(chainIds);
     crossChainTransferClient = new CrossChainTransferClient(spyLogger, chainIds, adapterManager);
     monitorInstance = new Monitor(spyLogger, monitorConfig, {

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -58,8 +58,8 @@ const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
 const multiCaller: DummyMultiCallerClient = new DummyMultiCallerClient(spyLogger);
 const address = randomAddress(); // Test contract address
 
-describe("MultiCallerClient", async function () {
-  beforeEach(async function () {
+describe("MultiCallerClient", function () {
+  beforeEach(function () {
     multiCaller.clearTransactionQueue();
     expect(multiCaller.transactionCount()).to.equal(0);
 
@@ -67,13 +67,13 @@ describe("MultiCallerClient", async function () {
     expect(multiCaller.simulationFailureCount()).to.equal(0);
   });
 
-  it("Correctly enqueues value transactions", async function () {
+  it("Correctly enqueues value transactions", function () {
     chainIds.forEach((chainId) => multiCaller.enqueueTransaction({ chainId, value: toBN(1) } as AugmentedTransaction));
     expect(multiCaller.valueTxnCount()).to.equal(chainIds.length);
     expect(multiCaller.transactionCount()).to.equal(chainIds.length);
   });
 
-  it("Correctly enqueues non-value transactions", async function () {
+  it("Correctly enqueues non-value transactions", function () {
     [undefined, toBN(0)].forEach((value) => {
       multiCaller.clearTransactionQueue();
       expect(multiCaller.transactionCount()).to.equal(0);
@@ -84,7 +84,7 @@ describe("MultiCallerClient", async function () {
     });
   });
 
-  it("Correctly enqueues mixed transactions", async function () {
+  it("Correctly enqueues mixed transactions", function () {
     chainIds.forEach((chainId) => {
       multiCaller.enqueueTransaction({ chainId } as AugmentedTransaction);
       multiCaller.enqueueTransaction({ chainId, value: toBN(1) } as AugmentedTransaction);
@@ -201,7 +201,7 @@ describe("MultiCallerClient", async function () {
     }
   });
 
-  it("Validates transaction data before multicall bundle generation", async function () {
+  it("Validates transaction data before multicall bundle generation", function () {
     const chainId = chainIds[0];
 
     for (const badField of ["address", "chainId"]) {
@@ -245,7 +245,7 @@ describe("MultiCallerClient", async function () {
     }
   });
 
-  it("buildMultiCallBundle can handle transactions to different target contracts", async function () {
+  it("buildMultiCallBundle can handle transactions to different target contracts", function () {
     const chainId = chainIds[0];
     const txns = [
       {
@@ -343,7 +343,7 @@ describe("MultiCallerClient", async function () {
     const multicallerWithMultisend = new DummyMultiCallerClient(spyLogger, {}, fakeMultisender as unknown as Contract);
 
     // Can't pass any transactions to multisender bundler that are permissioned or different chains:
-    void assertPromiseError(
+    await assertPromiseError(
       multicallerWithMultisend.buildMultiSenderBundle([
         {
           chainId: 1,
@@ -358,7 +358,7 @@ describe("MultiCallerClient", async function () {
       ] as AugmentedTransaction[]),
       "Multisender bundle data mismatch"
     );
-    void assertPromiseError(
+    await assertPromiseError(
       multicallerWithMultisend.buildMultiSenderBundle([
         {
           chainId: 1,

--- a/test/ProfitClient.PriceRetrieval.ts
+++ b/test/ProfitClient.PriceRetrieval.ts
@@ -37,7 +37,7 @@ const tokenPrices: { [addr: string]: string } = Object.fromEntries(
 );
 
 class ProfitClientWithMockPriceClient extends ProfitClient {
-  protected override async updateTokenPrices(): Promise<void> {
+  protected override updateTokenPrices(): Promise<void> {
     const l1Tokens: { [k: string]: L1Token } = Object.fromEntries(
       this.hubPoolClient.getL1Tokens().map((token) => [token["address"], token])
     );
@@ -45,6 +45,8 @@ class ProfitClientWithMockPriceClient extends ProfitClient {
     Object.keys(l1Tokens).forEach((address) => {
       this.tokenPrices[address] = toBNWei(tokenPrices[address]);
     });
+
+    return Promise.resolve();
   }
 }
 
@@ -62,7 +64,7 @@ const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
 let hubPoolClient: MockHubPoolClient;
 let profitClient: ProfitClientWithMockPriceClient; // tested
 
-describe("ProfitClient: Price Retrieval", async function () {
+describe("ProfitClient: Price Retrieval", function () {
   beforeEach(async function () {
     const [owner] = await ethers.getSigners();
 

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -533,9 +533,10 @@ describe("Relayer: Check for Unfilled Deposits and Fill", function () {
     // Fish the DepositWithBlock directly out of the SpokePoolClient;
     // confirm that the realizedLpFeePct is _not_ the UBA systemFee.
     const _deposit = spokePoolClients[originChainId].getDepositsForDestinationChain(destinationChainId)[0];
+    expect(_deposit.realizedLpFeePct).to.not.be.undefined;
     expect(_deposit.depositId).to.eq(deposit1?.depositId);
-    expect(_deposit.realizedLpFeePct?.gt(0)).to.not.be.undefined.and.to.be.true;
-    expect(_deposit.realizedLpFeePct?.eq(expectedSystemFeePct)).to.not.be.undefined.and.to.be.false;
+    expect(_deposit.realizedLpFeePct?.gt(0)).to.be.true;
+    expect(_deposit.realizedLpFeePct?.eq(expectedSystemFeePct)).to.be.false;
 
     await relayerInstance.checkForUnfilledDepositsAndFill();
     expect(lastSpyLogIncludes(spy, "Filling deposit")).to.be.true;

--- a/test/Relayer.RefundRequests.ts
+++ b/test/Relayer.RefundRequests.ts
@@ -21,6 +21,7 @@ import {
   defaultMinDepositConfirmations,
   defaultTokenConfig,
   repaymentChainId,
+  toBN,
 } from "./constants";
 import { MockConfigStoreClient, MockInventoryClient, MockProfitClient } from "./mocks";
 import { MockedMultiCallerClient } from "./mocks/MockMultiCallerClient";
@@ -77,7 +78,7 @@ async function waitOnBlock(spokePoolClient: SpokePoolClient): Promise<void> {
   }
 }
 
-describe("Relayer: Request refunds for cross-chain repayments", async function () {
+describe("Relayer: Request refunds for cross-chain repayments", function () {
   beforeEach(async function () {
     [owner, depositor, relayer] = await ethers.getSigners();
     ({
@@ -186,12 +187,11 @@ describe("Relayer: Request refunds for cross-chain repayments", async function (
       } as unknown as RelayerConfig
     );
 
-    await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // Seed owner to LP.
-    await setupTokensForWallet(spokePool_1, depositor, [erc20_1], null, 10);
-    await setupTokensForWallet(spokePool_2, depositor, [erc20_2], null, 10);
-    await setupTokensForWallet(spokePool_1, relayer, [erc20_1, erc20_2], null, 10);
-    await setupTokensForWallet(spokePool_2, relayer, [erc20_1, erc20_2], null, 10);
-
+    await setupTokensForWallet(spokePool_1, owner, [l1Token], undefined, 100); // Seed owner to LP.
+    await setupTokensForWallet(spokePool_1, depositor, [erc20_1], undefined, 10);
+    await setupTokensForWallet(spokePool_2, depositor, [erc20_2], undefined, 10);
+    await setupTokensForWallet(spokePool_1, relayer, [erc20_1, erc20_2], undefined, 10);
+    await setupTokensForWallet(spokePool_2, relayer, [erc20_1, erc20_2], undefined, 10);
     await l1Token.approve(hubPool.address, amountToLp);
     await hubPool.addLiquidity(l1Token.address, amountToLp);
     await configStore.updateTokenConfig(l1Token.address, defaultTokenConfig);
@@ -299,7 +299,7 @@ describe("Relayer: Request refunds for cross-chain repayments", async function (
 
     // Submit a invalid fill (for a non-existent deposit).
     const fakeDeposit = { ...deposit };
-    fakeDeposit.realizedLpFeePct = fakeDeposit.realizedLpFeePct.sub(1);
+    fakeDeposit.realizedLpFeePct = (fakeDeposit.realizedLpFeePct ?? toBN(0)).sub(1);
     fakeDeposit.relayerFeePct = fakeDeposit.relayerFeePct.sub(fakeDeposit.relayerFeePct);
 
     const fakeFill = await buildFillForRepaymentChain(spokePool_2, relayer, fakeDeposit, 1, spokePoolClient_1.chainId);
@@ -381,12 +381,12 @@ describe("Relayer: Request refunds for cross-chain repayments", async function (
     expect(refundRequests[0].transactionHash).to.equal(transactionHash);
   });
 
-  it.skip("Finds deposits outside of the relayer lookback window", async function () {
+  it.skip("Finds deposits outside of the relayer lookback window", function () {
     // @todo
     return;
   });
 
-  it.skip("Finds fills outside of the relayer lookback window", async function () {
+  it.skip("Finds fills outside of the relayer lookback window", function () {
     // @todo
     return;
   });

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -5,6 +5,7 @@ import {
   MultiCallerClient,
   SpokePoolClient,
   TokenClient,
+  UBAClient,
 } from "../src/clients";
 import { CONFIG_STORE_VERSION } from "../src/common";
 import { Relayer } from "../src/relayer/Relayer";
@@ -50,7 +51,7 @@ let relayerInstance: Relayer;
 let multiCallerClient: MultiCallerClient, profitClient: MockProfitClient;
 let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
-describe("Relayer: Token balance shortfall", async function () {
+describe("Relayer: Token balance shortfall", function () {
   beforeEach(async function () {
     [owner, depositor, relayer] = await ethers.getSigners();
     ({
@@ -123,7 +124,7 @@ describe("Relayer: Token balance shortfall", async function () {
         multiCallerClient,
         inventoryClient: new MockInventoryClient(),
         acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
-        ubaClient: null,
+        ubaClient: null as unknown as UBAClient,
       },
       {
         relayerTokens: [],
@@ -135,9 +136,9 @@ describe("Relayer: Token balance shortfall", async function () {
     );
 
     // Seed Owner and depositor wallets but dont seed relayer to test how the relayer handles being out of funds.
-    await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // Seed owner to LP.
-    await setupTokensForWallet(spokePool_1, depositor, [erc20_1], null, 10);
-    await setupTokensForWallet(spokePool_2, depositor, [erc20_2], null, 10);
+    await setupTokensForWallet(spokePool_1, owner, [l1Token], undefined, 100); // Seed owner to LP.
+    await setupTokensForWallet(spokePool_1, depositor, [erc20_1], undefined, 10);
+    await setupTokensForWallet(spokePool_2, depositor, [erc20_2], undefined, 10);
 
     // Execute large approval so we dont need to worry about this.
     await erc20_1.connect(relayer).approve(spokePool_1.address, toBNWei(100000));

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -57,7 +57,7 @@ let unfilledDeposits: RelayerUnfilledDeposit[] = [];
 
 let _getUnfilledDeposits: () => Promise<RelayerUnfilledDeposit[]>;
 
-describe("Relayer: Unfilled Deposits", async function () {
+describe("Relayer: Unfilled Deposits", function () {
   const sortableEventFields = [
     "blockNumber",
     "blockTimestamp",
@@ -109,7 +109,7 @@ describe("Relayer: Unfilled Deposits", async function () {
       hubPoolClient,
       destinationChainId,
       spokePool2DeploymentBlock,
-      { fromBlock: 0, toBlock: null, maxBlockLookBack: 0 }
+      { fromBlock: 0, toBlock: undefined, maxBlockLookBack: 0 }
     );
 
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
@@ -140,11 +140,11 @@ describe("Relayer: Unfilled Deposits", async function () {
       } as unknown as RelayerConfig
     );
 
-    await setupTokensForWallet(spokePool_1, owner, [l1Token], null, 100); // seed the owner to LP.
-    await setupTokensForWallet(spokePool_1, depositor, [erc20_1], null, 100); // seed the depositor to LP.
-    await setupTokensForWallet(spokePool_2, depositor, [erc20_2], null, 10);
-    await setupTokensForWallet(spokePool_1, relayer, [erc20_1], null, 10);
-    await setupTokensForWallet(spokePool_2, relayer, [erc20_2], null, 10);
+    await setupTokensForWallet(spokePool_1, owner, [l1Token], undefined, 100); // seed the owner to LP.
+    await setupTokensForWallet(spokePool_1, depositor, [erc20_1], undefined, 100); // seed the depositor to LP.
+    await setupTokensForWallet(spokePool_2, depositor, [erc20_2], undefined, 10);
+    await setupTokensForWallet(spokePool_1, relayer, [erc20_1], undefined, 10);
+    await setupTokensForWallet(spokePool_2, relayer, [erc20_2], undefined, 10);
 
     // Approve and add liquidity.
     await enableRoutesOnHubPool(hubPool, [

--- a/test/SpokePool.Utilities.ts
+++ b/test/SpokePool.Utilities.ts
@@ -78,10 +78,17 @@ const generateValidRefundRequest = async (
   return { deposit: deposit as DepositWithBlock, fill: fill as FillWithBlock, refundRequest: refundRequest };
 };
 
-describe("SpokePoolClient: Event Filtering", async function () {
+describe("SpokePoolClient: Event Filtering", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
-    destinationChainId = (await owner.provider.getNetwork()).chainId as number;
+    const provider = owner.provider;
+    expect(provider).to.not.be.undefined;
+    // Added to satisfy TS.
+    if (!provider) {
+      throw new Error("Provider is undefined");
+    }
+
+    destinationChainId = (await provider.getNetwork()).chainId as number;
 
     originChainId = random(100_000, 1_000_000, false);
     repaymentChainId = random(1_000_001, 2_000_000, false);

--- a/test/SpokePoolClient.DepositRoutes.ts
+++ b/test/SpokePoolClient.DepositRoutes.ts
@@ -20,11 +20,11 @@ let owner: SignerWithAddress;
 
 let spokePoolClient: SpokePoolClient;
 
-describe("SpokePoolClient: Deposit Routes", async function () {
+describe("SpokePoolClient: Deposit Routes", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
     // Deploy a minimal spokePool, without using the fixture as this does some route enabling within it.
-    spokePool = await hre.upgrades.deployProxy(await getContractFactory("_MockSpokePool", owner), [
+    spokePool = await hre["upgrades"].deployProxy(await getContractFactory("_MockSpokePool", owner), [
       0,
       owner.address,
       owner.address,

--- a/test/SpokePoolClient.RefundRequests.ts
+++ b/test/SpokePoolClient.RefundRequests.ts
@@ -19,7 +19,7 @@ let _relayer: SignerWithAddress, relayer: string;
 let deploymentBlock: number;
 let spokePoolClient: MockSpokePoolClient;
 
-describe("SpokePoolClient: Refund Requests", async function () {
+describe("SpokePoolClient: Refund Requests", function () {
   beforeEach(async function () {
     [_relayer] = await ethers.getSigners();
     relayer = _relayer.address;

--- a/test/SpokePoolClient.SpeedUp.ts
+++ b/test/SpokePoolClient.SpeedUp.ts
@@ -23,7 +23,7 @@ const destinationChainId2 = destinationChainId + 1;
 
 let spokePoolClient: SpokePoolClient;
 
-describe("SpokePoolClient: SpeedUp", async function () {
+describe("SpokePoolClient: SpeedUp", function () {
   const ignoredFields = [
     "blockNumber",
     "blockTimestamp",

--- a/test/SpokePoolClient.ValidateFill.ts
+++ b/test/SpokePoolClient.ValidateFill.ts
@@ -43,7 +43,7 @@ let spy: sinon.SinonSpy, spyLogger: winston.Logger;
 let spokePoolClient2: SpokePoolClient, hubPoolClient: HubPoolClient;
 let spokePoolClient1: SpokePoolClient, configStoreClient: ConfigStoreClient;
 
-describe("SpokePoolClient: Fill Validation", async function () {
+describe("SpokePoolClient: Fill Validation", function () {
   beforeEach(async function () {
     [owner, depositor, relayer] = await ethers.getSigners();
     // Creat two spoke pools: one to act as the source and the other to act as the destination.
@@ -255,7 +255,7 @@ describe("SpokePoolClient: Fill Validation", async function () {
     expect(searchRange2.low).to.be.lessThanOrEqual(deposit1Block);
 
     // Searching for deposit ID 3 that doesn't exist yet should throw.
-    void assertPromiseError(
+    await assertPromiseError(
       spokePoolClient1._getBlockRangeForDepositId(3, spokePool1DeploymentBlock, spokePoolClient1.latestBlockNumber, 10),
       "Failed to find deposit ID"
     );

--- a/test/SpokePoolClient.deposits.ts
+++ b/test/SpokePoolClient.deposits.ts
@@ -20,7 +20,7 @@ const destinationChainId2 = destinationChainId + 1;
 
 let spokePoolClient: SpokePoolClient;
 
-describe("SpokePoolClient: Deposits", async function () {
+describe("SpokePoolClient: Deposits", function () {
   beforeEach(async function () {
     [, depositor1, depositor2] = await ethers.getSigners();
     ({ spokePool, erc20, destErc20, weth, deploymentBlock } = await deploySpokePoolWithToken(originChainId));

--- a/test/SpokePoolClient.fills.ts
+++ b/test/SpokePoolClient.fills.ts
@@ -22,7 +22,7 @@ const originChainId2 = originChainId + 1;
 
 let spokePoolClient: SpokePoolClient;
 
-describe("SpokePoolClient: Fills", async function () {
+describe("SpokePoolClient: Fills", function () {
   beforeEach(async function () {
     [, depositor, relayer1, relayer2] = await ethers.getSigners();
     ({ spokePool, erc20, destErc20, weth, deploymentBlock } = await deploySpokePoolWithToken(

--- a/test/TokenClient.Approval.ts
+++ b/test/TokenClient.Approval.ts
@@ -1,5 +1,5 @@
 import { interfaceName } from "@uma/common";
-import { HubPoolClient, SpokePoolClient, TokenClient } from "../src/clients";
+import { ConfigStoreClient, HubPoolClient, SpokePoolClient, TokenClient } from "../src/clients";
 import {
   Contract,
   MAX_UINT_VAL,
@@ -27,7 +27,7 @@ let owner: SignerWithAddress, spy: sinon.SinonSpy, spyLogger: winston.Logger;
 let tokenClient: TokenClient; // tested
 let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
-describe("TokenClient: Origin token approval", async function () {
+describe("TokenClient: Origin token approval", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
     ({ spy, spyLogger } = createSpyLogger());
@@ -71,7 +71,7 @@ describe("TokenClient: Origin token approval", async function () {
 
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
 
-    const hubPoolClient = new HubPoolClient(createSpyLogger().spyLogger, hubPool, null);
+    const hubPoolClient = new HubPoolClient(createSpyLogger().spyLogger, hubPool, null as unknown as ConfigStoreClient);
     tokenClient = new TokenClient(spyLogger, owner.address, spokePoolClients, hubPoolClient);
   });
 

--- a/test/TokenClient.BalanceAlowance.ts
+++ b/test/TokenClient.BalanceAlowance.ts
@@ -14,7 +14,7 @@ import {
   zeroAddress,
 } from "./utils";
 
-import { HubPoolClient, SpokePoolClient, TokenClient } from "../src/clients"; // Tested
+import { ConfigStoreClient, HubPoolClient, SpokePoolClient, TokenClient } from "../src/clients"; // Tested
 
 let spokePool_1: Contract, spokePool_2: Contract;
 let erc20_1: Contract, weth_1: Contract, erc20_2: Contract, weth_2: Contract;
@@ -23,7 +23,7 @@ let owner: SignerWithAddress, spyLogger: winston.Logger;
 let tokenClient: TokenClient; // tested
 let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
-describe("TokenClient: Balance and Allowance", async function () {
+describe("TokenClient: Balance and Allowance", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
     ({ spyLogger } = createSpyLogger());
@@ -58,7 +58,7 @@ describe("TokenClient: Balance and Allowance", async function () {
     );
 
     const spokePoolClients = { [destinationChainId]: spokePoolClient_1, [originChainId]: spokePoolClient_2 };
-    const hubPoolClient = new HubPoolClient(createSpyLogger().spyLogger, hubPool, null);
+    const hubPoolClient = new HubPoolClient(createSpyLogger().spyLogger, hubPool, null as unknown as ConfigStoreClient);
 
     tokenClient = new TokenClient(spyLogger, owner.address, spokePoolClients, hubPoolClient);
   });

--- a/test/TokenClient.TokenShortfall.ts
+++ b/test/TokenClient.TokenShortfall.ts
@@ -24,7 +24,7 @@ let owner: SignerWithAddress, spyLogger: winston.Logger;
 let tokenClient: TokenClient; // tested
 let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
-describe("TokenClient: Token shortfall", async function () {
+describe("TokenClient: Token shortfall", function () {
   beforeEach(async function () {
     [owner] = await ethers.getSigners();
     ({ spyLogger } = createSpyLogger());

--- a/test/TransactionClient.ts
+++ b/test/TransactionClient.ts
@@ -10,8 +10,8 @@ const address = randomAddress(); // Test contract address
 const method = "testMethod";
 let txnClient: MockedTransactionClient;
 
-describe("TransactionClient", async function () {
-  beforeEach(async function () {
+describe("TransactionClient", function () {
+  beforeEach(function () {
     txnClient = new MockedTransactionClient(spyLogger);
   });
 

--- a/test/UBAClient.validateFlow.ts
+++ b/test/UBAClient.validateFlow.ts
@@ -422,11 +422,17 @@ describe("UBAClient: Flow validation", function () {
           // Don't add inflow to uba bundle state.
 
           // Throws errors if inflow is before, after, or in same bundle as outflow.
-          void assertPromiseError(ubaClient.validateFlow(outflow), "Could not find matched deposit in same bundle");
+          await assertPromiseError(ubaClient.validateFlow(outflow), "Could not find matched deposit in same bundle");
           outflow.matchedDeposit.blockNumber = expectedBlockRanges[originChainId][0].start - 1;
-          void assertPromiseError(ubaClient.validateFlow(outflow), "Could not find bundle block range containing flow");
+          await assertPromiseError(
+            ubaClient.validateFlow(outflow),
+            "Could not find bundle block range containing flow"
+          );
           outflow.matchedDeposit.blockNumber = expectedBlockRanges[originChainId][0].end + 1;
-          void assertPromiseError(ubaClient.validateFlow(outflow), "Could not find bundle block range containing flow");
+          await assertPromiseError(
+            ubaClient.validateFlow(outflow),
+            "Could not find bundle block range containing flow"
+          );
         });
       });
     });

--- a/test/UBAClientUtilities.ts
+++ b/test/UBAClientUtilities.ts
@@ -94,7 +94,7 @@ describe("UBAClientUtilities", function () {
     );
   };
   describe("getUbaActivationBundleStartBlocks", function () {
-    it("If uba activation block is not set", async function () {
+    it("If uba activation block is not set", function () {
       configStoreClient.setUBAActivationBlock(undefined);
       expect(() => getUbaActivationBundleStartBlocks(hubPoolClient)).to.throw(/UBA was not activated yet/);
     });
@@ -119,7 +119,7 @@ describe("UBAClientUtilities", function () {
         chainIds.map((chainId) => expectedBlockRanges[chainId][0].start)
       );
     });
-    it("If no validated proposals after UBA activation block, returns next bundle start blocks", async function () {
+    it("If no validated proposals after UBA activation block, returns next bundle start blocks", function () {
       const result = getUbaActivationBundleStartBlocks(hubPoolClient);
       deepEqualsWithBigNumber(
         result,
@@ -145,7 +145,7 @@ describe("UBAClientUtilities", function () {
     });
   });
   describe("getMostRecentBundleBlockRanges", function () {
-    it("Request maxBundleState 0", async function () {
+    it("Request maxBundleState 0", function () {
       // Should return by default single bundle range.
       const result = getMostRecentBundleBlockRanges(chainIds[0], 0, hubPoolClient, spokePoolClients);
       deepEqualsWithBigNumber(result, [
@@ -155,7 +155,7 @@ describe("UBAClientUtilities", function () {
         },
       ]);
     });
-    it("No bundles", async function () {
+    it("No bundles", function () {
       // If no bundles in memory, returns a single bundle range spanning from the spoke pool activation block
       // until the last block searched.
 
@@ -197,7 +197,7 @@ describe("UBAClientUtilities", function () {
     });
   });
   describe("getOpeningRunningBalances", function () {
-    it("No valid bundles", async function () {
+    it("No valid bundles", function () {
       const result = getOpeningRunningBalanceForEvent(
         hubPoolClient,
         0,
@@ -285,7 +285,7 @@ describe("UBAClientUtilities", function () {
       destinationSpokePoolClient: MockSpokePoolClient,
       repaymentSpokePoolClient: MockSpokePoolClient;
 
-    beforeEach(async function () {
+    beforeEach(function () {
       // Deposit spoke pool client:
       chainId = chainIds[0];
       spokePoolClient = spokePoolClients[chainId] as MockSpokePoolClient;
@@ -383,7 +383,7 @@ describe("UBAClientUtilities", function () {
       spokePoolClient.addEvent(event);
       await spokePoolClient.update();
 
-      void assertPromiseError(
+      await assertPromiseError(
         clients.getUBAFlows(tokenSymbol, chainId, spokePoolClients, hubPoolClient),
         "Found a UBA deposit with a defined realizedLpFeePct"
       );

--- a/test/UBAFeeConfig.ts
+++ b/test/UBAFeeConfig.ts
@@ -7,16 +7,16 @@ let config: MockUBAConfig;
 const originChainId = 10;
 const destinationChainId = 137;
 
-describe("UBAFeeConfig", async function () {
-  beforeEach(async function () {
+describe("UBAFeeConfig", function () {
+  beforeEach(function () {
     config = new MockUBAConfig();
   });
-  it("getUbaRewardMultiplier", async function () {
+  it("getUbaRewardMultiplier", function () {
     config = new MockUBAConfig();
     // Default should be 1
     expect(config.getUbaRewardMultiplier("999")).to.equal(toBNWei("1"));
   });
-  it("getIncentivePoolAdjustment", async function () {
+  it("getIncentivePoolAdjustment", function () {
     config = new MockUBAConfig();
     // Default should be 0
     expect(config.getIncentivePoolAdjustment("999")).to.equal(0);
@@ -81,14 +81,14 @@ describe("UBAFeeConfig", async function () {
   });
 
   describe("getBalancingFeeTuples", function () {
-    it("getZeroFeePointOnBalancingFeeCurve", async function () {
+    it("getZeroFeePointOnBalancingFeeCurve", function () {
       config.setBalancingFeeTuple(originChainId, [
         [toBNWei("1"), toBNWei("0")],
         [toBNWei("2"), toBNWei("1")],
       ]);
       expect(config.getZeroFeePointOnBalancingFeeCurve(originChainId)).to.equal(toBNWei("1"));
     });
-    it("isBalancingFeeCurveFlatAtZero", async function () {
+    it("isBalancingFeeCurveFlatAtZero", function () {
       config.setBalancingFeeTuple(originChainId, [[toBNWei("1"), toBNWei("0")]]);
       expect(config.isBalancingFeeCurveFlatAtZero(originChainId)).to.be.false;
       expect(config.isBalancingFeeCurveFlatAtZero(destinationChainId)).to.be.true;

--- a/test/UBAFeeSpokeCalculator.ts
+++ b/test/UBAFeeSpokeCalculator.ts
@@ -16,9 +16,9 @@ const lastValidatedRunningBalance = toBNWei("100");
 const lastValidatedIncentiveRunningBalance = toBNWei("10");
 const startingNetRunningBalanceAdjustment = toBNWei("0");
 
-describe("UBAFeeSpokeCalculator", async function () {
+describe("UBAFeeSpokeCalculator", function () {
   describe("Analog", function () {
-    beforeEach(async function () {
+    beforeEach(function () {
       depositor = randomAddress();
       recipient = randomAddress();
       originToken = randomAddress();
@@ -77,7 +77,7 @@ describe("UBAFeeSpokeCalculator", async function () {
       // Set a curve such that the balancing fee for this inflow should be ~= 10%
       config.setBalancingFeeTuple(originChainId, [[toBNWei("0"), toBNWei("0.1")]]);
     });
-    it("No flows", async function () {
+    it("No flows", function () {
       const result = ubaFeeCalculator.analog.calculateHistoricalRunningBalance(
         [],
         lastValidatedRunningBalance,
@@ -92,7 +92,7 @@ describe("UBAFeeSpokeCalculator", async function () {
       expect(result.incentiveBalance).to.equal(lastValidatedIncentiveRunningBalance);
       expect(result.netRunningBalanceAdjustment).to.equal(0);
     });
-    it("running balances are accumulated correctly", async function () {
+    it("running balances are accumulated correctly", function () {
       // This is a simple test with simple flows and no thresholds. Check that a deposit adds to a running balance
       // and fills and refunds subtract from the running balance. Check that the balancing fee is added only to
       // the incentive balance.
@@ -136,7 +136,7 @@ describe("UBAFeeSpokeCalculator", async function () {
       expect(result.incentiveBalance).to.equal(lastValidatedIncentiveRunningBalance.add(expectedBalancingFeeTotal));
       expect(result.netRunningBalanceAdjustment).to.equal(0);
     });
-    it("Upper bound threshold triggered by deposit", async function () {
+    it("Upper bound threshold triggered by deposit", function () {
       // Set hurdle such that next deposit triggers it.
       const upperBoundThreshold = { threshold: toBNWei("100"), target: toBNWei("0") };
       config.setBalanceTriggerThreshold(originChainId, tokenSymbol, {
@@ -192,7 +192,7 @@ describe("UBAFeeSpokeCalculator", async function () {
       expect(result.incentiveBalance).to.equal(lastValidatedIncentiveRunningBalance.add(expectedBalancingFeeTotal));
       expect(result.netRunningBalanceAdjustment).to.equal(expectedNetRunningAdjustment);
     });
-    it("Upper bound threshold triggered by next flow", async function () {
+    it("Upper bound threshold triggered by next flow", function () {
       // If the threshold is reset at a certain time, the current running balance can be so high over the threshold
       // that the next flow, even if its an outflow, can trigger the upper bound.
 
@@ -236,7 +236,7 @@ describe("UBAFeeSpokeCalculator", async function () {
       expect(result.incentiveBalance).to.equal(lastValidatedIncentiveRunningBalance.add(expectedBalancingFeeForFill));
       expect(result.netRunningBalanceAdjustment).to.equal(expectedNetRunningAdjustment);
     });
-    it("Lower bound threshold triggered by refund", async function () {
+    it("Lower bound threshold triggered by refund", function () {
       // Replicate the balancing fee computation used in getEventFee
       const expectedBalancingFeeForFill = ubaFeeCalculator.UBAFeeUtility.computePiecewiseLinearFunction(
         config.getBalancingFeeTuples(originChainId),
@@ -288,7 +288,7 @@ describe("UBAFeeSpokeCalculator", async function () {
       expect(result.incentiveBalance).to.equal(lastValidatedIncentiveRunningBalance.add(expectedBalancingFeeTotal));
       expect(result.netRunningBalanceAdjustment).to.equal(expectedNetRunningAdjustment);
     });
-    it("Lower bound threshold triggered by next flow", async function () {
+    it("Lower bound threshold triggered by next flow", function () {
       // If the threshold is reset at a certain time, the current running balance can be so low under the threshold
       // that the next flow, even if its an inflow, can trigger the lower bound.
 
@@ -329,7 +329,7 @@ describe("UBAFeeSpokeCalculator", async function () {
       );
       expect(result.netRunningBalanceAdjustment).to.equal(expectedNetRunningAdjustment);
     });
-    it("Multiple net running adjustments are applied in a flow sequence", async function () {
+    it("Multiple net running adjustments are applied in a flow sequence", function () {
       // Set hurdle such that first the deposit triggers the upper bound, and then the reset to the target
       // minus the fill triggers the lower bound.
       const upperBoundThreshold = { threshold: toBNWei("100"), target: toBNWei("50") };
@@ -391,7 +391,7 @@ describe("UBAFeeSpokeCalculator", async function () {
         expectedNetRunningAdjustmentFromDeposit.add(expectedNetRunningAdjustmentFromFill)
       );
     });
-    it("Throws if incentive fee for any flow is greater than incentive balance", async function () {
+    it("Throws if incentive fee for any flow is greater than incentive balance", function () {
       const flows: (UbaFlow & { incentiveFee: BigNumber })[] = [
         {
           ...(deposit as UbaInflow),

--- a/test/mocks/MockAdapterManager.ts
+++ b/test/mocks/MockAdapterManager.ts
@@ -11,7 +11,7 @@ export class MockAdapterManager extends AdapterManager {
   } = {};
 
   public mockedOutstandingCrossChainTransfers: { [chainId: number]: OutstandingTransfers } = {};
-  async sendTokenCrossChain(
+  sendTokenCrossChain(
     _address: string,
     chainId: number,
     l1Token: string,
@@ -22,7 +22,7 @@ export class MockAdapterManager extends AdapterManager {
     }
     const hash = createRandomBytes32();
     this.tokensSentCrossChain[chainId][l1Token] = { amount, hash };
-    return { hash } as TransactionResponse;
+    return Promise.resolve({ hash } as TransactionResponse);
   }
 
   setSupportedChains(chains: number[]): void {
@@ -32,12 +32,12 @@ export class MockAdapterManager extends AdapterManager {
     return this.adapterChains ?? super.supportedChains();
   }
 
-  override async getOutstandingCrossChainTokenTransferAmount(
+  override getOutstandingCrossChainTokenTransferAmount(
     chainId: number,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _l1Tokens: string[]
   ): Promise<OutstandingTransfers> {
-    return this.mockedOutstandingCrossChainTransfers[chainId];
+    return Promise.resolve(this.mockedOutstandingCrossChainTransfers[chainId]);
   }
 
   setMockedOutstandingCrossChainTransfers(chainId: number, address: string, l1Token: string, amount: BigNumber): void {

--- a/test/mocks/MockBundleDataClient.ts
+++ b/test/mocks/MockBundleDataClient.ts
@@ -5,12 +5,12 @@ export class MockBundleDataClient extends BundleDataClient {
   private pendingBundleRefunds: FillsToRefund = {};
   private nextBundleRefunds: FillsToRefund = {};
 
-  async getPendingRefundsFromValidBundles(): Promise<FillsToRefund[]> {
-    return [this.pendingBundleRefunds];
+  getPendingRefundsFromValidBundles(): Promise<FillsToRefund[]> {
+    return Promise.resolve([this.pendingBundleRefunds]);
   }
 
-  async getNextBundleRefunds(): Promise<FillsToRefund> {
-    return this.nextBundleRefunds;
+  getNextBundleRefunds(): Promise<FillsToRefund> {
+    return Promise.resolve(this.nextBundleRefunds);
   }
 
   setReturnedPendingBundleRefunds(refunds: FillsToRefund): void {

--- a/test/mocks/MockInventoryClient.ts
+++ b/test/mocks/MockInventoryClient.ts
@@ -5,7 +5,7 @@ export class MockInventoryClient extends InventoryClient {
     super(null, null, null, null, null, null, null, null, null);
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async determineRefundChainId(_deposit: Deposit): Promise<number> {
-    return 1;
+  determineRefundChainId(_deposit: Deposit): Promise<number> {
+    return Promise.resolve(1);
   }
 }

--- a/test/mocks/MockMultiCallerClient.ts
+++ b/test/mocks/MockMultiCallerClient.ts
@@ -10,7 +10,7 @@ export class MockedMultiCallerClient extends MultiCallerClient {
   // By default return undefined multisender so dataworker can just fallback to calling Multicaller instead
   // of having to deploy a Multisend2 on this network.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async _getMultisender(_: number): Promise<Contract | undefined> {
-    return this.multisend;
+  _getMultisender(_: number): Promise<Contract | undefined> {
+    return Promise.resolve(this.multisend);
   }
 }

--- a/test/mocks/MockTransactionClient.ts
+++ b/test/mocks/MockTransactionClient.ts
@@ -27,7 +27,7 @@ export class MockedTransactionClient extends TransactionClient {
     return result !== undefined && result !== txnClientPassResult;
   }
 
-  protected override async _simulate(txn: AugmentedTransaction): Promise<TransactionSimulationResult> {
+  protected override _simulate(txn: AugmentedTransaction): Promise<TransactionSimulationResult> {
     const fail = this.txnFailure(txn);
 
     this.logger.debug({
@@ -38,17 +38,14 @@ export class MockedTransactionClient extends TransactionClient {
 
     const gasLimit = this.gasLimit ?? this.randomGasLimit();
 
-    return {
+    return Promise.resolve({
       transaction: { ...txn, gasLimit },
       succeed: !fail,
       reason: fail ? this.txnFailureReason(txn) : "",
-    };
+    });
   }
 
-  protected override async _submit(
-    txn: AugmentedTransaction,
-    nonce: number | null = null
-  ): Promise<TransactionResponse> {
+  protected override _submit(txn: AugmentedTransaction, nonce: number | null = null): Promise<TransactionResponse> {
     if (this.txnFailure(txn)) {
       return Promise.reject(this.txnFailureReason(txn));
     }
@@ -67,6 +64,6 @@ export class MockedTransactionClient extends TransactionClient {
       txn: txnResponse,
     });
 
-    return txnResponse;
+    return Promise.resolve(txnResponse);
   }
 }

--- a/test/mocks/MockUBAClient.ts
+++ b/test/mocks/MockUBAClient.ts
@@ -70,7 +70,7 @@ export class MockUBAClient extends UBAClient {
     return this.flows[chainId]?.[tokenSymbol] ?? [];
   }
 
-  async validateFlow(flow: interfaces.UbaFlow): Promise<clients.ModifiedUBAFlow | undefined> {
+  validateFlow(flow: interfaces.UbaFlow): Promise<clients.ModifiedUBAFlow | undefined> {
     return super.validateFlow(flow);
   }
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,9 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "include": [".eslintrc.js", "index.ts", "./src", "./scripts", "./test", "./deploy", "./tasks"],
-  "exclude": ["artifacts", "cache", "dist", "node_modules"],
-  "compilerOptions": {
-    "target": "es6",
-    "module": "commonjs"
-  }
+  "exclude": ["artifacts", "cache", "dist", "node_modules"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,5 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {},
   "include": ["./test", "./src"]
 }


### PR DESCRIPTION
This PR enforces that all functions marked with `async` must have at least one `await` within them. This is for two reasons: firstly, it provides a layer of code consistency. Secondly (and more importantly), it can help prevent accidental cases where we should use await but don't.