### PR TITLE
chore: Bump SDK for composable bridging updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.4",
     "@across-protocol/contracts-v2": "2.4.6",
-    "@across-protocol/sdk-v2": "0.17.1",
+    "@across-protocol/sdk-v2": "0.17.4",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -3,16 +3,16 @@ import { Provider } from "@ethersproject/abstract-provider";
 import { constants as ethersConstants, utils as ethersUtils } from "ethers";
 import * as constants from "../common/Constants";
 import {
-    assert,
-    BigNumber,
-    formatFeePct,
-    getCurrentTime,
-    isDefined,
-    max,
-    winston,
-    toBNWei,
-    toBN,
-    assign
+  assert,
+  BigNumber,
+  formatFeePct,
+  getCurrentTime,
+  isDefined,
+  max,
+  winston,
+  toBNWei,
+  toBN,
+  assign,
 } from "../utils";
 import { HubPoolClient } from ".";
 import { Deposit, DepositWithBlock, L1Token, SpokePoolClientsByChain } from "../interfaces";
@@ -20,7 +20,7 @@ import { priceClient, relayFeeCalculator, utils as sdkUtils } from "@across-prot
 import { TOKEN_SYMBOLS_MAP, CHAIN_IDs } from "@across-protocol/constants-v2";
 
 const { formatEther } = ethersUtils;
-const { bnOne, bnUint32Max, fixedPointAdjustment: fixedPoint,  resolveDepositMessage} = sdkUtils;
+const { bnOne, bnUint32Max, fixedPointAdjustment: fixedPoint, resolveDepositMessage } = sdkUtils;
 
 // We use wrapped ERC-20 versions instead of the native tokens such as ETH, MATIC for ease of computing prices.
 export const MATIC = TOKEN_SYMBOLS_MAP.MATIC.addresses[CHAIN_IDs.MAINNET];
