### PR TITLE
refactor(ProfitClient): Overhaul gas token resolution

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -469,7 +469,7 @@ export class ProfitClient {
       const destinationToken =
         destinationChainId === hubPoolClient.chainId
           ? hubToken
-          : hubPoolClient.getDestinationTokenForL1Token(testSymbol, destinationChainId);
+          : hubPoolClient.getDestinationTokenForL1Token(hubToken, destinationChainId);
       assert(isDefined(destinationToken), `Chain ${destinationChainId} SpokePool is not configured for ${testSymbol}`);
 
       // @dev The relayer _can not_ be the recipient, since the SpokePool short-circuits the ERC20 transfer

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -1,4 +1,4 @@
-import { random } from "lodash";
+import { random, uniq } from "lodash";
 import { Provider } from "@ethersproject/abstract-provider";
 import { utils as ethersUtils } from "ethers";
 import {
@@ -38,12 +38,6 @@ const {
   resolveDepositMessage,
 } = sdkUtils;
 
-// We use wrapped ERC-20 versions instead of the native tokens such as ETH, MATIC for ease of computing prices.
-export const MATIC = TOKEN_SYMBOLS_MAP.MATIC.addresses[CHAIN_IDs.MAINNET];
-export const USDC = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET];
-export const WBTC = TOKEN_SYMBOLS_MAP.WBTC.addresses[CHAIN_IDs.MAINNET];
-export const WETH = TOKEN_SYMBOLS_MAP.WETH.addresses[CHAIN_IDs.MAINNET];
-
 // @note All FillProfit BigNumbers are scaled to 18 decimals unless specified otherwise.
 export type FillProfit = {
   grossRelayerFeePct: BigNumber; // Max of relayerFeePct and newRelayerFeePct from Deposit.
@@ -67,6 +61,9 @@ type UnprofitableFill = {
   nativeGasCost: BigNumber;
 };
 
+const WETH = "WETH";
+const MATIC = "MATIC";
+
 export const GAS_TOKEN_BY_CHAIN_ID: { [chainId: number]: string } = {
   1: WETH,
   10: WETH,
@@ -82,8 +79,6 @@ export const GAS_TOKEN_BY_CHAIN_ID: { [chainId: number]: string } = {
   84531: WETH,
   421613: WETH,
 };
-// TODO: Make this dynamic once we support chains with gas tokens that have different decimals.
-const GAS_TOKEN_DECIMALS = 18;
 
 // @dev This address is known on each chain and has previously been used to simulate Deposit gas costs.
 // Since _some_ known recipient address is needed for simulating a fill, default to this one. nb. Since
@@ -163,6 +158,19 @@ export class ProfitClient {
     this.isTestnet = this.hubPoolClient.chainId !== CHAIN_IDs.MAINNET;
   }
 
+  resolveGasToken(chainId: number): L1Token {
+    const symbol = GAS_TOKEN_BY_CHAIN_ID[chainId];
+    const token = TOKEN_SYMBOLS_MAP[symbol];
+    if (!isDefined(symbol) || !isDefined(token)) {
+      throw new Error(`Unable to resolve gas token for chain ID ${chainId}`);
+    }
+
+    const { decimals, addresses } = token;
+    const address = addresses[1]; // Mainnet tokens are always used for price lookups.
+
+    return { symbol, address, decimals };
+  }
+
   getAllPrices(): { [address: string]: BigNumber } {
     return this.tokenPrices;
   }
@@ -211,12 +219,13 @@ export class ProfitClient {
     fillAmount = deposit.amount
   ): Promise<Pick<FillProfit, "nativeGasCost" | "gasPriceUsd" | "gasCostUsd">> {
     const { destinationChainId: chainId } = deposit;
-    const gasPriceUsd = this.getPriceOfToken(GAS_TOKEN_BY_CHAIN_ID[chainId]);
+    const gasToken = this.resolveGasToken(chainId);
+    const gasPriceUsd = this.getPriceOfToken(gasToken.address);
     const nativeGasCost = await this.getTotalGasCost(deposit, fillAmount); // gas cost in native token
 
     if (gasPriceUsd.lte(0) || nativeGasCost.lte(0)) {
       const err = gasPriceUsd.lte(0) ? "gas price" : "gas consumption";
-      throw new Error(`Unable to compute gas cost (${err} unknown)`);
+      throw new Error(`Unable to compute chain ${chainId} fillRelay gas cost (${err} unknown)`);
     }
 
     // this.gasMultiplier is scaled to 18 decimals
@@ -224,7 +233,7 @@ export class ProfitClient {
       .mul(this.gasMultiplier)
       .mul(gasPriceUsd)
       .div(fixedPoint)
-      .div(toBN(10).pow(GAS_TOKEN_DECIMALS));
+      .div(toBN(10).pow(gasToken.decimals));
 
     return {
       nativeGasCost,
@@ -420,12 +429,12 @@ export class ProfitClient {
       this.hubPoolClient.getL1Tokens().map((token) => [token.address, token])
     );
 
-    // Also include MATIC in the price queries as we need it for gas cost calculation.
-    l1Tokens[MATIC] = {
-      address: MATIC,
-      symbol: "MATIC",
-      decimals: 18,
-    };
+    // Also ensure all gas tokens are included in the lookup.
+    uniq(Object.values(GAS_TOKEN_BY_CHAIN_ID)).map((symbol) => {
+      const { decimals, addresses } = TOKEN_SYMBOLS_MAP[symbol];
+      const address = addresses[1];
+      l1Tokens[address] ??= { symbol, decimals, address };
+    });
 
     this.logger.debug({ at: "ProfitClient", message: "Updating Profit client", tokens: Object.values(l1Tokens) });
 
@@ -454,14 +463,14 @@ export class ProfitClient {
     const quoteTimestamp = getCurrentTime();
 
     // Pre-fetch total gas costs for relays on enabled chains.
-    const testToken = "WETH";
-    const WETH = TOKEN_SYMBOLS_MAP[testToken].addresses[this.hubPoolClient.chainId];
+    const testSymbol = "WETH";
+    const hubToken = TOKEN_SYMBOLS_MAP[testSymbol].addresses[this.hubPoolClient.chainId];
     await sdkUtils.mapAsync(enabledChainIds, async (destinationChainId, idx) => {
       const destinationToken =
         destinationChainId === hubPoolClient.chainId
-          ? WETH
-          : hubPoolClient.getDestinationTokenForL1Token(WETH, destinationChainId);
-      assert(isDefined(destinationToken), `Chain ${destinationChainId} SpokePool is not configured for ${testToken}`);
+          ? hubToken
+          : hubPoolClient.getDestinationTokenForL1Token(testSymbol, destinationChainId);
+      assert(isDefined(destinationToken), `Chain ${destinationChainId} SpokePool is not configured for ${testSymbol}`);
 
       // @dev The relayer _can not_ be the recipient, since the SpokePool short-circuits the ERC20 transfer
       // and consumes less gas. Instead, just use the main RL address as the simulated relayer, since it has

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -62,9 +62,6 @@ type UnprofitableFill = {
   nativeGasCost: BigNumber;
 };
 
-const WETH = "WETH";
-const MATIC = "MATIC";
-
 // @dev This address is known on each chain and has previously been used to simulate Deposit gas costs.
 // Since _some_ known recipient address is needed for simulating a fill, default to this one. nb. Since
 // the SpokePool implements custom behaviour when relayer === recipient, it's important not to use the

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -68,7 +68,7 @@ describe("ProfitClient: Consider relay profit", () => {
   const randomiseGasCost = (chainId: number): BigNumber => {
     // Randomise the gas token price (usd)
     const gasToken = profitClient.resolveGasToken(chainId);
-    const gasPriceUsd = toBNWei(Math.random().toPrecision(10));
+    const gasPriceUsd = toBNWei(Math.random().toFixed(18));
     profitClient.setTokenPrice(gasToken.address, gasPriceUsd);
 
     // Randomise the fillRelay cost in units of gas.
@@ -390,7 +390,7 @@ describe("ProfitClient: Consider relay profit", () => {
   it("Allows per-route and per-token fee configuration", () => {
     // Setup custom USDC pricing to Optimism.
     chainIds.forEach((srcChainId) => {
-      process.env[`MIN_RELAYER_FEE_PCT_USDC_${srcChainId}_10`] = Math.random().toPrecision(10).toString();
+      process.env[`MIN_RELAYER_FEE_PCT_USDC_${srcChainId}_10`] = Math.random().toFixed(10).toString();
       process.env[`MIN_RELAYER_FEE_PCT_USDC_${srcChainId}_42161`] = "0.00005";
     });
 

--- a/test/mocks/MockProfitClient.ts
+++ b/test/mocks/MockProfitClient.ts
@@ -1,5 +1,5 @@
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
-import { GAS_TOKEN_BY_CHAIN_ID, HubPoolClient, ProfitClient } from "../../src/clients";
+import { HubPoolClient, ProfitClient } from "../../src/clients";
 import { SpokePoolClientsByChain } from "../../src/interfaces";
 import { isDefined } from "../../src/utils";
 import { BigNumber, winston } from "../utils";
@@ -28,8 +28,6 @@ export class MockProfitClient extends ProfitClient {
 
     // Some tests run against mocked chains, so hack in the necessary parts
     Object.values(spokePoolClients).map(({ chainId }) => {
-      GAS_TOKEN_BY_CHAIN_ID[chainId] ??= "WETH";
-
       // Ensure a minimum price for the gas token.
       const gasToken = this.resolveGasToken(hubPoolClient.chainId);
       const gasTokenPrice = this.getPriceOfToken(gasToken.address);


### PR DESCRIPTION
Specify the gas token for a chain by its symbol, and then dynamically resolve the underlying token on mainnet. Also, remove some hardcoding around the lookup of MATIC for Polygon. This is part of some cleanup to make it easier to run the relayer on a testnet.