### PR TITLE
improve: Update chain caching limits

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -154,17 +154,18 @@ export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } =
 export const IGNORED_HUB_PROPOSED_BUNDLES: number[] = [];
 export const IGNORED_HUB_EXECUTED_BUNDLES: number[] = [];
 
-// This is the max distance on each chain that reorgs can happen.
+// This is the max anticipated distance on each chain before RPC data is likely to be consistent amongst providers.
+// This distance should consider re-orgs, but also the time needed for various RPC providers to agree on chain state.
 // Provider caching will not be allowed for queries whose responses depend on blocks closer than this many blocks.
 // This is intended to be conservative.
-export const MAX_REORG_DISTANCE: { [chainId: number]: number } = {
-  1: 64,
+export const CHAIN_CACHE_FOLLOW_DISTANCE: { [chainId: number]: number } = {
+  1: 128,
   10: 120,
   137: 256,
   288: 0,
-  324: 0,
+  324: 512,
   8453: 120,
-  42161: 0,
+  42161: 32,
   // Testnets:
   5: 0,
   280: 0,

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -6,7 +6,7 @@ import { isPromiseFulfilled, isPromiseRejected } from "./TypeGuards";
 import createQueue, { QueueObject } from "async/queue";
 import { getRedis, RedisClient, setRedisKey } from "./RedisUtils";
 import {
-  MAX_REORG_DISTANCE,
+  CHAIN_CACHE_FOLLOW_DISTANCE,
   PROVIDER_CACHE_TTL,
   PROVIDER_CACHE_TTL_MODIFIER as ttl_modifier,
   BLOCK_NUMBER_TTL,
@@ -119,14 +119,15 @@ class CacheProvider extends RateLimitedProvider {
   ) {
     super(...jsonRpcConstructorParams);
 
-    if (MAX_REORG_DISTANCE[this.network.chainId] === undefined) {
-      throw new Error(`CacheProvider:constructor no MAX_REORG_DISTANCE for chain ${this.network.chainId}`);
+    const { chainId } = this.network;
+    if (CHAIN_CACHE_FOLLOW_DISTANCE[chainId] === undefined) {
+      throw new Error(`CacheProvider:constructor no MAX_REORG_DISTANCE for chain ${chainId}`);
     }
 
-    this.maxReorgDistance = MAX_REORG_DISTANCE[this.network.chainId];
+    this.maxReorgDistance = CHAIN_CACHE_FOLLOW_DISTANCE[chainId];
 
     // Pre-compute as much of the redis key as possible.
-    const cachePrefix = `${providerCacheNamespace},${new URL(this.connection.url).hostname},${this.network.chainId}`;
+    const cachePrefix = `${providerCacheNamespace},${new URL(this.connection.url).hostname},${chainId}`;
     this.getBlockByNumberPrefix = `${cachePrefix}:getBlockByNumber,`;
     this.getLogsCachePrefix = `${cachePrefix}:eth_getLogs,`;
     this.callCachePrefix = `${cachePrefix}:eth_call,`;


### PR DESCRIPTION
 - Bump zkSync and Arbitrum defaults from 0 to account for occasional RPC provider lag leading to caching bad data.
 - Increase the Ethereum default from 64 to 128 for the same reason.
 - Minor refactor around this.network.chainId.