### PR TITLE
improve(ProviderUtils): Temporarily ignore block size field

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -90,6 +90,7 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
         "miner", // polygon (sometimes)
         "l1BatchNumber", // zkSync
         "l1BatchTimestamp", // zkSync
+        "size", // Alchemy/Arbitrum (temporary)
       ],
       rpcResultA,
       rpcResultB


### PR DESCRIPTION
Alchemy have been disagreeing with other providers on Arbitrum for a few days now; it causes higher RPC usage and unnecessary log noise. Disable it for now, with the option of reverting in future (if they fix it) or retaining it indefinitely, since we don't actually rely on this field.