### PR TITLE
refactor: Use BlockFinder from SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@uma/common": "2.33.0",
     "@uma/contracts-node": "^0.4.16",
     "@uma/financial-templates-lib": "^2.32.11",
-    "@uma/sdk": "^0.34.2",
     "async": "^3.2.4",
     "axios": "^1.4.0",
     "dotenv": "^16.3.1",

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -1,8 +1,4 @@
-import { utils as sdkUtils } from "@across-protocol/sdk-v2";
-import { getProvider, getRedis, isDefined, setRedisKey, shouldCache } from "./";
-
-type BlockFinder = sdkUtils.BlockFinder;
-const { BlockFinder } = sdkUtils;
+import { BlockFinder, getProvider, getRedis, isDefined, setRedisKey, shouldCache } from "./";
 
 const blockFinders: { [chainId: number]: BlockFinder } = {};
 

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -1,7 +1,10 @@
-import { BlockFinder } from "@uma/financial-templates-lib";
-import { Block, getProvider, getRedis, isDefined, setRedisKey, shouldCache } from "./";
+import { utils as sdkUtils } from "@across-protocol/sdk-v2";
+import { getProvider, getRedis, isDefined, setRedisKey, shouldCache } from "./";
 
-const blockFinders: { [chainId: number]: BlockFinder<Block> } = {};
+type BlockFinder = sdkUtils.BlockFinder;
+const { BlockFinder } = sdkUtils;
+
+const blockFinders: { [chainId: number]: BlockFinder } = {};
 
 /**
  * @notice Return block finder for chain. Loads from in memory blockFinder cache if this function was called before
@@ -9,10 +12,10 @@ const blockFinders: { [chainId: number]: BlockFinder<Block> } = {};
  * @param chainId
  * @returns
  */
-export async function getBlockFinder(chainId: number): Promise<BlockFinder<Block>> {
+export async function getBlockFinder(chainId: number): Promise<BlockFinder> {
   if (!isDefined(blockFinders[chainId])) {
     const providerForChain = await getProvider(chainId);
-    blockFinders[chainId] = new BlockFinder<Block>(providerForChain.getBlock.bind(providerForChain), [], chainId);
+    blockFinders[chainId] = new BlockFinder(providerForChain);
   }
   return blockFinders[chainId];
 }
@@ -29,7 +32,7 @@ export async function getBlockFinder(chainId: number): Promise<BlockFinder<Block
 export async function getBlockForTimestamp(
   chainId: number,
   timestamp: number,
-  blockFinder?: BlockFinder<Block>
+  blockFinder?: BlockFinder
 ): Promise<number> {
   blockFinder ??= await getBlockFinder(chainId);
   const redisClient = await getRedis();

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -1,5 +1,7 @@
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 
+export class BlockFinder extends sdkUtils.BlockFinder {};
+
 export const {
   toBN,
   bnToHex,
@@ -16,5 +18,4 @@ export const {
   blockExplorerLink,
   blockExplorerLinks,
   createShortHexString: shortenHexString,
-  BlockFinder,
 } = sdkUtils;

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -1,6 +1,6 @@
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 
-export class BlockFinder extends sdkUtils.BlockFinder {};
+export class BlockFinder extends sdkUtils.BlockFinder {}
 
 export const {
   toBN,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3301,7 +3301,7 @@
     mocha "^8.3.0"
     node-fetch "^2.6.1"
 
-"@uma/sdk@^0.34.1", "@uma/sdk@^0.34.2":
+"@uma/sdk@^0.34.1":
   version "0.34.2"
   resolved "https://registry.yarnpkg.com/@uma/sdk/-/sdk-0.34.2.tgz#b433b437f750c4afaf2f110209c80c513437eb94"
   integrity sha512-49akhv4eOLjoWvxawciNI9OztfDp2IyuJEuU8ME3BWAaQM+RYurPylKyxCPSzrmlCbx1KSQU97FXDOeH7hP4gg==


### PR DESCRIPTION
This change migrates from the UMA BlockFinder to the Across-local variant and enables us to drop @uma/sdk as a direct dependency. We still inherit it from other packages, though.