### PR TITLE
improve: Support relayer self-filling despite insufficient balance

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -184,7 +184,7 @@ export class Relayer {
     for (const { deposit, version, unfilledAmount, fillCount, invalidFills } of confirmedUnfilledDeposits) {
       const { relayerTokens, slowDepositors } = config;
 
-      const { originChainId, destinationChainId, originToken } = deposit;
+      const { depositId, depositor, recipient, originChainId, destinationChainId, originToken, amount } = deposit;
       const destinationChain = getNetworkName(destinationChainId);
 
       // Skip any L1 tokens that are not specified in the config.
@@ -221,10 +221,10 @@ export class Relayer {
           message: "😱 Skipping deposit with greater unfilled amount than API suggested limit",
           limit: acrossApiClient.getLimit(l1Token.address),
           l1Token: l1Token.address,
-          depositId: deposit.depositId,
-          amount: deposit.amount,
+          depositId,
+          amount,
           unfilledAmount: unfilledAmount.toString(),
-          originChainId: deposit.originChainId,
+          originChainId,
           transactionHash: deposit.transactionHash,
         });
         continue;
@@ -245,12 +245,12 @@ export class Relayer {
       }
 
       // If depositor is on the slow deposit list, then send a zero fill to initiate a slow relay and return early.
-      if (slowDepositors?.includes(deposit.depositor)) {
+      if (slowDepositors?.includes(depositor)) {
         if (sendSlowRelays && fillCount === 0 && tokenClient.hasBalanceForZeroFill(deposit)) {
           this.logger.debug({
             at: "Relayer",
             message: "Initiating slow fill for grey listed depositor",
-            depositor: deposit.depositor,
+            depositor,
           });
           this.zeroFillDeposit(deposit);
         }
@@ -275,8 +275,10 @@ export class Relayer {
         } else {
           profitClient.captureUnprofitableFill(deposit, unfilledAmount, gasCost);
         }
-      } else if (deposit.recipient === this.relayerAddress) {
-        // A relayer can fill its own deposit without an ERC20 transfer.
+      } else if (depositor === this.relayerAddress && recipient === this.relayerAddress) {
+        // A relayer can fill its own deposit without an ERC20 transfer. Only bypass profitability requirements if the
+        // relayer is both the depositor and the recipient, because a deposit on a cheap SpokePool chain could cause
+        // expensive fills on (for example) mainnet.
         this.fillRelay(deposit, unfilledAmount, destinationChainId);
       } else {
         tokenClient.captureTokenShortfallForFill(deposit, unfilledAmount);

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -275,6 +275,9 @@ export class Relayer {
         } else {
           profitClient.captureUnprofitableFill(deposit, unfilledAmount, gasCost);
         }
+      } else if (deposit.recipient === this.relayerAddress) {
+        // A relayer can fill its own deposit without an ERC20 transfer.
+        this.fillRelay(deposit, unfilledAmount, destinationChainId);
       } else {
         tokenClient.captureTokenShortfallForFill(deposit, unfilledAmount);
         // If we don't have enough balance to fill the unfilled amount and the fill count on the deposit is 0 then send a

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -275,7 +275,7 @@ export class Relayer {
         } else {
           profitClient.captureUnprofitableFill(deposit, unfilledAmount, gasCost);
         }
-      } else if (depositor === this.relayerAddress && recipient === this.relayerAddress) {
+      } else if ([depositor, recipient].every((address) => address === this.relayerAddress)) {
         // A relayer can fill its own deposit without an ERC20 transfer. Only bypass profitability requirements if the
         // relayer is both the depositor and the recipient, because a deposit on a cheap SpokePool chain could cause
         // expensive fills on (for example) mainnet.

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -210,15 +210,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
   it("Correctly validates self-relays", async function () {
     const relayerFeePct = bnZero;
     for (const testDepositor of [depositor, relayer]) {
-      await deposit(
-        spokePool_1,
-        erc20_1,
-        relayer,
-        testDepositor,
-        destinationChainId,
-        amountToDeposit,
-        relayerFeePct,
-      );
+      await deposit(spokePool_1, erc20_1, relayer, testDepositor, destinationChainId, amountToDeposit, relayerFeePct);
 
       await updateAllClients();
       await relayerInstance.checkForUnfilledDepositsAndFill();


### PR DESCRIPTION
The relayer doesn't need to have have enough of the token to complete a                                                                                                                        
fill when its own address is the recipient of the transfer.