### PR TITLE
fix: Bump config store version

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -4,7 +4,7 @@ import { utils } from "@across-protocol/sdk-v2";
 // Maximum supported version of the configuration loaded into the Across ConfigStore.
 // It protects bots from running outdated code against newer version of the on-chain config store.
 // @dev Incorrectly setting this value may lead to incorrect behaviour and potential loss of funds.
-export const CONFIG_STORE_VERSION = 1;
+export const CONFIG_STORE_VERSION = 2;
 
 // The first version where UBA is in effect.
 export const { UBA_MIN_CONFIG_STORE_VERSION } = utils;


### PR DESCRIPTION
This needs to match the latest version in the config store, which is now 2