### PR TITLE
fix: Log aborted zero-fills (w/ message) at warn

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -355,7 +355,7 @@ export class Relayer {
     // Verify that the _original_ message was empty, since that's what would be used in a slow fill. If a non-empty
     // message was nullified by an update, it can be full-filled but preferably not automatically zero-filled.
     if (!isMessageEmpty(deposit.message)) {
-      this.logger.debug({
+      this.logger.warn({
         at: "Relayer::zeroFillDeposit",
         message: "Suppressing zero-fill for deposit with message.",
         deposit,


### PR DESCRIPTION
This is a condition that should ideally be readily observable for bot
operators.