### PR TITLE
feat: Add shortcuts for running dataworker and finalizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
     "clean": "dir=\"./node_modules\"; mv \"${dir}\" \"${dir}_\" 2>/dev/null && rm -r \"${dir}_\" &",
     "reinstall": "yarn clean && yarn install && yarn build",
     "update": "git pull && yarn reinstall && yarn version --non-interactive && git show --quiet",
+    "run-disputer": "DISPUTER_ENABLED=true HARDHAT_CONFIG=./dist/hardhat.config.js node ./dist/index.js --dataworker",
+    "run-executor": "EXECUTOR_ENABLED=true HARDHAT_CONFIG=./dist/hardhat.config.js node ./dist/index.js --dataworker",
+    "run-proposer": "PROPOSER_ENABLED=true HARDHAT_CONFIG=./dist/hardhat.config.js node ./dist/index.js --dataworker",
+    "run-finalizer": "FINALIZER_ENABLED=true HARDHAT_CONFIG=./dist/hardhat.config.js node ./dist/index.js --finalizer",
     "relay": "HARDHAT_CONFIG=./dist/hardhat.config.js node ./dist/index.js --relayer",
     "deposit": "yarn ts-node ./scripts/spokepool.ts deposit",
     "dispute": "yarn ts-node ./scripts/hubpool.ts dispute"


### PR DESCRIPTION
This negates the need to modify env vars when switching between the various dataworker personalities (and finalizer).

Usage:
- yarn run-disputer --wallet <wallet>
- yarn run-executor --wallet <wallet>
- yarn run-proposer --wallet <wallet>
- yarn run-finalizer --wallet <wallet>