### PR TITLE
improve: disconnect all clients

### DIFF
--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -180,8 +180,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
         break;
       }
     }
-  } catch (error) {
+  } finally {
     await disconnectRedisClients(logger);
-    throw error;
   }
 }

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -1,4 +1,4 @@
-import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, disconnectRedisClient } from "../utils";
+import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, disconnectRedisClients } from "../utils";
 import { spokePoolClientsToProviders } from "../common";
 import { Dataworker } from "./Dataworker";
 import { DataworkerConfig } from "./DataworkerConfig";
@@ -181,7 +181,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
       }
     }
   } catch (error) {
-    await disconnectRedisClient(logger);
+    await disconnectRedisClients(logger);
     throw error;
   }
 }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -11,7 +11,7 @@ import {
   blockExplorerLink,
   getBlockForTimestamp,
   getCurrentTime,
-  disconnectRedisClient,
+  disconnectRedisClients,
   getMultisender,
   winston,
 } from "../utils";
@@ -271,7 +271,7 @@ export async function runFinalizer(_logger: winston.Logger, baseSigner: Wallet):
       }
     }
   } catch (error) {
-    await disconnectRedisClient(logger);
+    await disconnectRedisClients(logger);
     throw error;
   }
 }

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -270,8 +270,7 @@ export async function runFinalizer(_logger: winston.Logger, baseSigner: Wallet):
         break;
       }
     }
-  } catch (error) {
+  } finally {
     await disconnectRedisClients(logger);
-    throw error;
   }
 }

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -72,8 +72,7 @@ export async function runMonitor(_logger: winston.Logger, baseSigner: Wallet): P
         break;
       }
     }
-  } catch (error) {
+  } finally {
     await disconnectRedisClients(logger);
-    throw error;
   }
 }

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -1,4 +1,4 @@
-import { winston, processEndPollingLoop, config, startupLogLevel, Wallet, disconnectRedisClient } from "../utils";
+import { winston, processEndPollingLoop, config, startupLogLevel, Wallet, disconnectRedisClients } from "../utils";
 import { Monitor } from "./Monitor";
 import { MonitorConfig } from "./MonitorConfig";
 import { constructMonitorClients } from "./MonitorClientHelper";
@@ -73,7 +73,7 @@ export async function runMonitor(_logger: winston.Logger, baseSigner: Wallet): P
       }
     }
   } catch (error) {
-    await disconnectRedisClient(logger);
+    await disconnectRedisClients(logger);
     throw error;
   }
 }

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -51,8 +51,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Wallet): P
         break;
       }
     }
-  } catch (error) {
+  } finally {
     await disconnectRedisClients(logger);
-    throw error;
   }
 }

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -1,5 +1,5 @@
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
-import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, disconnectRedisClient } from "../utils";
+import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, disconnectRedisClients } from "../utils";
 import { Relayer } from "./Relayer";
 import { RelayerConfig } from "./RelayerConfig";
 import { constructRelayerClients, RelayerClients, updateRelayerClients } from "./RelayerClientHelper";
@@ -52,7 +52,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Wallet): P
       }
     }
   } catch (error) {
-    await disconnectRedisClient(logger);
+    await disconnectRedisClients(logger);
     throw error;
   }
 }

--- a/src/scripts/testUBAClient.ts
+++ b/src/scripts/testUBAClient.ts
@@ -15,7 +15,7 @@ import {
   retrieveSignerFromCLIArgs,
   Logger,
   getBlockForTimestamp,
-  disconnectRedisClient,
+  disconnectRedisClients,
   REDIS_URL,
   getRedisCache,
 } from "../utils";
@@ -145,7 +145,7 @@ export async function testUBAClient(_logger: winston.Logger, baseSigner: Wallet)
 export async function run(_logger: winston.Logger): Promise<void> {
   const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
   await testUBAClient(_logger, baseSigner);
-  await disconnectRedisClient(logger);
+  await disconnectRedisClients(logger);
 }
 
 // eslint-disable-next-line no-process-exit

