### PR TITLE
improve: Remove relayer testnet incompatibility

### DIFF
--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -84,10 +84,14 @@ export async function constructRelayerClients(
 
   // The relayer will originate cross chain rebalances from both its own EOA address and the atomic depositor address
   // so we should track both for accurate cross-chain inventory management.
-  const adapterManager = new AdapterManager(logger, spokePoolClients, commonClients.hubPoolClient, [
-    baseSigner.address,
-    CONTRACT_ADDRESSES[commonClients.hubPoolClient.chainId].atomicDepositor.address,
-  ]);
+  const atomicDepositor = CONTRACT_ADDRESSES[commonClients.hubPoolClient.chainId]?.atomicDepositor;
+  const monitoredAddresses = [baseSigner.address, atomicDepositor?.address];
+  const adapterManager = new AdapterManager(
+    logger,
+    spokePoolClients,
+    commonClients.hubPoolClient,
+    monitoredAddresses.filter(() => sdkUtils.isDefined)
+  );
 
   const bundleDataClient = new BundleDataClient(
     logger,


### PR DESCRIPTION
The AtomicWethDepositor contract isn't deployed on testnets, so only include it as a monitored address if it is defined on the HubPool chain.