### PR TITLE
refactor: Simplify relayer partial fill handling

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -113,6 +113,9 @@ export class Relayer {
     const { config } = this;
     const { acrossApiClient, hubPoolClient, profitClient, spokePoolClients, tokenClient } = this.clients;
 
+    // Flush any pre-existing enqueued transactions that might not have been executed.
+    this.clients.multiCallerClient.clearTransactionQueue();
+
     const unfilledDeposits = await this.getUnfilledDeposits();
 
     // Sum the total unfilled deposit amount per origin chain and set a MDC for that chain.
@@ -525,21 +528,7 @@ export class Relayer {
     const { depositId, originChainId, destinationChainId, transactionHash: depositHash } = deposit;
     const { inventoryClient, profitClient } = this.clients;
 
-    // TODO: Consider adding some way for Relayer to delete transactions in Queue for fills for same deposit.
-    // This way the relayer could set a repayment chain ID for any fill that follows a 1 wei fill in the queue.
-    // This isn't implemented due to complexity because its a very rare case in production, because its very
-    // unlikely that a relayer could enqueue a 1 wei fill (lacking balance to fully fill it) for a deposit and
-    // then later on in the run have enough balance to fully fill it.
-    const fillsInQueueForSameDeposit = this.clients.multiCallerClient
-      .getQueuedTransactions(deposit.destinationChainId)
-      .some(({ method, args }) => {
-        return (
-          (method === "fillRelay" && args[9] === depositId && args[6] === originChainId) ||
-          (method === "fillRelayWithUpdatedDeposit" && args[11] === depositId && args[7] === originChainId)
-        );
-      });
-
-    if (!fillAmount.eq(deposit.amount) || fillsInQueueForSameDeposit) {
+    if (!fillAmount.eq(deposit.amount)) {
       const originChain = getNetworkName(originChainId);
       const destinationChain = getNetworkName(destinationChainId);
       this.logger.debug({

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -133,7 +133,6 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
     profitClient.setTokenPrice(l1Token.address, bnOne);
-    Object.values(spokePoolClients).map((spokePoolClient) => profitClient.setGasCost(spokePoolClient.chainId, bnOne));
 
     relayerInstance = new Relayer(
       relayer.address,

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -411,8 +411,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     // The first fill is still pending but if we rerun the relayer loop, it shouldn't try to fill a second time.
     await Promise.all([spokePoolClient_1.update(), spokePoolClient_2.update(), hubPoolClient.update()]);
     await relayerInstance.checkForUnfilledDepositsAndFill();
-    // Only still 1 transaction.
-    expect(multiCallerClient.transactionCount()).to.equal(1); // no Transactions to send.
+    expect(multiCallerClient.transactionCount()).to.equal(0); // no new transactions were enqueued.
   });
 
   it("Respects configured relayer routes", async function () {

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -1,3 +1,4 @@
+import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import {
   AcrossApiClient,
   ConfigStoreClient,
@@ -109,6 +110,7 @@ describe("Relayer: Token balance shortfall", async function () {
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
+    profitClient.setTokenPrice(l1Token.address, sdkUtils.bnOne);
 
     relayerInstance = new Relayer(
       relayer.address,

--- a/test/mocks/MockProfitClient.ts
+++ b/test/mocks/MockProfitClient.ts
@@ -1,7 +1,7 @@
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { GAS_TOKEN_BY_CHAIN_ID, HubPoolClient, ProfitClient, WETH } from "../../src/clients";
 import { SpokePoolClientsByChain } from "../../src/interfaces";
-import { BigNumber, toBNWei, winston } from "../utils";
+import { BigNumber, winston } from "../utils";
 
 export class MockProfitClient extends ProfitClient {
   constructor(
@@ -25,8 +25,8 @@ export class MockProfitClient extends ProfitClient {
 
     // Some tests run against mocked chains, so hack in the necessary parts
     Object.values(spokePoolClients).map(({ chainId }) => {
-        this.setGasCost(chainId, sdkUtils.bnOne);
-        GAS_TOKEN_BY_CHAIN_ID[chainId] ??= WETH;
+      this.setGasCost(chainId, sdkUtils.bnOne);
+      GAS_TOKEN_BY_CHAIN_ID[chainId] ??= WETH;
     });
     this.setTokenPrice(WETH, sdkUtils.bnOne);
   }

--- a/test/mocks/MockProfitClient.ts
+++ b/test/mocks/MockProfitClient.ts
@@ -24,10 +24,9 @@ export class MockProfitClient extends ProfitClient {
     );
 
     // Some tests run against mocked chains, so hack in the necessary parts
-    const chainIds = [666, 1337];
-    chainIds.forEach((chainId) => {
-      GAS_TOKEN_BY_CHAIN_ID[chainId] = WETH;
-      this.setGasCost(chainId, toBNWei(chainId));
+    Object.values(spokePoolClients).map(({ chainId }) => {
+        this.setGasCost(chainId, sdkUtils.bnOne);
+        GAS_TOKEN_BY_CHAIN_ID[chainId] ??= WETH;
     });
     this.setTokenPrice(WETH, sdkUtils.bnOne);
   }


### PR DESCRIPTION
Checking for existing fills in the pending transaction queue is only necessary because of some test cases that instrument the relayer in specific ways result in the relayer enqueueing multiple fills for the same deposit. This is not how the relayer works in production.

Flushing the transaction queue at the start of each run allows for the relayer to assume that it has no previously-enqueued fills.