### PR TITLE
improve: Update MockProfitClient ahead of changes

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -97,9 +97,9 @@ export class ProfitClient {
     readonly hubPoolClient: HubPoolClient,
     spokePoolClients: SpokePoolClientsByChain,
     readonly enabledChainIds: number[],
-    readonly defaultMinRelayerFeePct: BigNumber = toBNWei(constants.RELAYER_MIN_FEE_PCT),
-    readonly debugProfitability: boolean = false,
-    protected gasMultiplier: BigNumber = toBNWei(1)
+    readonly defaultMinRelayerFeePct = toBNWei(constants.RELAYER_MIN_FEE_PCT),
+    readonly debugProfitability = false,
+    protected gasMultiplier = toBNWei(1)
   ) {
     // Require 1% <= gasMultiplier <= 400%
     assert(

--- a/test/Relayer.RefundRequests.ts
+++ b/test/Relayer.RefundRequests.ts
@@ -161,7 +161,6 @@ describe("Relayer: Request refunds for cross-chain repayments", async function (
     );
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
-    profitClient.testInit();
 
     relayerInstance = new Relayer(
       relayer.address,

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -109,7 +109,6 @@ describe("Relayer: Token balance shortfall", async function () {
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
-    profitClient.testInit();
 
     relayerInstance = new Relayer(
       relayer.address,

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -109,7 +109,6 @@ describe("Relayer: Unfilled Deposits", async function () {
     multiCallerClient = new MockedMultiCallerClient(spyLogger);
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
-    profitClient.testInit();
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,


### PR DESCRIPTION
Done in preparation for follow-on changes relating to Across messaging:
- Automatically setup gas tokens for known test chains, rather than requiring the user to call MockProfitClient.testInit().
- Add singular setter-like methods for token prices and gas costs.
- Remove some redundant type annotations.