### PR TITLE
fix: :ambulance: resolve double stringify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ dump.rdb*
 cache
 artifacts
 dist
+
+# Debugging files
+*.log

--- a/src/caching/RedisCache.ts
+++ b/src/caching/RedisCache.ts
@@ -30,7 +30,7 @@ export class RedisCache implements interfaces.CachingMechanismInterface {
 
   public async set<T>(key: string, value: T, ttl: number = constants.DEFAULT_CACHING_TTL): Promise<string | undefined> {
     // Call the setRedisKey function to set the value in redis.
-    await setRedisKey(key, JSON.stringify(value), this.redisClient, ttl);
+    await setRedisKey(key, String(value), this.redisClient, ttl);
     // Return key to indicate that the value was set successfully.
     return key;
   }

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -128,5 +128,17 @@ export async function queryHistoricalDepositForFill(
   spokePoolClient: SpokePoolClient,
   fill: Fill
 ): Promise<DepositWithBlock | undefined> {
-  return utils.queryHistoricalDepositForFill(spokePoolClient, fill, await getRedisCache(spokePoolClient.logger));
+  try {
+    return await utils.queryHistoricalDepositForFill(
+      spokePoolClient,
+      fill,
+      await getRedisCache(spokePoolClient.logger)
+    );
+  } catch (e) {
+    spokePoolClient.logger.error({
+      at: "DepositUtils#queryHistoricalDepositForFill",
+      message: e,
+    });
+    throw e;
+  }
 }


### PR DESCRIPTION
The `RedisCache` introduced a double `JSON.stringify` and a `JSON.parse` issue. These ran fine in an isolated environment because `JSON.parse(JSON.parse(JSON.stringify(JSON.stringify(X))))` will compute fine, but key/values clashed with our existing cache. 

This new hot fix removes the double `JSON.stringify` issue that was present with the merge of the latest PR.

The cache should be cleared for good measure.

This was tested using a relayer iteration and a dataworker interation with a lookback of 16 bundles.