@@ -431,9 +431,10 @@ export class ProfitClient {
 
     // Pre-fetch total gas costs for relays on enabled chains.
     await sdkUtils.mapAsync(enabledChainIds, async (destinationChainId, idx) => {
-      const destinationToken = destinationChainId === hubPoolClient.chainId
-        ? USDC
-        : hubPoolClient.getDestinationTokenForL1Token(USDC, destinationChainId);
+      const destinationToken =
+        destinationChainId === hubPoolClient.chainId
+          ? USDC
+          : hubPoolClient.getDestinationTokenForL1Token(USDC, destinationChainId);
       const deposit: Deposit = {
         depositId,
         depositor: testRecipient,

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -69,7 +69,7 @@ const GAS_TOKEN_DECIMALS = 18;
 // relayer's own address.
 // @todo: Consider using an address with confirmed 0 destinationToken balance so that the initial cost
 // of populating storage is included in the estimate.
-const testRecipient = "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B";
+const TEST_RECIPIENT = "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B";
 
 // These are used to simulate fills on L2s to return estimated gas costs.
 // Note: the type here assumes that all of these classes take the same constructor parameters.

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -48,7 +48,7 @@ export async function constructDataworkerClients(
   // Disable profitability by default as only the relayer needs it.
   // The dataworker only needs price updates from ProfitClient to calculate bundle volume.
   const profitClient = config.proposerEnabled
-    ? new ProfitClient(logger, commonClients.hubPoolClient, {}, [])
+    ? new ProfitClient(logger, commonClients.hubPoolClient, {}, [], "")
     : undefined;
 
   // Must come after hubPoolClient.

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -15,7 +15,6 @@ import {
   getNetworkName,
   getUnfilledDeposits,
   isDefined,
-  isDepositSpedUp,
   toBN,
   toBNWei,
   winston,
@@ -23,7 +22,7 @@ import {
 import { RelayerClients } from "./RelayerClientHelper";
 import { RelayerConfig } from "./RelayerConfig";
 
-const zeroFillAmount = sdkUtils.bnOne;
+const { isDepositSpedUp, bnOne: zeroFillAmount } = sdkUtils;
 const UNPROFITABLE_DEPOSIT_NOTICE_PERIOD = 60 * 60; // 1 hour
 
 export class Relayer {
@@ -623,7 +622,7 @@ export class Relayer {
           return;
         }
 
-        const gasCost = this.clients.profitClient.getTotalGasCost(deposit.destinationChainId).toString();
+        const gasCost = this.clients.profitClient.getTotalGasCost(deposit).toString();
         const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForDeposit(deposit);
         const formatFunction = createFormatFunction(2, 4, false, decimals);
         const gasFormatFunction = createFormatFunction(2, 10, false, 18);

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -79,6 +79,7 @@ export async function constructRelayerClients(
     commonClients.hubPoolClient,
     spokePoolClients,
     enabledChainIds,
+    baseSigner.address,
     config.minRelayerFeePct,
     config.debugProfitability,
     config.relayerGasMultiplier

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -117,10 +117,6 @@ export function getUniqueEarlyDepositsInRange(
   );
 }
 
-export function isDepositSpedUp(deposit: Deposit): boolean {
-  return deposit.speedUpSignature !== undefined && deposit.newRelayerFeePct !== undefined;
-}
-
 // Load a deposit for a fill if the fill's deposit ID is outside this client's search range.
 // This can be used by the Dataworker to determine whether to give a relayer a refund for a fill
 // of a deposit older or younger than its fixed lookback.

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -22,10 +22,11 @@ import {
   expect,
   hubPoolFixture,
   originChainId,
+  randomAddress,
   winston,
 } from "./utils";
 
-const { bnZero, fixedPointAdjustment: fixedPoint, toGWei } = sdkUtils;
+const { bnOne, bnZero, fixedPointAdjustment: fixedPoint, toGWei } = sdkUtils;
 const { formatEther } = ethers.utils;
 
 const chainIds = [originChainId, destinationChainId];
@@ -99,6 +100,7 @@ describe("ProfitClient: Consider relay profit", () => {
   // Define LOG_IN_TEST for logging to console.
   const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
   let hubPoolClient: MockHubPoolClient, profitClient: MockProfitClient;
+  let message = "0x"; // Empty message by default.
 
   beforeEach(async () => {
     const [owner] = await ethers.getSigners();
@@ -140,6 +142,7 @@ describe("ProfitClient: Consider relay profit", () => {
       hubPoolClient,
       spokePoolClients,
       [],
+      randomAddress(),
       minRelayerFeePct,
       debugProfitability
     );
@@ -151,14 +154,15 @@ describe("ProfitClient: Consider relay profit", () => {
 
   // Verify gas cost calculation first, so we can leverage it in all subsequent tests.
   it("Verify gas cost estimation", () => {
-    chainIds.forEach((chainId) => {
-      spyLogger.debug({ message: `Verifying USD fill cost calculation for chain ${chainId}.` });
+    chainIds.forEach((destinationChainId) => {
+      spyLogger.debug({ message: `Verifying USD fill cost calculation for chain ${destinationChainId}.` });
+      const deposit = { destinationChainId, message } as Deposit;
 
-      const nativeGasCost = profitClient.getTotalGasCost(chainId);
+      const nativeGasCost = profitClient.getTotalGasCost(deposit);
       expect(nativeGasCost.eq(0)).to.be.false;
-      expect(nativeGasCost.eq(gasCost[chainId])).to.be.true;
+      expect(nativeGasCost.eq(gasCost[destinationChainId])).to.be.true;
 
-      const gasTokenAddr = GAS_TOKEN_BY_CHAIN_ID[chainId];
+      const gasTokenAddr = GAS_TOKEN_BY_CHAIN_ID[destinationChainId];
       let gasToken = Object.values(tokens).find((token) => gasTokenAddr === token.address);
       expect(gasToken).to.not.be.undefined;
       gasToken = gasToken as L1Token;
@@ -166,25 +170,26 @@ describe("ProfitClient: Consider relay profit", () => {
       const gasPriceUsd = tokenPrices[gasToken.symbol];
       expect(gasPriceUsd.eq(tokenPrices[gasToken.symbol])).to.be.true;
 
-      const estimate = profitClient.estimateFillCost(chainId);
-      expect(estimate.nativeGasCost.eq(gasCost[chainId])).to.be.true;
+      const estimate = profitClient.estimateFillCost(deposit);
+      expect(estimate.nativeGasCost.eq(gasCost[destinationChainId])).to.be.true;
       expect(estimate.gasPriceUsd.eq(tokenPrices[gasToken.symbol])).to.be.true;
       expect(estimate.gasCostUsd.eq(gasPriceUsd.mul(nativeGasCost).div(toBN(10).pow(gasToken.decimals)))).to.be.true;
     });
   });
 
   it("Verify gas multiplier", () => {
-    chainIds.forEach((chainId) => {
-      spyLogger.debug({ message: `Verifying gas multiplier for chainId ${chainId}.` });
+    chainIds.forEach((destinationChainId) => {
+      spyLogger.debug({ message: `Verifying gas multiplier for chainId ${destinationChainId}.` });
+      const deposit = { destinationChainId, message } as Deposit;
 
-      const nativeGasCost = profitClient.getTotalGasCost(chainId);
+      const nativeGasCost = profitClient.getTotalGasCost(deposit);
       expect(nativeGasCost.gt(0)).to.be.true;
 
       const gasMultipliers = [0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
       gasMultipliers.forEach((gasMultiplier) => {
         profitClient.setGasMultiplier(toBNWei(gasMultiplier));
 
-        const gasTokenAddr = GAS_TOKEN_BY_CHAIN_ID[chainId];
+        const gasTokenAddr = GAS_TOKEN_BY_CHAIN_ID[destinationChainId];
         let gasToken = Object.values(tokens).find((token) => gasTokenAddr === token.address);
         expect(gasToken).to.not.be.undefined;
         gasToken = gasToken as L1Token;
@@ -194,7 +199,7 @@ describe("ProfitClient: Consider relay profit", () => {
           .mul(toBNWei(gasMultiplier))
           .div(fixedPoint)
           .div(fixedPoint);
-        const { gasCostUsd } = profitClient.estimateFillCost(chainId);
+        const { gasCostUsd } = profitClient.estimateFillCost(deposit);
         expect(expectedFillCostUsd.eq(gasCostUsd)).to.be.true;
       });
     });
@@ -203,16 +208,18 @@ describe("ProfitClient: Consider relay profit", () => {
   it("Return 0 when gas cost fails to be fetched", () => {
     const destinationChainId = 137;
     profitClient.setGasCost(destinationChainId, undefined);
-    expect(profitClient.getTotalGasCost(destinationChainId)).to.equal(bnZero);
+    const deposit = { destinationChainId, message } as Deposit;
+    expect(profitClient.getTotalGasCost(deposit)).to.equal(bnZero);
   });
 
   it("Verify token price and gas cost lookup failures", () => {
     const fillAmount = toBNWei(1);
     const l1Token = tokens["WETH"];
+    const relayerFeePct = toBNWei("0.0003");
     hubPoolClient.setTokenInfoToReturn(l1Token);
 
     chainIds.forEach((destinationChainId) => {
-      const deposit = { destinationChainId, relayerFeePct: toBNWei("0.0003") } as Deposit;
+      const deposit = { destinationChainId, message, relayerFeePct } as Deposit;
 
       // Verify that it works before we break it.
       expect(() =>
@@ -220,7 +227,7 @@ describe("ProfitClient: Consider relay profit", () => {
       ).to.not.throw();
 
       spyLogger.debug({ message: `Verify exception on chain ${destinationChainId} gas cost estimation failure.` });
-      const destinationGasCost = profitClient.getTotalGasCost(destinationChainId);
+      const destinationGasCost = profitClient.getTotalGasCost(deposit);
       profitClient.setGasCost(destinationChainId, undefined);
       expect(() =>
         profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct)
@@ -262,7 +269,8 @@ describe("ProfitClient: Consider relay profit", () => {
     const fillAmounts = [".001", "0.1", 1, 10, 100, 1_000, 100_000];
 
     chainIds.forEach((destinationChainId) => {
-      const { gasCostUsd } = profitClient.estimateFillCost(destinationChainId);
+      let deposit = { destinationChainId, message } as Deposit;
+      const { gasCostUsd } = profitClient.estimateFillCost(deposit);
 
       Object.values(tokens).forEach((l1Token) => {
         const tokenPriceUsd = profitClient.getPriceOfToken(l1Token.address);
@@ -289,7 +297,7 @@ describe("ProfitClient: Consider relay profit", () => {
 
           relayerFeePcts.forEach((_relayerFeePct) => {
             const relayerFeePct = _relayerFeePct.gt(maxRelayerFeePct) ? maxRelayerFeePct : _relayerFeePct;
-            const deposit = { relayerFeePct, destinationChainId } as Deposit;
+            deposit.relayerFeePct = relayerFeePct;
 
             const expected = testProfitability(deposit, fillAmountUsd, gasCostUsd, zeroRefundFee);
             spyLogger.debug({
@@ -317,9 +325,11 @@ describe("ProfitClient: Consider relay profit", () => {
   it("Considers refund fees when computing profitability", () => {
     const fillAmounts = [".001", "0.1", 1, 10, 100, 1_000, 100_000];
     const refundFeeMultipliers = ["-0.1", "-0.01", "-0.001", "-0.0001", 0.0001, 0.001, 0.01, 0.1, 1];
+    const relayerFeePct = toBN(0.0001);
 
     chainIds.forEach((destinationChainId) => {
-      const { gasCostUsd } = profitClient.estimateFillCost(destinationChainId);
+      const deposit = { destinationChainId, relayerFeePct, message } as Deposit;
+      const { gasCostUsd } = profitClient.estimateFillCost(deposit);
 
       Object.values(tokens).forEach((l1Token) => {
         const tokenPriceUsd = profitClient.getPriceOfToken(l1Token.address);
@@ -332,9 +342,6 @@ describe("ProfitClient: Consider relay profit", () => {
 
           const fillAmountUsd = fillAmount.mul(tokenPriceUsd).div(fixedPoint);
           const gasCostPct = gasCostUsd.mul(fixedPoint).div(fillAmountUsd);
-
-          const relayerFeePct = toBN(0.0001);
-          const deposit = { relayerFeePct, destinationChainId } as Deposit;
 
           refundFeeMultipliers.forEach((_multiplier) => {
             const feeMultiplier = toBNWei(_multiplier);
@@ -410,13 +417,14 @@ describe("ProfitClient: Consider relay profit", () => {
     hubPoolClient.setTokenInfoToReturn(l1Token);
 
     const fillAmount = toBNWei(1);
-    const deposit = { relayerFeePct: toBNWei("0.001"), destinationChainId } as Deposit;
+    const relayerFeePct = toBNWei("0.001");
+    const deposit = { destinationChainId, message, relayerFeePct } as Deposit;
 
     let fill: FillProfit;
     fill = profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct);
     expect(fill.grossRelayerFeePct.eq(deposit.relayerFeePct)).to.be.true;
 
-    deposit["newRelayerFeePct"] = toBNWei("0.1");
+    deposit.newRelayerFeePct = deposit.relayerFeePct.mul(10);
     fill = profitClient.calculateFillProfitability(deposit, fillAmount, zeroRefundFee, l1Token, minRelayerFeePct);
     expect(fill.grossRelayerFeePct.eq(deposit.newRelayerFeePct)).to.be.true;
   });
@@ -426,9 +434,10 @@ describe("ProfitClient: Consider relay profit", () => {
     hubPoolClient.setTokenInfoToReturn(l1Token);
 
     const deposit = {
+      destinationChainId,
+      message,
       relayerFeePct: toBNWei("0.1"),
       newRelayerFeePct: toBNWei("0.01"),
-      destinationChainId,
     } as Deposit;
     const fillAmount = toBNWei(1);
 

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import { utils as sdkUtils } from "@across-protocol/sdk-v2";
+import { constants as sdkConstants, utils as sdkUtils } from "@across-protocol/sdk-v2";
 import {
   ConfigStoreClient,
   FillProfit,
@@ -100,7 +100,7 @@ describe("ProfitClient: Consider relay profit", () => {
   // Define LOG_IN_TEST for logging to console.
   const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
   let hubPoolClient: MockHubPoolClient, profitClient: MockProfitClient;
-  const message = "0x"; // Empty message by default.
+  const message = sdkConstants.EMPTY_MESSAGE; // Empty message by default.
 
   beforeEach(async () => {
     const [owner] = await ethers.getSigners();

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -26,7 +26,7 @@ import {
   winston,
 } from "./utils";
 
-const { bnOne, bnZero, fixedPointAdjustment: fixedPoint, toGWei } = sdkUtils;
+const { bnZero, fixedPointAdjustment: fixedPoint, toGWei } = sdkUtils;
 const { formatEther } = ethers.utils;
 
 const chainIds = [originChainId, destinationChainId];
@@ -100,7 +100,7 @@ describe("ProfitClient: Consider relay profit", () => {
   // Define LOG_IN_TEST for logging to console.
   const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
   let hubPoolClient: MockHubPoolClient, profitClient: MockProfitClient;
-  let message = "0x"; // Empty message by default.
+  const message = "0x"; // Empty message by default.
 
   beforeEach(async () => {
     const [owner] = await ethers.getSigners();
@@ -269,7 +269,7 @@ describe("ProfitClient: Consider relay profit", () => {
     const fillAmounts = [".001", "0.1", 1, 10, 100, 1_000, 100_000];
 
     chainIds.forEach((destinationChainId) => {
-      let deposit = { destinationChainId, message } as Deposit;
+      const deposit = { destinationChainId, message } as Deposit;
       const { gasCostUsd } = profitClient.estimateFillCost(deposit);
 
       Object.values(tokens).forEach((l1Token) => {

--- a/test/ProfitClient.PriceRetrieval.ts
+++ b/test/ProfitClient.PriceRetrieval.ts
@@ -5,6 +5,7 @@ import {
   createSpyLogger,
   hubPoolFixture,
   deployConfigStore,
+  randomAddress,
   winston,
   BigNumber,
   toBN,
@@ -76,7 +77,8 @@ describe("ProfitClient: Price Retrieval", async function () {
     await hubPoolClient.update();
 
     mainnetTokens.forEach((token: L1Token) => hubPoolClient.addL1Token(token));
-    profitClient = new ProfitClientWithMockPriceClient(spyLogger, hubPoolClient, {}, [], toBN(0));
+    const relayerAddress = randomAddress();
+    profitClient = new ProfitClientWithMockPriceClient(spyLogger, hubPoolClient, {}, [], relayerAddress, toBN(0));
   });
 
   it("Correctly fetches token prices", async function () {

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -113,7 +113,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
     );
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
-    profitClient = new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
+    profitClient = new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, [], relayer.address);
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,

--- a/test/mocks/MockProfitClient.ts
+++ b/test/mocks/MockProfitClient.ts
@@ -9,6 +9,7 @@ export class MockProfitClient extends ProfitClient {
     hubPoolClient: HubPoolClient,
     spokePoolClients: SpokePoolClientsByChain,
     enabledChainIds: number[],
+    relayerAddress: string,
     defaultMinRelayerFeePct?: BigNumber,
     debugProfitability?: boolean,
     gasMultiplier?: BigNumber
@@ -18,6 +19,7 @@ export class MockProfitClient extends ProfitClient {
       hubPoolClient,
       spokePoolClients,
       enabledChainIds,
+      relayerAddress,
       defaultMinRelayerFeePct,
       debugProfitability,
       gasMultiplier

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,12 +60,13 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.17.1":
-  version "0.17.1"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.1.tgz#8394e801304a5a57c3a8469c59d93642ce7647d9"
-  integrity sha512-jcNjV/IXc88FFSWYhhdfNXJGhHhInib7jCKXOiU5qBOykOntTkiljkYZZBxYrvUqh5mBLxqepRMLoSk4l5NfoQ==
+"@across-protocol/sdk-v2@0.17.4":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.4.tgz#595e813b4d1ce6b9f67254e6def3b022007ac62a"
+  integrity sha512-1PerCY2URknsC99XB2K+0XFdKRwVDeMRM35eksG6HNE+4SjwxioAUn+wWLfZ4PFuESA4Rhg79gNnKdIWPk4jrw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
+    "@across-protocol/constants-v2" "^1.0.4"
     "@across-protocol/contracts-v2" "^2.4.4"
     "@eth-optimism/sdk" "^2.1.0"
     "@pinata/sdk" "^2.1.0"


### PR DESCRIPTION
This PR gets relayer-v2 over the hurdle of a new SDK bump. The behaviour implemented here should be unchanged - the main impact is to supply a Deposit object to the relayFeeCalculator getGasCosts() method, rather than a simple chain ID.