### PR TITLE
improve: Upgrade to sdk-v2 version with optimized caching logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.4",
     "@across-protocol/contracts-v2": "2.4.6",
-    "@across-protocol/sdk-v2": "0.17.4",
+    "@across-protocol/sdk-v2": "0.17.7",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -13,7 +13,8 @@ export class HubPoolClient extends clients.HubPoolClient {
     deploymentBlock?: number,
     chainId = 1,
     eventSearchConfig: MakeOptional<EventSearchConfig, "toBlock"> = { fromBlock: 0, maxBlockLookBack: 0 },
-    cachingMechanism?: interfaces.CachingMechanismInterface
+    cachingMechanism?: interfaces.CachingMechanismInterface,
+    timeToCache?: number
   ) {
     super(
       logger,
@@ -25,6 +26,7 @@ export class HubPoolClient extends clients.HubPoolClient {
       {
         ignoredHubExecutedBundles: IGNORED_HUB_EXECUTED_BUNDLES,
         ignoredHubProposedBundles: IGNORED_HUB_PROPOSED_BUNDLES,
+        timeToCache,
       },
       cachingMechanism
     );

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -254,7 +254,8 @@ export async function constructClients(
     Number(getDeploymentBlockNumber("HubPool", config.hubPoolChainId)),
     config.hubPoolChainId,
     hubPoolClientSearchSettings,
-    await getRedisCache(logger)
+    await getRedisCache(logger),
+    config.timeToCache
   );
 
   const multiCallerClient = new MultiCallerClient(logger, config.multiCallChunkSize, hubSigner);

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -43,7 +43,7 @@ export class CommonConfig {
     this.version = ACROSS_BOT_VERSION ?? "unknown";
 
     this.timeToCache = Number(HUB_POOL_TIME_TO_CACHE ?? 60 * 60); // 1 hour by default.
-    if (this.timeToCache < 0) {
+    if (Number.isNaN(this.timeToCache) || this.timeToCache < 0) {
       throw new Error("Invalid default caching safe lag");
     }
 

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -18,6 +18,7 @@ export class CommonConfig {
   readonly version: string;
   readonly maxConfigVersion: number;
   readonly blockRangeEndBlockBuffer: { [chainId: number]: number };
+  readonly timeToCache: number;
 
   // State we'll load after we update the config store client and fetch all chains we want to support.
   public multiCallChunkSize: { [chainId: number]: number };
@@ -36,9 +37,15 @@ export class CommonConfig {
       SPOKE_POOL_CHAINS_OVERRIDE,
       ACROSS_BOT_VERSION,
       ACROSS_MAX_CONFIG_VERSION,
+      HUB_POOL_TIME_TO_CACHE,
     } = env;
 
     this.version = ACROSS_BOT_VERSION ?? "unknown";
+
+    this.timeToCache = Number(HUB_POOL_TIME_TO_CACHE ?? 60 * 60); // 1 hour by default.
+    if (this.timeToCache < 0) {
+      throw new Error("Invalid default caching safe lag");
+    }
 
     // Maximum version of the Across ConfigStore version that is supported.
     // Operators should normally use the defaults here, but it can be overridden for testing.

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -1,4 +1,5 @@
-import { BlockFinder, getProvider, getRedis, isDefined, setRedisKey, shouldCache } from "./";
+import { BlockFinder, getProvider, isDefined } from "./";
+import { getCachedBlockForTimestamp } from "@across-protocol/sdk-v2";
 
 const blockFinders: { [chainId: number]: BlockFinder } = {};
 
@@ -30,29 +31,5 @@ export async function getBlockForTimestamp(
   timestamp: number,
   blockFinder?: BlockFinder
 ): Promise<number> {
-  blockFinder ??= await getBlockFinder(chainId);
-  const redisClient = await getRedis();
-
-  // If no redis client, then request block from blockFinder. Otherwise try to load from redis cache.
-  if (redisClient === undefined) {
-    return (await blockFinder.getBlockForTimestamp(timestamp)).number;
-  }
-
-  const key = `${chainId}_block_number_${timestamp}`;
-  const result = await redisClient.get(key);
-  if (result === null) {
-    const provider = await getProvider(chainId);
-    const [currentBlock, { number: blockNumber }] = await Promise.all([
-      provider.getBlock("latest"),
-      blockFinder.getBlockForTimestamp(timestamp),
-    ]);
-
-    // Expire key after 90 days.
-    if (shouldCache(timestamp, currentBlock.timestamp)) {
-      await setRedisKey(key, blockNumber.toString(), redisClient, 60 * 60 * 24 * 90);
-    }
-    return blockNumber;
-  } else {
-    return parseInt(result);
-  }
+  return getCachedBlockForTimestamp(chainId, timestamp, blockFinder ?? (await getBlockFinder(chainId)));
 }

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -22,14 +22,15 @@ export async function getBlockFinder(chainId: number): Promise<BlockFinder> {
  * If redis cache is not available, then requests block from blockFinder.
  * @param chainId Chain to load block finder for.
  * @param timestamp Approximate timestamp of the to requested block number.
- * @param blockFinder Caller can optionally pass in a block finder object to use instead of creating a new one
+ * @param _blockFinder Caller can optionally pass in a block finder object to use instead of creating a new one
  * or loading from cache. This is useful for testing primarily.
  * @returns Block number for the requested timestamp.
  */
 export async function getBlockForTimestamp(
   chainId: number,
   timestamp: number,
-  blockFinder?: BlockFinder
+  _blockFinder?: BlockFinder
 ): Promise<number> {
-  return utils.getCachedBlockForTimestamp(chainId, timestamp, blockFinder ?? (await getBlockFinder(chainId)));
+  const blockFinder = _blockFinder ?? (await getBlockFinder(chainId));
+  return utils.getCachedBlockForTimestamp(chainId, timestamp, blockFinder);
 }

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -1,5 +1,5 @@
 import { BlockFinder, getProvider, isDefined } from "./";
-import { getCachedBlockForTimestamp } from "@across-protocol/sdk-v2";
+import { utils } from "@across-protocol/sdk-v2";
 
 const blockFinders: { [chainId: number]: BlockFinder } = {};
 
@@ -31,5 +31,5 @@ export async function getBlockForTimestamp(
   timestamp: number,
   blockFinder?: BlockFinder
 ): Promise<number> {
-  return getCachedBlockForTimestamp(chainId, timestamp, blockFinder ?? (await getBlockFinder(chainId)));
+  return utils.getCachedBlockForTimestamp(chainId, timestamp, blockFinder ?? (await getBlockFinder(chainId)));
 }

--- a/src/utils/UmaUtils.ts
+++ b/src/utils/UmaUtils.ts
@@ -1,7 +1,7 @@
 import { HubPoolClient } from "../clients";
 import { CONTRACT_ADDRESSES } from "../common";
 import { ProposedRootBundle, SortableEvent } from "../interfaces";
-import { Contract, ethers, getCachedBlockForTimestamp, isEventOlder, sortEventsDescending } from ".";
+import { Contract, ethers, getBlockForTimestamp, isEventOlder, sortEventsDescending } from ".";
 
 export async function getDvmContract(provider: ethers.providers.Provider): Promise<Contract> {
   const { chainId } = await provider.getNetwork();
@@ -28,7 +28,7 @@ export async function getDisputeForTimestamp(
   const priceRequestBlock =
     disputeRequestBlock !== undefined
       ? disputeRequestBlock
-      : await getCachedBlockForTimestamp(hubPoolClient.chainId, disputeRequestTimestamp);
+      : await getBlockForTimestamp(hubPoolClient.chainId, disputeRequestTimestamp);
 
   const disputes = await dvm.queryFilter(filter, priceRequestBlock, priceRequestBlock);
   return disputes.find((e) => e.args.time.toString() === disputeRequestTimestamp.toString()) as SortableEvent;

--- a/src/utils/UmaUtils.ts
+++ b/src/utils/UmaUtils.ts
@@ -1,7 +1,7 @@
 import { HubPoolClient } from "../clients";
 import { CONTRACT_ADDRESSES } from "../common";
 import { ProposedRootBundle, SortableEvent } from "../interfaces";
-import { Contract, ethers, getBlockForTimestamp, isEventOlder, sortEventsDescending } from ".";
+import { Contract, ethers, getCachedBlockForTimestamp, isEventOlder, sortEventsDescending } from ".";
 
 export async function getDvmContract(provider: ethers.providers.Provider): Promise<Contract> {
   const { chainId } = await provider.getNetwork();
@@ -28,7 +28,7 @@ export async function getDisputeForTimestamp(
   const priceRequestBlock =
     disputeRequestBlock !== undefined
       ? disputeRequestBlock
-      : await getBlockForTimestamp(hubPoolClient.chainId, disputeRequestTimestamp);
+      : await getCachedBlockForTimestamp(hubPoolClient.chainId, disputeRequestTimestamp);
 
   const disputes = await dvm.queryFilter(filter, priceRequestBlock, priceRequestBlock);
   return disputes.find((e) => e.args.time.toString() === disputeRequestTimestamp.toString()) as SortableEvent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.17.4":
-  version "0.17.4"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.4.tgz#595e813b4d1ce6b9f67254e6def3b022007ac62a"
-  integrity sha512-1PerCY2URknsC99XB2K+0XFdKRwVDeMRM35eksG6HNE+4SjwxioAUn+wWLfZ4PFuESA4Rhg79gNnKdIWPk4jrw==
+"@across-protocol/sdk-v2@0.17.7":
+  version "0.17.7"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.7.tgz#b7ae5e047910caf2ccb35b7c32afb319f9b9b36e"
+  integrity sha512-W2AwPjW95k5o+cSNkezcq4RTDyCN8u6PcUS5xBzCAF0Ed9hNUjS3gxW85gC/bw3fVftbMwmDe2Jk6K/WrX7CEA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.4"


### PR DESCRIPTION
Should see speed ups in dataworker by:
- reducing time to cache utilization in HubPoolClient
- use redis cache for block finder getBlockForTimestamp functions