### PR TITLE
improve(inventory-manager): Check ERC20 balance before submitting cross chain bridge

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -318,7 +318,7 @@ export class InventoryClient {
         // balance then this logic ensures that we only fill the first n number of chains where we can.
         if (amount.lt(balance)) {
           // As a precautionary step before proceeding, check that the token balance for the token we're about to send
-          // hasn't changed on L1. It's possible its changed since we updated the inventory due to one or more of the 
+          // hasn't changed on L1. It's possible its changed since we updated the inventory due to one or more of the
           // RPC's returning slowly.
           const expectedBalance = this.tokenClient.getBalance(1, l1Token);
           const tokenContract = new Contract(l1Token, ERC20.abi, this.hubPoolClient.hubPool.signer);
@@ -326,24 +326,25 @@ export class InventoryClient {
           if (!expectedBalance.eq(currentBalance)) {
             this.logger.warn({
               at: "InventoryClient",
-              message: `🚧 Token balance in relayer on Ethereum changed before sending cross chain transfer, skipping rebalance`,
+              message:
+                "🚧 Token balance in relayer on Ethereum changed before sending cross chain transfer, skipping rebalance",
               l1Token,
               l2ChainId: chainId,
               expectedBalance,
-              currentBalance
+              currentBalance,
             });
             continue;
           } else {
             this.logger.debug({
               at: "InventoryClient",
-              message: `Token balance in relayer on Ethereum is as expected, sending cross chain transfer`,
+              message: "Token balance in relayer on Ethereum is as expected, sending cross chain transfer",
               l1Token,
               l2ChainId: chainId,
-              expectedBalance
+              expectedBalance,
             });
             possibleRebalances.push(rebalance);
             // Decrement token balance in client for this chain and increment cross chain counter.
-            this.trackCrossChainTransfer(l1Token, amount, chainId);  
+            this.trackCrossChainTransfer(l1Token, amount, chainId);
           }
         } else {
           // Extract unexecutable rebalances for logging.

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -327,7 +327,7 @@ export class InventoryClient {
             this.logger.warn({
               at: "InventoryClient",
               message:
-                "🚧 Token balance in relayer on Ethereum changed before sending cross chain transfer, skipping rebalance",
+                "🚧 Token balance on Ethereum changed before sending transaction, skipping rebalance",
               l1Token,
               l2ChainId: chainId,
               expectedBalance,

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -326,8 +326,7 @@ export class InventoryClient {
           if (!expectedBalance.eq(currentBalance)) {
             this.logger.warn({
               at: "InventoryClient",
-              message:
-                "🚧 Token balance on Ethereum changed before sending transaction, skipping rebalance",
+              message: "🚧 Token balance on Ethereum changed before sending transaction, skipping rebalance",
               l1Token,
               l2ChainId: chainId,
               expectedBalance,

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -319,7 +319,7 @@ export class InventoryClient {
         if (amount.lt(balance)) {
           // As a precautionary step before proceeding, check that the token balance for the token we're about to send
           // hasn't changed on L1. It's possible its changed since we updated the inventory due to one or more of the
-          // RPC's returning slowly.
+          // RPC's returning slowly, leading to concurrent/overlapping instances of the bot running.
           const expectedBalance = this.tokenClient.getBalance(1, l1Token);
           const tokenContract = new Contract(l1Token, ERC20.abi, this.hubPoolClient.hubPool.signer);
           const currentBalance = await tokenContract.balanceOf(this.relayer);

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -11,6 +11,7 @@ import {
   DefaultLogLevels,
   TransactionResponse,
   AnyObject,
+  ERC20,
 } from "../utils";
 import { HubPoolClient, TokenClient, BundleDataClient } from ".";
 import { AdapterManager, CrossChainTransferClient } from "./bridges";
@@ -316,9 +317,34 @@ export class InventoryClient {
         // the rebalance to this particular chain. Note that if the sum of all rebalances required exceeds the l1
         // balance then this logic ensures that we only fill the first n number of chains where we can.
         if (amount.lt(balance)) {
-          possibleRebalances.push(rebalance);
-          // Decrement token balance in client for this chain and increment cross chain counter.
-          this.trackCrossChainTransfer(l1Token, amount, chainId);
+          // As a precautionary step before proceeding, check that the token balance for the token we're about to send
+          // hasn't changed on L1. It's possible its changed since we updated the inventory due to one or more of the 
+          // RPC's returning slowly.
+          const expectedBalance = this.tokenClient.getBalance(1, l1Token);
+          const tokenContract = new Contract(l1Token, ERC20.abi, this.hubPoolClient.hubPool.signer);
+          const currentBalance = await tokenContract.balanceOf(this.relayer);
+          if (!expectedBalance.eq(currentBalance)) {
+            this.logger.warn({
+              at: "InventoryClient",
+              message: `🚧 Token balance in relayer on Ethereum changed before sending cross chain transfer, skipping rebalance`,
+              l1Token,
+              l2ChainId: chainId,
+              expectedBalance,
+              currentBalance
+            });
+            continue;
+          } else {
+            this.logger.debug({
+              at: "InventoryClient",
+              message: `Token balance in relayer on Ethereum is as expected, sending cross chain transfer`,
+              l1Token,
+              l2ChainId: chainId,
+              expectedBalance
+            });
+            possibleRebalances.push(rebalance);
+            // Decrement token balance in client for this chain and increment cross chain counter.
+            this.trackCrossChainTransfer(l1Token, amount, chainId);  
+          }
         } else {
           // Extract unexecutable rebalances for logging.
           unexecutedRebalances.push(rebalance);

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -10,6 +10,7 @@ export class RelayerConfig extends CommonConfig {
   readonly debugProfitability: boolean;
   // Whether token price fetch failures will be ignored when computing relay profitability.
   // If this is false, the relayer will throw an error when fetching prices fails.
+  readonly skipRelays: boolean;
   readonly sendingRelaysEnabled: boolean;
   readonly sendingSlowRelaysEnabled: boolean;
   readonly sendingRefundRequestsEnabled: boolean;
@@ -43,7 +44,8 @@ export class RelayerConfig extends CommonConfig {
       RELAYER_GAS_MULTIPLIER,
       RELAYER_INVENTORY_CONFIG,
       RELAYER_TOKENS,
-      SEND_RELAYS,
+      SUBMIT_TRANSACTIONS,
+      SKIP_RELAYS,
       SEND_SLOW_RELAYS,
       SEND_REFUND_REQUESTS,
       MIN_RELAYER_FEE_PCT,
@@ -131,7 +133,8 @@ export class RelayerConfig extends CommonConfig {
     }
     this.debugProfitability = DEBUG_PROFITABILITY === "true";
     this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
-    this.sendingRelaysEnabled = SEND_RELAYS === "true";
+    this.sendingRelaysEnabled = SUBMIT_TRANSACTIONS === "true";
+    this.skipRelays = SKIP_RELAYS === "true";
     this.sendingRefundRequestsEnabled = SEND_REFUND_REQUESTS !== "false";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
     this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -44,7 +44,7 @@ export class RelayerConfig extends CommonConfig {
       RELAYER_GAS_MULTIPLIER,
       RELAYER_INVENTORY_CONFIG,
       RELAYER_TOKENS,
-      SUBMIT_TRANSACTIONS,
+      SEND_RELAYS,
       SKIP_RELAYS,
       SEND_SLOW_RELAYS,
       SEND_REFUND_REQUESTS,
@@ -133,7 +133,7 @@ export class RelayerConfig extends CommonConfig {
     }
     this.debugProfitability = DEBUG_PROFITABILITY === "true";
     this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
-    this.sendingRelaysEnabled = SUBMIT_TRANSACTIONS === "true";
+    this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.skipRelays = SKIP_RELAYS === "true";
     this.sendingRefundRequestsEnabled = SEND_REFUND_REQUESTS !== "false";
     this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";

--- a/test/InventoryClient.InventoryRebalance.ts
+++ b/test/InventoryClient.InventoryRebalance.ts
@@ -292,7 +292,7 @@ describe("InventoryClient: Rebalancing inventory", async function () {
       .whenCalledWith(owner.address)
       .returns(initialAllocation[1][mainnetUsdc].sub(toMegaWei(1)));
     await inventoryClient.rebalanceInventoryIfNeeded();
-    expect(spyLogIncludes(spy, -2, "balance in relayer on Ethereum changed before sending cross chain transfer")).to.be
+    expect(spyLogIncludes(spy, -2, "Token balance on Ethereum changed")).to.be;
       .true;
 
     // Reset and check again.

--- a/test/InventoryClient.InventoryRebalance.ts
+++ b/test/InventoryClient.InventoryRebalance.ts
@@ -292,8 +292,7 @@ describe("InventoryClient: Rebalancing inventory", async function () {
       .whenCalledWith(owner.address)
       .returns(initialAllocation[1][mainnetUsdc].sub(toMegaWei(1)));
     await inventoryClient.rebalanceInventoryIfNeeded();
-    expect(spyLogIncludes(spy, -2, "Token balance on Ethereum changed")).to.be;
-      .true;
+    expect(spyLogIncludes(spy, -2, "Token balance on Ethereum changed")).to.be.true;
 
     // Reset and check again.
     mainnetUsdcContract.balanceOf.whenCalledWith(owner.address).returns(initialAllocation[1][mainnetUsdc]);


### PR DESCRIPTION
The  `TokenClient` fetches ERC20 balances for the relayer prior to carrying out Relayer duties. This means that there could be a multiple minute delay between balances between fetched and the inventory 
manager executing, exposing the relayer to the risk of sending a duplicate rebalance.

This PR adds a simple check for the ERC20 balance as close to sending the inventory rebalance as possible. The downside is a slower inventory manager run, which is mitigated by a side effect of allowing the bot-runner to refactor the inventory manager out of the relayer. This can be done by setting the new environment variable `SKIP_RELAYS` which will skip the relayer portion of the `relayer/index.ts` run.

Signed-off-by: nicholaspai <npai.nyc@gmail.com>

Fixes ACX1595
