### PR TITLE
fix: Correct ProfitClient type annotation

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -209,7 +209,7 @@ export class ProfitClient {
     };
   }
 
-  getUnprofitableFills(): { [chainId: number]: { deposit: DepositWithBlock; fillAmount: BigNumber }[] } {
+  getUnprofitableFills(): { [chainId: number]: UnprofitableFill[] } {
     return this.unprofitableFills;
   }
 


### PR DESCRIPTION
This was missed in the previous commit. tsc isn't complaining about it and the code runs OK locally, but better to apply this fix now.