### PR TITLE
feat: Support reading mnemonic or private key from file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ typechain*
 .DS_Store
 dump.rdb*
 .idea
+.mnemonic
+.keyfile
+.secret
 
 # Hardhat files
 cache

--- a/src/utils/CLIUtils.ts
+++ b/src/utils/CLIUtils.ts
@@ -12,7 +12,7 @@ export function retrieveSignerFromCLIArgs(): Promise<Wallet> {
   // Resolve the wallet type & verify that it is valid.
   const keyType = (args.wallet as string) ?? "mnemonic";
   if (!isValidKeyType(keyType)) {
-    throw new Error(`Unsupported key type (${keyType}); expected "mnemonic", "privateKey" or "gckms"`);
+    throw new Error(`Unsupported key type (${keyType}); expected "secret", "mnemonic", "privateKey" or "gckms"`);
   }
 
   // Build out the signer options to pass to the signer utils.
@@ -30,6 +30,6 @@ export function retrieveSignerFromCLIArgs(): Promise<Wallet> {
  * @param keyType The key type to check.
  * @returns True if the key type is valid, false otherwise.
  */
-function isValidKeyType(keyType: unknown): keyType is "mnemonic" | "privateKey" | "gckms" {
-  return ["mnemonic", "privateKey", "gckms"].includes(keyType as string);
+function isValidKeyType(keyType: unknown): keyType is "secret" | "mnemonic" | "privateKey" | "gckms" {
+  return ["secret", "mnemonic", "privateKey", "gckms"].includes(keyType as string);
 }


### PR DESCRIPTION
Rather than read the mnemonic or private key directly from .env, specify the location of a separate file via the SECRET env var. Then, open that file and read the mnemonic or key from there. Global fs scope is applied to the location, so it can be located in a totally different path, and can even have more restrictive permissions. This significantly reduces the chance of leaking critical secrets - i.e. when sharing screen.

A simple regex is applied to determine whether the format matches a private key, and if not, it's assumed to be a mnemonic. This should make it easier to manage for operators.