### PR TITLE
improve: leverage caching interface

### DIFF
--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1,4 +1,4 @@
-import { clients } from "@across-protocol/sdk-v2";
+import { clients, interfaces } from "@across-protocol/sdk-v2";
 import { BigNumber, Contract } from "ethers";
 import winston from "winston";
 import { MakeOptional, EventSearchConfig } from "../utils";
@@ -12,12 +12,22 @@ export class HubPoolClient extends clients.HubPoolClient {
     configStoreClient: clients.AcrossConfigStoreClient,
     deploymentBlock?: number,
     chainId = 1,
-    eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 }
+    eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 },
+    cachingMechanism?: interfaces.CachingMechanismInterface
   ) {
-    super(logger, hubPool, configStoreClient, deploymentBlock, chainId, eventSearchConfig, {
-      ignoredHubExecutedBundles: IGNORED_HUB_EXECUTED_BUNDLES,
-      ignoredHubProposedBundles: IGNORED_HUB_PROPOSED_BUNDLES,
-    });
+    super(
+      logger,
+      hubPool,
+      configStoreClient,
+      deploymentBlock,
+      chainId,
+      eventSearchConfig,
+      {
+        ignoredHubExecutedBundles: IGNORED_HUB_EXECUTED_BUNDLES,
+        ignoredHubProposedBundles: IGNORED_HUB_PROPOSED_BUNDLES,
+      },
+      cachingMechanism
+    );
   }
 
   async computeRealizedLpFeePct(

--- a/src/clients/UBAClient.ts
+++ b/src/clients/UBAClient.ts
@@ -1,4 +1,4 @@
-import { clients } from "@across-protocol/sdk-v2";
+import { clients, interfaces } from "@across-protocol/sdk-v2";
 import { FillWithBlock, RefundRequestWithBlock } from "../interfaces";
 import { HubPoolClient } from "./HubPoolClient";
 import { SpokePoolClient } from "./SpokePoolClient";
@@ -11,9 +11,10 @@ export class UBAClient extends clients.UBAClient {
     clientConfig: clients.UBAClientConfig,
     tokenSymbols: string[],
     hubPoolClient: HubPoolClient,
-    spokePoolClients: { [chainId: number]: SpokePoolClient }
+    spokePoolClients: { [chainId: number]: SpokePoolClient },
+    cachingMechanism?: interfaces.CachingMechanismInterface
   ) {
-    super(clientConfig, tokenSymbols, hubPoolClient, spokePoolClients);
+    super(clientConfig, tokenSymbols, hubPoolClient, spokePoolClients, cachingMechanism);
   }
 
   async getFills(chainId: number, filter: SpokePoolFillFilter = {}): Promise<FillWithBlock[]> {

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -10,6 +10,7 @@ import {
   getCurrentTime,
   SpokePool,
   isDefined,
+  getRedisCache,
 } from "../utils";
 import { HubPoolClient, MultiCallerClient, ConfigStoreClient, SpokePoolClient } from "../clients";
 import { CommonConfig } from "./Config";
@@ -252,7 +253,8 @@ export async function constructClients(
     configStoreClient,
     Number(getDeploymentBlockNumber("HubPool", config.hubPoolChainId)),
     config.hubPoolChainId,
-    hubPoolClientSearchSettings
+    hubPoolClientSearchSettings,
+    await getRedisCache(logger)
   );
 
   const multiCallerClient = new MultiCallerClient(logger, config.multiCallChunkSize, hubSigner);

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -1,4 +1,12 @@
-import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, disconnectRedisClient } from "../utils";
+import {
+  processEndPollingLoop,
+  winston,
+  config,
+  startupLogLevel,
+  Wallet,
+  disconnectRedisClient,
+  getRedisCache,
+} from "../utils";
 import { spokePoolClientsToProviders } from "../common";
 import { Dataworker } from "./Dataworker";
 import { DataworkerConfig } from "./DataworkerConfig";
@@ -106,7 +114,8 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet)
         new sdkClients.UBAClientConfig(),
         clients.hubPoolClient.getL1Tokens().map((token) => token.symbol),
         clients.hubPoolClient,
-        spokePoolClients
+        spokePoolClients,
+        await getRedisCache(logger)
       );
       await clients.configStoreClient.update();
       const version = clients.configStoreClient.getConfigStoreVersionForTimestamp();

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -11,7 +11,7 @@ import {
   updateSpokePoolClients,
 } from "../common";
 import { SpokePoolClientsByChain } from "../interfaces";
-import { Wallet } from "../utils";
+import { Wallet, getRedisCache } from "../utils";
 import { RelayerConfig } from "./RelayerConfig";
 
 export interface RelayerClients extends Clients {
@@ -46,7 +46,8 @@ export async function constructRelayerClients(
     new sdkClients.UBAClientConfig(),
     commonClients.hubPoolClient.getL1Tokens().map((token) => token.symbol),
     commonClients.hubPoolClient,
-    spokePoolClients
+    spokePoolClients,
+    await getRedisCache(logger)
   );
 
   // We only use the API client to load /limits for chains so we should remove any chains that are not included in the


### PR DESCRIPTION
We have existing logic that utilizes caching in the Hub & UBA Client. This change will pass a Redis instance to them directly so that we can better leverage caching in the DW.

Suggested PR before merging: https://github.com/across-protocol/sdk-v2/pull/436