### PR TITLE
fix(Dataworker): Dereference originChainId by index, not key

### DIFF
--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -85,7 +85,7 @@ export function updateRunningBalanceForEarlyDeposit(
   updateAmount: BigNumber
 ): void {
   // deposit.args is a pure array; there are no mapping to be dereferenced.
-  const originChainId = deposit.args[1].toNumber();
+  const originChainId = Number(deposit.args[1].toString());
   const originToken = deposit.args[6];
 
   const l1TokenCounterpart = hubPoolClient.getL1TokenCounterpartAtBlock(

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -86,10 +86,11 @@ export function updateRunningBalanceForEarlyDeposit(
 ): void {
   // deposit.args is a pure array; there are no mapping to be dereferenced.
   const originChainId = deposit.args[1].toNumber();
+  const originToken = deposit.args[6];
 
   const l1TokenCounterpart = hubPoolClient.getL1TokenCounterpartAtBlock(
     originChainId,
-    deposit.args.originToken,
+    originToken,
     // TODO: this must be handled s.t. it doesn't depend on when this is run.
     // For now, tokens do not change their mappings often, so this will work, but
     // to keep the system resilient, this must be updated.

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -84,17 +84,21 @@ export function updateRunningBalanceForEarlyDeposit(
   deposit: typechain.FundsDepositedEvent,
   updateAmount: BigNumber
 ): void {
+  // deposit.args is a pure array; there are no mapping to be dereferenced.
+  const originChainId = deposit.args[1].toNumber();
+
   const l1TokenCounterpart = hubPoolClient.getL1TokenCounterpartAtBlock(
-    Number(deposit.args.originChainId.toString()),
+    originChainId,
     deposit.args.originToken,
     // TODO: this must be handled s.t. it doesn't depend on when this is run.
     // For now, tokens do not change their mappings often, so this will work, but
     // to keep the system resilient, this must be updated.
     hubPoolClient.latestBlockNumber
   );
+
   updateRunningBalance(
     runningBalances,
-    Number(deposit.args.originChainId.toString()),
+    originChainId,
     l1TokenCounterpart,
     updateAmount
   );

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -97,12 +97,7 @@ export function updateRunningBalanceForEarlyDeposit(
     hubPoolClient.latestBlockNumber
   );
 
-  updateRunningBalance(
-    runningBalances,
-    originChainId,
-    l1TokenCounterpart,
-    updateAmount
-  );
+  updateRunningBalance(runningBalances, originChainId, l1TokenCounterpart, updateAmount);
 }
 
 export function addLastRunningBalance(


### PR DESCRIPTION
Temporary fix to resolve an issue with future quoteTimestamps. We need a more robust solution than this in the long run.