### PR TITLE
feat: avoid directly using

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,21 @@ jobs:
       - run:
           name: Run lint
           command: yarn lint
+  no-leaked-logs:
+    docker:
+      - image: circleci/python:3.7
+    steps:
+      - checkout
+      - run:
+          name: Search for connection.url
+          command: |
+            if find . -type f -not -path "./node_modules/*" -not -path "./src/utils/NetworkUtils.ts" -exec grep -H "connection.url" {} +; then
+              echo "Found 'connection.url'. Failing the test."
+              exit 1
+            else
+              echo "'connection.url' not found."
+              exit 0
+            fi
 workflows:
   version: 2.1
   build_and_test:
@@ -62,5 +77,8 @@ workflows:
           requires:
             - install
       - lint:
+          requires:
+            - install
+      - no-leaked-logs:
           requires:
             - install


### PR DESCRIPTION
This includes a new test in CircleCI that looks for a direct reference to `provider.connection.url`. We _almost never_ need to reference this path except to print logs. We should do that in one location centrally and fail a CI build if we encounter this throughout the rest of the code.

Note: this is not meant to be a true security check for leaked secrets. There are many ways to bypass this check. However, for most normal actors who are using the code in the style that we are used to seeing, this CI build should flag on accidental pre-exposure.