### PR TITLE
refactor: Remove UMA interfaces lookup

### DIFF
--- a/test/TokenClient.Approval.ts
+++ b/test/TokenClient.Approval.ts
@@ -1,4 +1,3 @@
-import { interfaceName } from "@uma/common";
 import { HubPoolClient, SpokePoolClient, TokenClient } from "../src/clients";
 import {
   Contract,
@@ -49,8 +48,8 @@ describe("TokenClient: Origin token approval", async function () {
     const store = await (
       await getContractFactory("Store", owner)
     ).deploy({ rawValue: "0" }, { rawValue: "0" }, zeroAddress);
-    await finder.changeImplementationAddress(utf8ToHex(interfaceName.CollateralWhitelist), collateralWhitelist.address);
-    await finder.changeImplementationAddress(utf8ToHex(interfaceName.Store), store.address);
+    await finder.changeImplementationAddress(utf8ToHex("CollateralWhitelist"), collateralWhitelist.address);
+    await finder.changeImplementationAddress(utf8ToHex("Store"), store.address);
     ({ hubPool, l1Token_1 } = await deployAndConfigureHubPool(owner, [], finder.address, zeroAddress));
     await collateralWhitelist.addToWhitelist(l1Token_1.address);
     await hubPool.setBond(l1Token_1.address, toBNWei("5"));

--- a/test/fixtures/UmaEcosystemFixture.ts
+++ b/test/fixtures/UmaEcosystemFixture.ts
@@ -2,7 +2,6 @@ import * as utils from "@across-protocol/contracts-v2/dist/test-utils";
 import { Contract } from "ethers";
 import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { utf8ToHex, identifier, refundProposalLiveness } from "@across-protocol/contracts-v2/dist/test-utils";
-import { interfaceName } from "@uma/common";
 
 export async function setupUmaEcosystem(owner: SignerWithAddress): Promise<{
   timer: Contract;
@@ -25,11 +24,11 @@ export async function setupUmaEcosystem(owner: SignerWithAddress): Promise<{
   const store = await (
     await utils.getContractFactory("Store", owner)
   ).deploy({ rawValue: "0" }, { rawValue: "0" }, timer.address);
-  await finder.changeImplementationAddress(utf8ToHex(interfaceName.CollateralWhitelist), collateralWhitelist.address);
-  await finder.changeImplementationAddress(utf8ToHex(interfaceName.IdentifierWhitelist), identifierWhitelist.address);
-  await finder.changeImplementationAddress(utf8ToHex(interfaceName.SkinnyOptimisticOracle), optimisticOracle.address);
-  await finder.changeImplementationAddress(utf8ToHex(interfaceName.Store), store.address);
-  await finder.changeImplementationAddress(utf8ToHex(interfaceName.Oracle), mockOracle.address);
+  await finder.changeImplementationAddress(utf8ToHex("CollateralWhitelist"), collateralWhitelist.address);
+  await finder.changeImplementationAddress(utf8ToHex("IdentifierWhitelist"), identifierWhitelist.address);
+  await finder.changeImplementationAddress(utf8ToHex("SkinnyOptimisticOracle"), optimisticOracle.address);
+  await finder.changeImplementationAddress(utf8ToHex("Store"), store.address);
+  await finder.changeImplementationAddress(utf8ToHex("Oracle"), mockOracle.address);
   await identifierWhitelist.addSupportedIdentifier(identifier);
   return {
     timer,


### PR DESCRIPTION
These names change very rarely, and we only have need for a small number of the complete set.