--- a/src/scripts/testUBAClient.ts
+++ b/src/scripts/testUBAClient.ts
@@ -143,9 +143,12 @@ export async function testUBAClient(_logger: winston.Logger, baseSigner: Wallet)
 }
 
 export async function run(_logger: winston.Logger): Promise<void> {
-  const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
-  await testUBAClient(_logger, baseSigner);
-  await disconnectRedisClients(logger);
+  try {
+    const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
+    await testUBAClient(_logger, baseSigner);
+  } finally {
+    await disconnectRedisClients(logger);
+  }
 }
 
 // eslint-disable-next-line no-process-exit

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -201,9 +201,12 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
 }
 
 export async function run(_logger: winston.Logger): Promise<void> {
-  const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
-  await validate(_logger, baseSigner);
-  await disconnectRedisClients(logger);
+  try {
+    const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
+    await validate(_logger, baseSigner);
+  } finally {
+    await disconnectRedisClients(logger);
+  }
 }
 
 // eslint-disable-next-line no-process-exit

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -21,7 +21,7 @@ import {
   getBlockForTimestamp,
   sortEventsDescending,
   getDisputeForTimestamp,
-  disconnectRedisClient,
+  disconnectRedisClients,
 } from "../utils";
 import {
   constructSpokePoolClientsForFastDataworker,
@@ -203,7 +203,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
 export async function run(_logger: winston.Logger): Promise<void> {
   const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
   await validate(_logger, baseSigner);
-  await disconnectRedisClient(logger);
+  await disconnectRedisClients(logger);
 }
 
 // eslint-disable-next-line no-process-exit

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -35,7 +35,7 @@ import {
   paginatedEventQuery,
   ZERO_ADDRESS,
   getRefund,
-  disconnectRedisClient,
+  disconnectRedisClients,
 } from "../utils";
 import { createDataworker } from "../dataworker";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
@@ -486,7 +486,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
 export async function run(_logger: winston.Logger): Promise<void> {
   const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
   await runScript(_logger, baseSigner);
-  await disconnectRedisClient(logger);
+  await disconnectRedisClients(logger);
 }
 
 // eslint-disable-next-line no-process-exit

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -484,9 +484,12 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
 }
 
 export async function run(_logger: winston.Logger): Promise<void> {
-  const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
-  await runScript(_logger, baseSigner);
-  await disconnectRedisClients(logger);
+  try {
+    const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
+    await runScript(_logger, baseSigner);
+  } finally {
+    await disconnectRedisClients(logger);
+  }
 }
 
 // eslint-disable-next-line no-process-exit

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -71,8 +71,9 @@ const redisClients: { [url: string]: RedisClient } = {};
 
 export async function getRedis(logger?: winston.Logger, url = REDIS_URL): Promise<RedisClient | undefined> {
   if (!redisClients[url]) {
+    let redisClient: _RedisClient | undefined = undefined;
     try {
-      const redisClient = createClient({ url });
+      redisClient = createClient({ url });
       await redisClient.connect();
       logger?.debug({
         at: "RedisUtils#getRedis",
@@ -86,6 +87,9 @@ export async function getRedis(logger?: winston.Logger, url = REDIS_URL): Promis
         message: `Failed to connect to redis server at ${url}.`,
         error: String(err),
       });
+      if (redisClient) {
+        await redisClient.disconnect();
+      }
     }
   }
 

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -137,12 +137,21 @@ export async function disconnectRedisClients(logger?: winston.Logger): Promise<v
   // todo understand why redisClients arent't GCed automagically.
   const clients = Object.values(redisClients);
   for (const client of clients) {
-    logger?.debug({
+    const logParams = {
       at: "RedisUtils#disconnectRedisClient",
       message: "Disconnecting from redis server.",
       url: client.url,
-    });
-    await client.disconnect();
+    };
+    // We don't want to throw an error if we can't disconnect from redis.
+    // We can log the error and continue.
+    try {
+      await client.disconnect();
+      logParams["success"] = true;
+    } catch (e) {
+      logParams["success"] = false;
+      logParams["error"] = e;
+    }
+    logger?.debug(logParams);
   }
 }
 

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -30,6 +30,10 @@ export class RedisClient {
     return isDefined(this.namespace) ? `${this.namespace}:${key}` : key;
   }
 
