### PR TITLE
fix: Use RL relayer address for basic gas cost estimation

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -20,7 +20,7 @@ import { Deposit, DepositWithBlock, L1Token, SpokePoolClientsByChain } from "../
 import { HubPoolClient } from ".";
 
 const { formatEther } = ethersUtils;
-const { EMPTY_MESSAGE } = sdkConsts;
+const { EMPTY_MESSAGE, DEFAULT_SIMULATED_RELAYER_ADDRESS: TEST_RELAYER } = sdkConsts;
 const { bnOne, bnUint32Max, fixedPointAdjustment: fixedPoint, isMessageEmpty, resolveDepositMessage } = sdkUtils;
 
 // We use wrapped ERC-20 versions instead of the native tokens such as ETH, MATIC for ease of computing prices.
@@ -63,14 +63,6 @@ export const GAS_TOKEN_BY_CHAIN_ID: { [chainId: number]: string } = {
 };
 // TODO: Make this dynamic once we support chains with gas tokens that have different decimals.
 const GAS_TOKEN_DECIMALS = 18;
-
-// @dev This address is known on each chain and has previously been used to simulate Deposit gas costs.
-// Since _some_ known recipient address is needed for simulating a fill, default to this one. nb. Since
-// the SpokePool implements custom behaviour when relayer === recipient, it's important not to use the
-// relayer's own address.
-// @todo: Consider using an address with confirmed 0 destinationToken balance so that the initial cost
-// of populating storage is included in the estimate.
-const TEST_RECIPIENT = "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B";
 
 // These are used to simulate fills on L2s to return estimated gas costs.
 // Note: the type here assumes that all of these classes take the same constructor parameters.
@@ -436,10 +428,14 @@ export class ProfitClient {
         destinationChainId === hubPoolClient.chainId
           ? USDC
           : hubPoolClient.getDestinationTokenForL1Token(USDC, destinationChainId);
+
+      // @dev The relayer _can not_ be the recipient, since the SpokePool short-circuits the ERC20 transfer
+      // and consumes less gas. Instead, just use the main RL address as the simulated relayer, since it has
+      // all supported tokens and approvals in place on all chains.
       const deposit: Deposit = {
         depositId,
-        depositor: TEST_RECIPIENT,
-        recipient: TEST_RECIPIENT,
+        depositor: relayerAddress,
+        recipient: relayerAddress,
         originToken: "", // not relevant
         amount: fillAmount,
         originChainId: this.enabledChainIds.find((chainId) => chainId !== destinationChainId),
@@ -452,7 +448,7 @@ export class ProfitClient {
       };
 
       // An extra toBN cast is needed as the provider returns a different BigNumber type.
-      const gasCost = await relayerFeeQueries[destinationChainId].getGasCosts(deposit, fillAmount, relayerAddress);
+      const gasCost = await relayerFeeQueries[destinationChainId].getGasCosts(deposit, fillAmount, TEST_RELAYER);
       this.totalGasCosts[this.enabledChainIds[idx]] = toBN(gasCost);
     });
 

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -423,7 +423,7 @@ export class ProfitClient {
   }
 
   private async updateGasCosts(): Promise<void> {
-    const { enabledChainIds, hubPoolClient, relayerAddress, relayerFeeQueries } = this;
+    const { enabledChainIds, hubPoolClient, relayerFeeQueries } = this;
     const depositId = random(bnUint32Max.toNumber()); // random depositId + "" originToken => ~impossible to collide.
     const fillAmount = bnOne;
     const quoteTimestamp = getCurrentTime();

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -64,6 +64,12 @@ export const GAS_TOKEN_BY_CHAIN_ID: { [chainId: number]: string } = {
 // TODO: Make this dynamic once we support chains with gas tokens that have different decimals.
 const GAS_TOKEN_DECIMALS = 18;
 
+// @dev This address is known on each chain and has previously been used to simulate Deposit gas costs.
+// Since _some_ known recipient address is needed for simulating a fill, default to this one. nb. Since
+// the SpokePool implements custom behaviour when relayer === recipient, it's important not to use the
+// relayer's own address. The specified address is deliberately setup by RL to have a 0 token balance.
+const TEST_RECIPIENT = "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B";
+
 // These are used to simulate fills on L2s to return estimated gas costs.
 // Note: the type here assumes that all of these classes take the same constructor parameters.
 const QUERY_HANDLERS: {
@@ -434,8 +440,8 @@ export class ProfitClient {
       // all supported tokens and approvals in place on all chains.
       const deposit: Deposit = {
         depositId,
-        depositor: relayerAddress,
-        recipient: relayerAddress,
+        depositor: TEST_RECIPIENT,
+        recipient: TEST_RECIPIENT,
         originToken: "", // not relevant
         amount: fillAmount,
         originChainId: this.enabledChainIds.find((chainId) => chainId !== destinationChainId),


### PR DESCRIPTION
It's invalid to use the current relayer's EOA because that address may not hold USDC on all chains. Instead, default to the main RL address.

The relayer's own address will be used for dynamic message-based simulation.