### PR TITLE
improve(dataworker): Change 288 buffer to be 0

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -126,7 +126,7 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
   1: 25, // At 12s/block, 25 blocks = 5 mins
   10: 150, // 2s/block, 5 mins = 300 seconds = 300 transactions. And 1 block per txn.
   137: 750, // At 2s/block, 25 mins = 25 * 60 / 2 = 750 blocks
-  288: 0, // **UPDATE** 288 is disabled so there should be no buffer. At 60s/block, 50 blocks = 25 mins
+  288: 0, // **UPDATE** 288 is disabled so there should be no buffer.
   324: 1500, // At 1s/block, 25 mins = 1500 blocks.
   8453: 750, // At 2s/block, 25 mins = 750 blocks.
   42161: 300, // At a conservative 1 TPS, 5 mins = 300 seconds = 300 transactions. And 1 block per txn.

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -126,7 +126,7 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
   1: 25, // At 12s/block, 25 blocks = 5 mins
   10: 150, // 2s/block, 5 mins = 300 seconds = 300 transactions. And 1 block per txn.
   137: 750, // At 2s/block, 25 mins = 25 * 60 / 2 = 750 blocks
-  288: 5, // At 60s/block, 50 blocks = 25 mins
+  288: 0, // **UPDATE** 288 is disabled so there should be no buffer. At 60s/block, 50 blocks = 25 mins
   324: 1500, // At 1s/block, 25 mins = 1500 blocks.
   8453: 750, // At 2s/block, 25 mins = 750 blocks.
   42161: 300, // At a conservative 1 TPS, 5 mins = 300 seconds = 300 transactions. And 1 block per txn.


### PR DESCRIPTION
This buffer is added to force the proposer to use `bundleEndBlocks` that lag the latest blocks seen by `SpokePoolClients`. This is used to create a minimum distance between proposals. For disabled chains, like 288, this buffer should be 0 since the end blocks should not advance between bundles