### PR TITLE
fix: Restore relayer testnet support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.4",
     "@across-protocol/contracts-v2": "2.4.6",
-    "@across-protocol/sdk-v2": "0.17.8",
+    "@across-protocol/sdk-v2": "0.17.9",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -106,11 +106,11 @@ const QUERY_HANDLERS: {
   42161: relayFeeCalculator.ArbitrumQueries,
   8453: relayFeeCalculator.BaseQueries,
   // Testnets:
-  5: relayFeeCalculator.EthereumQueries,
+  5: relayFeeCalculator.EthereumGoerliQueries,
   280: relayFeeCalculator.zkSyncGoerliQueries,
-  80001: relayFeeCalculator.PolygonQueries,
+  80001: relayFeeCalculator.PolygonMumbaiQueries,
   84531: relayFeeCalculator.BaseGoerliQueries,
-  421613: relayFeeCalculator.ArbitrumQueries,
+  421613: relayFeeCalculator.ArbitrumGoerliQueries,
 };
 
 const { PriceClient } = priceClient;
@@ -471,11 +471,14 @@ export class ProfitClient {
     const quoteTimestamp = getCurrentTime();
 
     // Pre-fetch total gas costs for relays on enabled chains.
+    const testToken = "WETH";
+    const WETH = TOKEN_SYMBOLS_MAP[testToken].addresses[this.hubPoolClient.chainId];
     await sdkUtils.mapAsync(enabledChainIds, async (destinationChainId, idx) => {
       const destinationToken =
         destinationChainId === hubPoolClient.chainId
-          ? USDC
-          : hubPoolClient.getDestinationTokenForL1Token(USDC, destinationChainId);
+          ? WETH
+          : hubPoolClient.getDestinationTokenForL1Token(WETH, destinationChainId);
+      assert(isDefined(destinationToken), `Chain ${destinationChainId} SpokePool is not configured for ${testToken}`);
 
       // @dev The relayer _can not_ be the recipient, since the SpokePool short-circuits the ERC20 transfer
       // and consumes less gas. Instead, just use the main RL address as the simulated relayer, since it has

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.17.8":
-  version "0.17.8"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.8.tgz#0e6a668452eb3adb2008d918c0a01dafbf49d4a9"
-  integrity sha512-RYSyyyPq6qZuPuTbHV6GJuO4EUSIu4CXJLiVp4mJ1G8KfOYqETIwwsSmomZY1vmYtHeiCe7EdqPlF1A2Czk/9A==
+"@across-protocol/sdk-v2@0.17.9":
+  version "0.17.9"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.9.tgz#8caf44f1ad6d40260b05543ecc8d8f4f4d3c61dc"
+  integrity sha512-J6r5pU9lG/OR1MBnpZ1ECnPceYXDsfJsH3Wh1cvr8CvTIIlQ3bdSIXwwnfJdAjvSXUHvk6s7HQNoVJBeUjfZQw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.4"


### PR DESCRIPTION
- Use the correct relayFeeCalculator query handlers for the various testnets.
- When selecting the HubPool token to map to a SpokePool token for test, be sure to use the HubPool's chain ID, rather than defaulting to mainnet.
- Simulate the fill with WETH, rather than USDC. Testnet tokens are annoying to configure because there are too many random ERC20s claiming to be WETH and USDC (and others). Since WETH is required as part of most SpokePool deployments, if we pick the wrong address on a testnet then at least we'll be "wrong" consistently.

Fixes ACX-1647