+  get url(): string {
+    return this.client.options.url;
+  }
+
   async get(key: string): Promise<string | undefined> {
     return this.client.get(this.getNamespacedKey(key));
   }
@@ -129,12 +133,16 @@ export async function getDeposit(key: string, redisClient: RedisClient): Promise
   }
 }
 
-export async function disconnectRedisClient(logger?: winston.Logger): Promise<void> {
-  const redisClient = await getRedis(logger);
-  if (redisClient !== undefined) {
-    // todo understand why redisClient isn't GCed automagically.
-    logger.debug({ at: "disconnectRedisClient", message: "Disconnecting from redis server." });
-    await redisClient.disconnect();
+export async function disconnectRedisClients(logger?: winston.Logger): Promise<void> {
+  // todo understand why redisClients arent't GCed automagically.
+  const clients = Object.values(redisClients);
+  for (const client of clients) {
+    logger?.debug({
+      at: "RedisUtils#disconnectRedisClient",
+      message: "Disconnecting from redis server.",
+      url: client.url,
+    });
+    await client.disconnect();
   }
 }
 

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -82,14 +82,12 @@ export async function getRedis(logger?: winston.Logger, url = REDIS_URL): Promis
       });
       redisClients[url] = new RedisClient(redisClient, globalNamespace);
     } catch (err) {
+      await redisClient?.disconnect();
       logger?.debug({
         at: "RedisUtils#getRedis",
         message: `Failed to connect to redis server at ${url}.`,
         error: String(err),
       });
-      if (redisClient) {
-        await redisClient.disconnect();
-      }
     }
   }
 

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -135,12 +135,12 @@ export async function getDeposit(key: string, redisClient: RedisClient): Promise
 
 export async function disconnectRedisClients(logger?: winston.Logger): Promise<void> {
   // todo understand why redisClients arent't GCed automagically.
-  const clients = Object.values(redisClients);
-  for (const client of clients) {
+  const clients = Object.entries(redisClients);
+  for (const [url, client] of clients) {
     const logParams = {
       at: "RedisUtils#disconnectRedisClient",
       message: "Disconnecting from redis server.",
-      url: client.url,
+      url,
     };
     // We don't want to throw an error if we can't disconnect from redis.
     // We can log the error and continue.
@@ -150,6 +150,10 @@ export async function disconnectRedisClients(logger?: winston.Logger): Promise<v
     } catch (e) {
       logParams["success"] = false;
       logParams["error"] = e;
+    } finally {
+      // No matter what we need to eject this from
+      // our memory cache object.
+      delete redisClients[url];
     }
     logger?.debug(logParams);
   }


### PR DESCRIPTION
Our disconnect logic currently only handles the default `redis` URL. (logic below). We ignore all the clients held in the  `redisClients` singleton.

```
export async function disconnectRedisClient(logger?: winston.Logger): Promise<void> {
  const redisClient = await getRedis(logger);
  if (redisClient !== undefined) {
    // todo understand why redisClient isn't GCed automagically.
    logger.debug({ at: "disconnectRedisClient", message: "Disconnecting from redis server." });
    await redisClient.disconnect();
  }
}
```

In addition, we're calling `getRedis` to find the client we want to disconnect. The issue is that if the following logic fails (within `getRedis()`), then we have created a redis connection that isn't stored to the `redisClients` singleton. We can never close this because it isn't saved.

```
      const redisClient = createClient({ url });
      await redisClient.connect();
```

Then, when we eventually call `disconnectRedisClient()` in the catch handlers. If the error was related to redis, then the issue circles back to the problem of calling `getRedis()` within the disconnect logic. This will throw in the catch statement and cause an uncaught exception.

---

In all of our try/catch blocks, we attempt to disconnectRedisClient. A more apt usage would be to use the `finally` block which is guaranteed to run after a try/catch regardless of failure. 

---

Lastly, we don't eject the disconnected redis client from our `redisClients` object.