### PR TITLE
fix: let debugger gracefully not execute if undefined

### DIFF
--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -41,8 +41,8 @@ export class RedisClient {
       // EX: Expire key after expirySeconds.
       await this.client.set(key, val, { EX: expirySeconds });
     } else {
-      if (expirySeconds <= 0 && this.logger) {
-        this.logger.warn({
+      if (expirySeconds <= 0) {
+        this.logger?.warn({
           at: "RedisClient#setRedisKey",
           message: `Tried to set key ${key} with expirySeconds = ${expirySeconds}. This shouldn't be allowed.`,
         });

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -20,7 +20,7 @@ export class RedisClient {
     private readonly namespace?: string,
     private readonly logger?: winston.Logger
   ) {
-    this?.logger.debug({
+    this.logger?.debug({
       at: "RedisClient#constructor",
       message: isDefined(namespace) ? `Created redis client with namespace ${namespace}` : "Created redis client.",
     });

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -20,7 +20,7 @@ export class RedisClient {
     private readonly namespace?: string,
     private readonly logger?: winston.Logger
   ) {
-    this.logger.debug({
+    this?.logger.debug({
       at: "RedisClient#constructor",
       message: isDefined(namespace) ? `Created redis client with namespace ${namespace}` : "Created redis client.",
     });
@@ -70,21 +70,18 @@ export async function getRedis(logger?: winston.Logger, url = REDIS_URL): Promis
     try {
       const redisClient = createClient({ url });
       await redisClient.connect();
-      if (logger) {
-        logger.debug({
-          at: "RedisUtils#getRedis",
-          message: `Connected to redis server at ${url} successfully!`,
-          dbSize: await redisClient.dbSize(),
-        });
-      }
+      logger?.debug({
+        at: "RedisUtils#getRedis",
+        message: `Connected to redis server at ${url} successfully!`,
+        dbSize: await redisClient.dbSize(),
+      });
       redisClients[url] = new RedisClient(redisClient, globalNamespace);
     } catch (err) {
-      if (logger) {
-        logger.debug({
-          at: "RedisUtils#getRedis",
-          message: `Failed to connect to redis server at ${url}.`,
-        });
-      }
+      logger?.debug({
+        at: "RedisUtils#getRedis",
+        message: `Failed to connect to redis server at ${url}.`,
+        error: String(err),
+      });
     }
   }
 


### PR DESCRIPTION
This will resolve the failure we were seeing when we connected to Redis, then immediately failed. 

A note: there are no checks for this and it should be a compilation error to attempt to reference a function on a potentially undefined type.

An error sample that is now resolved:
```
2023-10-14 18:45:34 [debug]: {
  "at": "RedisUtils#getRedis",
  "message": "Connected to redis server at redis://xxxxxxxxxx successfully!",
  "dbSize": 37236,
  "bot-identifier": "xxxxxxxxxx"
}
2023-10-14 18:45:34 [debug]: {
  "at": "RedisUtils#getRedis",
  "message": "Failed to connect to redis server at redis://xxxxxxxxxx",
  "bot-identifier": "xxxxxxxxxx"
}
```