### PR TITLE
feat: add basic response validation to the RetryProvider

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -426,6 +426,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       logger.debug({
         at: "ProviderUtils",
         message: "Provider returned invalid response",
+        provider: getOriginFromURL(provider.connection.url),
         method,
         params,
         response,

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -431,7 +431,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
         params,
         response,
       });
-      throw new Error(`Response failed validation for method ${method}, params ${params}, response ${response}`);
+      throw new Error("Response failed validation");
     }
     return response;
   }

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -415,13 +415,24 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
     return isDefined(response);
   }
 
-  _sendAndValidate(provider: ethers.providers.StaticJsonRpcProvider, method: string, params: Array<any>): Promise<any> {
-    return provider.send(method, params).then((response) => {
-      if (!this._validateResponse(method, params, response)) {
-        throw new Error(`Response failed validation for method ${method}, params ${params}, response ${response}`);
-      }
-      return response;
-    });
+  async _sendAndValidate(
+    provider: ethers.providers.StaticJsonRpcProvider,
+    method: string,
+    params: Array<any>
+  ): Promise<any> {
+    const response = await provider.send(method, params);
+    if (!this._validateResponse(method, params, response)) {
+      // Not a warning to avoid spam since this could trigger a lot.
+      logger.debug({
+        at: "ProviderUtils",
+        message: "Provider returned invalid response",
+        method,
+        params,
+        response,
+      });
+      throw new Error(`Response failed validation for method ${method}, params ${params}, response ${response}`);
+    }
+    return response;
   }
 
   _trySend(provider: ethers.providers.StaticJsonRpcProvider, method: string, params: Array<any>): Promise<any> {


### PR DESCRIPTION
This adds a simple method to make sure we don't accept a null or undefined response. In the future, we can enhance this logic by validating that it contains the fields, etc that we expect.