### PR TITLE
chore: Use sdk-v2 getABI()

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@maticnetwork/maticjs-ethers": "^1.0.3",
     "@openzeppelin/hardhat-upgrades": "^1.28.0",
     "@uma/common": "2.33.0",
-    "@uma/contracts-node": "^0.4.16",
     "@uma/financial-templates-lib": "^2.34.1",
     "async": "^3.2.4",
     "axios": "^1.4.0",

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -73,7 +73,7 @@ export async function finalize(
 
   // Note: Could move this into a client in the future to manage # of calls and chunk calls based on
   // input byte length.
-  const multicall2 = getMultisender(hubChainId, hubSigner);
+  const multicall2 = await getMultisender(hubChainId, hubSigner);
   const finalizationsToBatch: { txn: Multicall2Call; withdrawal?: Withdrawal }[] = [];
 
   // For each chain, delegate to a handler to look up any TokensBridged events and attempt finalization.

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -1,6 +1,5 @@
-import { gasPriceOracle, typeguards } from "@across-protocol/sdk-v2";
+import { gasPriceOracle, typeguards, utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { FeeData } from "@ethersproject/abstract-provider";
-import { getAbi } from "@uma/contracts-node";
 import dotenv from "dotenv";
 import { AugmentedTransaction } from "../clients";
 import { DEFAULT_GAS_FEE_SCALERS, multicall3Addresses } from "../common";
@@ -34,11 +33,11 @@ const txnRetryable = (error?: unknown): boolean => {
   return expectedRpcErrorMessages.has((error as Error)?.message);
 };
 
-export function getMultisender(chainId: number, baseSigner: Wallet): Contract | undefined {
+export async function getMultisender(chainId: number, baseSigner: Wallet): Promise<Contract | undefined> {
   if (!multicall3Addresses[chainId] || !baseSigner) {
     return undefined;
   }
-  return new Contract(multicall3Addresses[chainId], getAbi("Multicall3"), baseSigner);
+  return new Contract(multicall3Addresses[chainId], await sdkUtils.getABI("Multicall3"), baseSigner);
 }
 
 // Note that this function will throw if the call to the contract on method for given args reverts. Implementers

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -1,3 +1,4 @@
+import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import {
   AugmentedTransaction,
   knownRevertReasons,
@@ -8,7 +9,6 @@ import { TransactionSimulationResult } from "../src/utils";
 import { MockedTransactionClient, txnClientPassResult } from "./mocks/MockTransactionClient";
 import { CHAIN_ID_TEST_LIST as chainIds } from "./constants";
 import { createSpyLogger, Contract, expect, randomAddress, winston, toBN, smock, assertPromiseError } from "./utils";
-import { getAbi } from "@uma/contracts-node";
 import { MockedMultiCallerClient } from "./mocks/MockMultiCallerClient";
 
 class DummyMultiCallerClient extends MockedMultiCallerClient {
@@ -339,7 +339,7 @@ describe("MultiCallerClient", async function () {
   });
 
   it("Correctly handles unpermissioned transactions", async function () {
-    const fakeMultisender = await smock.fake(getAbi("Multicall3"), { address: randomAddress() });
+    const fakeMultisender = await smock.fake(await sdkUtils.getABI("Multicall3"), { address: randomAddress() });
     const multicallerWithMultisend = new DummyMultiCallerClient(spyLogger, {}, fakeMultisender as unknown as Contract);
 
     // Can't pass any transactions to multisender bundler that are permissioned or different chains:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3340,7 +3340,7 @@
   resolved "https://registry.yarnpkg.com/@uma/contracts-frontend/-/contracts-frontend-0.4.18.tgz#339093239ea6f2ba2914de424ad609e6f9346379"
   integrity sha512-0UcA0Io+RB8p2BAeoyubNb0wQzvIWynQ2805ZzbwWhDB2jlW2xRNAKPRP6kcxaqtzCYcEoLnsTLwOP0ojmeWjw==
 
-"@uma/contracts-node@^0.4.0", "@uma/contracts-node@^0.4.16", "@uma/contracts-node@^0.4.17":
+"@uma/contracts-node@^0.4.0", "@uma/contracts-node@^0.4.17":
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/@uma/contracts-node/-/contracts-node-0.4.17.tgz#6abd815723c8344017eb5c302f6a5b0b690eeb4e"
   integrity sha512-e7cVJr3yhKrPZn1TAo/CCOt+QacJON6Mj71lcwHq/rnx+tgjujK2MsOhihytmb79ejPTKg1b5+2GIDL02ttrrQ==


### PR DESCRIPTION
This replaces the version from contracts-node and permits contracts-node to be dropped as a direct dependency.