### PR TITLE
chore: Update SDK-v2 version so that UBA min version is bumped

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@across-protocol/contracts-v2": "2.4.3",
-    "@across-protocol/sdk-v2": "0.15.22",
+    "@across-protocol/sdk-v2": "0.15.24",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -37,10 +37,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.15.22":
-  version "0.15.22"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.15.22.tgz#a33c772005a781e1bf4492a32b7f41dae23d4051"
-  integrity sha512-EniItgtgTRvnjP/tWQze71F9+/uOqdg7IUugmaBhrJQ3heeySFDMgooJZGAgjmVJMrTfZXWKMaarDpy5nQAifg==
+"@across-protocol/sdk-v2@0.15.24":
+  version "0.15.24"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.15.24.tgz#aa9528769e379c0faa770b032a524bd1707d4a9b"
+  integrity sha512-FdDcDEJ8z4nhqZ2ENOBJ4ZUZTMTZNrz8ADCaDgFdvUFK6J+Iv617PCiJBbJbQdC4n3HOsDB8Anovu+BBSd2ncQ==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/contracts-v2" "^2.4.3"


### PR DESCRIPTION
Neccessary to get this in before we can bump the VERSION field in the config store contract before going back to https://github.com/across-protocol/relayer-v2/pull/937