### PR TITLE
chore: Drop Across API timeout from 60s to 3s

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -25,7 +25,7 @@ export class AcrossApiClient {
     readonly hubPoolClient: HubPoolClient,
     readonly spokePoolClients: SpokePoolClientsByChain,
     readonly tokensQuery: string[] = [],
-    readonly timeout: number = 60000
+    readonly timeout: number = 3000
   ) {
     if (Object.keys(tokensQuery).length === 0) {
       this.tokensQuery = Object.entries(TOKEN_SYMBOLS_MAP).map(([, details]) => details.addresses[CHAIN_IDs.MAINNET]);


### PR DESCRIPTION
Most API queries should resolve in under 1 second, but there are occasions where we log that we hit the 60s timeout. This is a major slowdown for the bots. Since we now rotate to the next available route, if the first query doesn't resolve shortly after it was sent, we should just fail quickly and rotate instead.