### PR TITLE
improve(spokepool): Use SpokePool.depositNow()

### DIFF
--- a/scripts/spokepool.ts
+++ b/scripts/spokepool.ts
@@ -82,15 +82,13 @@ async function deposit(args: Record<string, number | string>, signer: Wallet): P
 
   const relayerFeePct = Zero; // @todo: Make configurable.
   const maxCount = MaxUint256;
-  const quoteTimestamp = Math.round(Date.now() / 1000);
 
-  const deposit = await spokePool.deposit(
+  const deposit = await spokePool.depositNow(
     recipient,
     token.address,
     amount,
     toChainId,
     relayerFeePct,
-    quoteTimestamp,
     "0x",
     maxCount
   );


### PR DESCRIPTION
The existing logic of using the host's current time doesn't work well on mainnet because of the slow block times, so deposits often fail in simulation.