### PR TITLE
improve: warn on infinite redis ttl expiration

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -119,6 +119,11 @@ class CacheProvider extends RateLimitedProvider {
   ) {
     super(...jsonRpcConstructorParams);
 
+    logger.info({
+      at: "CacheProvider#constructor",
+      message: `Created cache provider with namespace ${providerCacheNamespace}`,
+    });
+
     if (MAX_REORG_DISTANCE[this.network.chainId] === undefined) {
       throw new Error(`CacheProvider:constructor no MAX_REORG_DISTANCE for chain ${this.network.chainId}`);
     }

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -19,7 +19,12 @@ export class RedisClient {
     private readonly client: _RedisClient,
     private readonly namespace?: string,
     private readonly logger?: winston.Logger
-  ) {}
+  ) {
+    this.logger.info({
+      at: "RedisClient#constructor",
+      message: isDefined(namespace) ? `Created redis client with namespace ${namespace}` : "Created redis client.",
+    });
+  }
 
   private getNamespacedKey(key: string): string {
     return isDefined(this.namespace) ? `${this.namespace}:${key}` : key;

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -35,9 +35,11 @@ export class RedisClient {
   }
 
   async set(key: string, val: string, expirySeconds = constants.DEFAULT_CACHING_TTL): Promise<void> {
+    // Apply namespace to key.
+    key = this.getNamespacedKey(key);
     if (expirySeconds > 0) {
       // EX: Expire key after expirySeconds.
-      await this.client.set(this.getNamespacedKey(key), val, { EX: expirySeconds });
+      await this.client.set(key, val, { EX: expirySeconds });
     } else {
       if (expirySeconds <= 0 && this.logger) {
         this.logger.warn({
@@ -45,7 +47,7 @@ export class RedisClient {
           message: `Tried to set key ${key} with expirySeconds = ${expirySeconds}. This shouldn't be allowed.`,
         });
       }
-      await this.client.set(modifiedKey, val);
+      await this.client.set(key, val);
     }
   }
 


### PR DESCRIPTION
In light of recent cache changes, it was noted that we have an outstanding amount of k/v pairs with infinite expiration. This must be avoided because all data should become stale over time. 

This change alerts GCP if we detect any infinite caching. It is a pass-through warning because we don't have any catching logic in place to handle these errors.