### PR TITLE
improve: make api stripping more robust

### DIFF
--- a/src/utils/NetworkUtils.ts
+++ b/src/utils/NetworkUtils.ts
@@ -8,3 +8,16 @@ export function getNativeTokenSymbol(chainId: number | string): string {
   }
   return "ETH";
 }
+
+/**
+ * Returns the origin of a URL.
+ * @param url A URL.
+ * @returns The origin of the URL, or "UNKNOWN" if the URL is invalid.
+ */
+export function getOriginFromURL(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch (e) {
+    return "UNKNOWN";
+  }
+}


### PR DESCRIPTION
We are relying on a regular expression that's not entirely resistant to different network protocols. Let's use the built in `URL` class to pick out the `origin` field of the URL.