### PR TITLE
feat(ProfitClient): Support padding native gas units

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -38,6 +38,8 @@ const {
   resolveDepositMessage,
 } = sdkUtils;
 
+type TransactionCostEstimate = sdkUtils.TransactionCostEstimate;
+
 // We use wrapped ERC-20 versions instead of the native tokens such as ETH, MATIC for ease of computing prices.
 export const MATIC = TOKEN_SYMBOLS_MAP.MATIC.addresses[CHAIN_IDs.MAINNET];
 export const USDC = TOKEN_SYMBOLS_MAP.USDC.addresses[CHAIN_IDs.MAINNET];
@@ -50,9 +52,11 @@ export type FillProfit = {
   tokenPriceUsd: BigNumber; // Resolved USD price of the bridged token.
   fillAmountUsd: BigNumber; // Amount of the bridged token being filled.
   grossRelayerFeeUsd: BigNumber; // USD value of the relay fee paid by the user.
-  nativeGasCost: BigNumber; // Cost of completing the fill in the native gas token.
-  gasMultiplier: BigNumber; // Multiplier to apply to nativeGasCost as padding or discount
-  gasPriceUsd: BigNumber; // Price paid per unit of gas in USD.
+  nativeGasCost: BigNumber; // Cost of completing the fill in the units of gas.
+  tokenGasCost: BigNumber; // Cost of completing the fill in the relevant gas token.
+  gasPadding: BigNumber; // Positive padding applied to nativeGasCost and tokenGasCost before profitability.
+  gasMultiplier: BigNumber; // Multiplier applied to token-only fill cost estimates before profitability.
+  gasTokenPriceUsd: BigNumber; // Price paid per unit of gas the gas token in USD.
   gasCostUsd: BigNumber; // Estimated cost of completing the fill in USD.
   refundFeeUsd: BigNumber; // Estimated relayer refund fee on the refund chain.
   relayerCapitalUsd: BigNumber; // Amount to be sent by the relayer in USD.
@@ -64,6 +68,7 @@ export type FillProfit = {
 type UnprofitableFill = {
   deposit: DepositWithBlock;
   fillAmount: BigNumber;
+  gasCost: BigNumber;
   nativeGasCost: BigNumber;
 };
 
@@ -95,7 +100,7 @@ const TEST_RECIPIENT = "0xBb23Cd0210F878Ea4CcA50e9dC307fb0Ed65Cf6B";
 // Note: the type here assumes that all of these classes take the same constructor parameters.
 const QUERY_HANDLERS: {
   [chainId: number]: new (
-    ...args: ConstructorParameters<typeof relayFeeCalculator.EthereumQueries>
+    ...args: ConstructorParameters<typeof relayFeeCalculator.BaseQueries>
   ) => relayFeeCalculator.QueryInterface;
 } = {
   1: relayFeeCalculator.EthereumQueries,
@@ -123,7 +128,7 @@ export class ProfitClient {
   private unprofitableFills: { [chainId: number]: UnprofitableFill[] } = {};
 
   // Track total gas costs of a relay on each chain.
-  protected totalGasCosts: { [chainId: number]: BigNumber } = {};
+  protected totalGasCosts: { [chainId: number]: TransactionCostEstimate } = {};
 
   // Queries needed to fetch relay gas costs.
   private relayerFeeQueries: { [chainId: number]: relayFeeCalculator.QueryInterface } = {};
@@ -139,14 +144,21 @@ export class ProfitClient {
     readonly relayerAddress: string,
     readonly defaultMinRelayerFeePct = toBNWei(constants.RELAYER_MIN_FEE_PCT),
     readonly debugProfitability = false,
-    protected gasMultiplier = toBNWei(1)
+    protected gasMultiplier = toBNWei(constants.DEFAULT_RELAYER_GAS_MULTIPLIER),
+    protected gasPadding = toBNWei(constants.DEFAULT_RELAYER_GAS_PADDING)
   ) {
-    // Require 1% <= gasMultiplier <= 400%
+    // Require 0% <= gasPadding <= 200%
     assert(
-      this.gasMultiplier.gte(toBNWei("0.00")) && this.gasMultiplier.lte(toBNWei(4)),
+      this.gasPadding.gte(toBNWei("0")) && this.gasPadding.lte(toBNWei(2)),
+      `Gas padding out of range (${this.gasPadding})`
+    );
+    this.gasPadding = toBNWei("1").add(gasPadding);
+
+    // Require 0% <= gasMultiplier <= 400%
+    assert(
+      this.gasMultiplier.gte(toBNWei("0")) && this.gasMultiplier.lte(toBNWei(4)),
       `Gas multiplier out of range (${this.gasMultiplier})`
     );
-
     this.priceClient = new PriceClient(logger, [
       new acrossApi.PriceFeed(),
       new coingecko.PriceFeed({ apiKey: process.env.COINGECKO_PRO_API_KEY }),
@@ -179,19 +191,18 @@ export class ProfitClient {
   }
 
   // @todo: Factor in the gas cost of submitting the RefundRequest on alt refund chains.
-  async getTotalGasCost(deposit: Deposit, fillAmount = deposit.amount): Promise<BigNumber> {
+  async getTotalGasCost(deposit: Deposit, fillAmount = deposit.amount): Promise<TransactionCostEstimate> {
     const { destinationChainId: chainId } = deposit;
 
     // If there's no attached message, gas consumption from previous fills can be used in most cases.
     // @todo: Simulate this per-token in future, because some ERC20s consume more gas.
     if (isMessageEmpty(resolveDepositMessage(deposit)) && isDefined(this.totalGasCosts[chainId])) {
-      return toBN(this.totalGasCosts[chainId]);
+      return this.totalGasCosts[chainId];
     }
 
     const { relayerAddress, relayerFeeQueries } = this;
     try {
-      const gasCost = await relayerFeeQueries[chainId].getGasCosts(deposit, fillAmount, relayerAddress);
-      return toBN(gasCost); // BigNumberish -> BigNumber
+      return await relayerFeeQueries[chainId].getGasCosts(deposit, fillAmount, relayerAddress);
     } catch (err) {
       const reason = isEthersError(err) ? err.reason : isError(err) ? err.message : "unknown error";
       this.logger.warn({
@@ -201,7 +212,7 @@ export class ProfitClient {
         deposit,
         fillAmount,
       });
-      return bnZero;
+      return { nativeGasCost: bnZero, tokenGasCost: bnZero };
     }
   }
 
@@ -209,26 +220,39 @@ export class ProfitClient {
   async estimateFillCost(
     deposit: Deposit,
     fillAmount = deposit.amount
-  ): Promise<Pick<FillProfit, "nativeGasCost" | "gasPriceUsd" | "gasCostUsd">> {
+  ): Promise<Pick<FillProfit, "nativeGasCost" | "tokenGasCost" | "gasTokenPriceUsd" | "gasCostUsd">> {
     const { destinationChainId: chainId } = deposit;
-    const gasPriceUsd = this.getPriceOfToken(GAS_TOKEN_BY_CHAIN_ID[chainId]);
-    const nativeGasCost = await this.getTotalGasCost(deposit, fillAmount); // gas cost in native token
+    const gasTokenPriceUsd = this.getPriceOfToken(GAS_TOKEN_BY_CHAIN_ID[chainId]);
+    let { nativeGasCost, tokenGasCost } = await this.getTotalGasCost(deposit, fillAmount);
 
-    if (gasPriceUsd.lte(0) || nativeGasCost.lte(0)) {
-      const err = gasPriceUsd.lte(0) ? "gas price" : "gas consumption";
-      throw new Error(`Unable to compute gas cost (${err} unknown)`);
+    Object.entries({
+      "gas cost": nativeGasCost, // raw gas units
+      "gas price": tokenGasCost, // gas token (i.e. wei)
+      "gas token price": gasTokenPriceUsd, // usd/gasToken
+    }).forEach(([err, field]) => {
+      if (field.lte(0)) {
+        throw new Error(`Unable to compute gas cost (${err} unknown)`);
+      }
+    });
+
+    // Fills with messages have arbitrary execution and therefore lower certainty about the simulated execution cost.
+    // Pad these estimates before computing profitability to allow execution headroom and reduce the chance of an OoG.
+    nativeGasCost = nativeGasCost.mul(this.gasPadding).div(fixedPoint);
+    tokenGasCost = tokenGasCost.mul(this.gasPadding).div(fixedPoint);
+
+    // Gas estimates for token-only fills are stable and reliable. Allow these to be scaled up or down via the
+    // configured gasMultiplier. Do not scale the nativeGasCost, since it might be used to set the transaction gasLimit.
+    // @todo Consider phasing this out and relying solely on the minimum profitability config.
+    if (isMessageEmpty(resolveDepositMessage(deposit))) {
+      tokenGasCost = tokenGasCost.mul(this.gasMultiplier).div(fixedPoint);
     }
 
-    // this.gasMultiplier is scaled to 18 decimals
-    const gasCostUsd = nativeGasCost
-      .mul(this.gasMultiplier)
-      .mul(gasPriceUsd)
-      .div(fixedPoint)
-      .div(toBN(10).pow(GAS_TOKEN_DECIMALS));
+    const gasCostUsd = tokenGasCost.mul(gasTokenPriceUsd).div(toBN(10).pow(GAS_TOKEN_DECIMALS));
 
     return {
       nativeGasCost,
-      gasPriceUsd,
+      tokenGasCost,
+      gasTokenPriceUsd,
       gasCostUsd,
     };
   }
@@ -301,14 +325,17 @@ export class ProfitClient {
     const relayerCapitalUsd = relayerCapital.mul(tokenPriceUsd).div(fixedPoint);
 
     // Estimate the gas cost of filling this relay.
-    const { nativeGasCost, gasPriceUsd, gasCostUsd } = await this.estimateFillCost(deposit, fillAmount);
+    const { nativeGasCost, tokenGasCost, gasTokenPriceUsd, gasCostUsd } = await this.estimateFillCost(
+      deposit,
+      fillAmount
+    );
 
     // Determine profitability.
     const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd).sub(refundFeeUsd);
     const netRelayerFeePct = netRelayerFeeUsd.mul(fixedPoint).div(relayerCapitalUsd);
 
     // If token price or gas price is unknown, assume the relay is unprofitable.
-    const profitable = tokenPriceUsd.gt(0) && gasPriceUsd.gt(0) && netRelayerFeePct.gte(minRelayerFeePct);
+    const profitable = tokenPriceUsd.gt(0) && gasTokenPriceUsd.gt(0) && netRelayerFeePct.gte(minRelayerFeePct);
 
     return {
       grossRelayerFeePct,
@@ -316,8 +343,10 @@ export class ProfitClient {
       fillAmountUsd,
       grossRelayerFeeUsd,
       nativeGasCost,
+      tokenGasCost,
+      gasPadding: this.gasPadding,
       gasMultiplier: this.gasMultiplier,
-      gasPriceUsd,
+      gasTokenPriceUsd,
       gasCostUsd,
       refundFeeUsd,
       relayerCapitalUsd,
@@ -351,6 +380,7 @@ export class ProfitClient {
     if (!fill.profitable || this.debugProfitability) {
       const { depositId, originChainId } = deposit;
       const profitable = fill.profitable ? "profitable" : "unprofitable";
+
       this.logger.debug({
         at: "ProfitClient#isFillProfitable",
         message: `${l1Token.symbol} deposit ${depositId} on chain ${originChainId} is ${profitable}`,
@@ -360,8 +390,10 @@ export class ProfitClient {
         fillAmountUsd: formatEther(fill.fillAmountUsd),
         grossRelayerFeePct: `${formatFeePct(fill.grossRelayerFeePct)}%`,
         nativeGasCost: formatEther(fill.nativeGasCost),
-        gasMultiplier: `${formatFeePct(fill.gasMultiplier)}%`,
-        gasPriceUsd: formatEther(fill.gasPriceUsd),
+        tokenGasCost: formatEther(fill.tokenGasCost),
+        gasPadding: this.gasPadding,
+        gasMultiplier: this.gasMultiplier,
+        gasTokenPriceUsd: formatEther(fill.gasTokenPriceUsd),
         refundFeeUsd: formatEther(fill.refundFeeUsd),
         relayerCapitalUsd: formatEther(fill.relayerCapitalUsd),
         grossRelayerFeeUsd: formatEther(fill.grossRelayerFeeUsd),
@@ -482,8 +514,9 @@ export class ProfitClient {
       };
 
       // An extra toBN cast is needed as the provider returns a different BigNumber type.
-      const gasCost = await relayerFeeQueries[destinationChainId].getGasCosts(deposit, fillAmount, TEST_RELAYER);
-      this.totalGasCosts[this.enabledChainIds[idx]] = toBN(gasCost);
+      const getGasCosts = relayerFeeQueries[destinationChainId].getGasCosts;
+      const { nativeGasCost, tokenGasCost } = await getGasCosts(deposit, fillAmount, TEST_RELAYER);
+      this.totalGasCosts[this.enabledChainIds[idx]] = { nativeGasCost, tokenGasCost };
     });
 
     this.logger.debug({

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -138,7 +138,8 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
   421613: 0,
 };
 
-export const DEFAULT_RELAYER_GAS_MULTIPLIER = 1.2;
+export const DEFAULT_RELAYER_GAS_PADDING = ".15"; // Padding on token- and message-based relayer fill gas estimates.
+export const DEFAULT_RELAYER_GAS_MULTIPLIER = "1.0"; // Multiplier on pre-profitability token-only gas estimates.
 
 export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
 export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -549,7 +549,7 @@ export class Relayer {
       : destinationChainId;
 
     const refundFee = this.computeRefundFee(version, deposit);
-    const { profitable, nativeGasCost } = await profitClient.isFillProfitable(
+    const { profitable, nativeGasCost: gasLimit } = await profitClient.isFillProfitable(
       deposit,
       fillAmount,
       refundFee,
@@ -558,7 +558,7 @@ export class Relayer {
 
     return {
       repaymentChainId: profitable ? preferredChainId : undefined,
-      gasLimit: nativeGasCost,
+      gasLimit,
     };
   }
 

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -83,7 +83,8 @@ export async function constructRelayerClients(
     baseSigner.address,
     config.minRelayerFeePct,
     config.debugProfitability,
-    config.relayerGasMultiplier
+    config.relayerGasMultiplier,
+    config.relayerGasPadding
   );
   await profitClient.update();
 

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -19,6 +19,7 @@ export class RelayerConfig extends CommonConfig {
   readonly relayerTokens: string[];
   readonly relayerOriginChains: number[] = [];
   readonly relayerDestinationChains: number[] = [];
+  readonly relayerGasPadding: BigNumber;
   readonly relayerGasMultiplier: BigNumber;
   readonly minRelayerFeePct: BigNumber;
   readonly acceptInvalidFills: boolean;
@@ -44,6 +45,7 @@ export class RelayerConfig extends CommonConfig {
       SLOW_DEPOSITORS,
       DEBUG_PROFITABILITY,
       RELAYER_GAS_MULTIPLIER,
+      RELAYER_GAS_PADDING,
       RELAYER_INVENTORY_CONFIG,
       RELAYER_TOKENS,
       SEND_RELAYS,
@@ -136,6 +138,7 @@ export class RelayerConfig extends CommonConfig {
       });
     }
     this.debugProfitability = DEBUG_PROFITABILITY === "true";
+    this.relayerGasPadding = toBNWei(RELAYER_GAS_PADDING || Constants.DEFAULT_RELAYER_GAS_PADDING);
     this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingMessageRelaysEnabled = SEND_MESSAGE_RELAYS === "true";

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -28,6 +28,8 @@ import {
   winston,
 } from "./utils";
 
+type TransactionCostEstimate = sdkUtils.TransactionCostEstimate;
+
 const { bnOne, bnZero, fixedPointAdjustment: fixedPoint, toGWei } = sdkUtils;
 const { formatEther } = ethers.utils;
 
@@ -57,11 +59,12 @@ const tokenPrices: { [symbol: string]: BigNumber } = {
 
 // Quirk: Use the chainId as the gas price in Gwei. This gives a range of
 // gas prices to test with, since there's a spread in the chainId numbers.
-const gasCost: { [chainId: number]: BigNumber } = Object.fromEntries(
+const gasCost: { [chainId: number]: TransactionCostEstimate } = Object.fromEntries(
   chainIds.map((chainId) => {
-    const nativeGasPrice = toGWei(chainId);
-    const gasConsumed = toBN(100_000); // Assume 100k gas for a single fill
-    return [chainId, gasConsumed.mul(nativeGasPrice)];
+    const nativeGasCost = toBN(100_000); // Assume 100k gas for a single fill
+    const gasTokenPrice = toBN(chainId);
+    const tokenGasCost = nativeGasCost.mul(gasTokenPrice);
+    return [chainId, { nativeGasCost, tokenGasCost }];
   })
 );
 
@@ -160,43 +163,67 @@ describe("ProfitClient: Consider relay profit", () => {
       spyLogger.debug({ message: `Verifying USD fill cost calculation for chain ${destinationChainId}.` });
       const deposit = { destinationChainId, message } as Deposit;
 
-      const nativeGasCost = await profitClient.getTotalGasCost(deposit, deposit.amount);
-      expect(nativeGasCost.eq(0)).to.be.false;
-      expect(nativeGasCost.eq(gasCost[destinationChainId])).to.be.true;
+      const { tokenGasCost } = await profitClient.getTotalGasCost(deposit, deposit.amount);
+      expect(tokenGasCost.eq(0)).to.be.false;
+      expect(tokenGasCost.eq(gasCost[destinationChainId].tokenGasCost)).to.be.true;
 
       const gasTokenAddr = GAS_TOKEN_BY_CHAIN_ID[destinationChainId];
       let gasToken = Object.values(tokens).find((token) => gasTokenAddr === token.address);
       expect(gasToken).to.not.be.undefined;
       gasToken = gasToken as L1Token;
-
-      const gasPriceUsd = tokenPrices[gasToken.symbol];
-      expect(gasPriceUsd.eq(tokenPrices[gasToken.symbol])).to.be.true;
+      const gasTokenPriceUsd = tokenPrices[gasToken.symbol];
 
       const estimate = await profitClient.estimateFillCost(deposit, deposit.amount);
-      expect(estimate.nativeGasCost.eq(gasCost[destinationChainId])).to.be.true;
-      expect(estimate.gasPriceUsd.eq(tokenPrices[gasToken.symbol])).to.be.true;
-      expect(estimate.gasCostUsd.eq(gasPriceUsd.mul(nativeGasCost).div(toBN(10).pow(gasToken.decimals)))).to.be.true;
+      Object.entries(gasCost[destinationChainId]).forEach(([k, v]) => expect(estimate[k].eq(v)).to.be.true);
+      expect(estimate.gasCostUsd.eq(tokenGasCost.mul(gasTokenPriceUsd).div(toBN(10).pow(gasToken.decimals)))).to.be
+        .true;
+    }
+  });
+
+  it("Verify gas padding", async () => {
+    const gasPadding = ["0", "0.10", "0.20", "0.50", "1"].map((padding) => toBNWei("1").add(toBNWei(padding)));
+
+    profitClient.setGasMultiplier(toBNWei("1")); // Neutralise any gas multiplier.
+
+    for (const destinationChainId of chainIds) {
+      spyLogger.debug({ message: `Verifying gas padding for chainId ${destinationChainId}.` });
+      const deposit = { destinationChainId, message } as Deposit;
+
+      const { nativeGasCost: defaultNativeGasCost, tokenGasCost: defaultTokenGasCost } =
+        await profitClient.getTotalGasCost(deposit, deposit.amount);
+
+      for (const padding of gasPadding) {
+        profitClient.setGasPadding(padding);
+
+        const expectedNativeGasCost = defaultNativeGasCost.mul(padding).div(fixedPoint);
+        const expectedTokenGasCost = defaultTokenGasCost.mul(padding).div(fixedPoint);
+
+        const { nativeGasCost, tokenGasCost } = await profitClient.estimateFillCost(deposit);
+        expect(expectedNativeGasCost.eq(nativeGasCost)).to.be.true;
+        expect(expectedTokenGasCost.eq(tokenGasCost)).to.be.true;
+      }
     }
   });
 
   it("Verify gas multiplier", async () => {
+    const gasMultipliers = [0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0].map((multiplier) => toBNWei(multiplier));
+
     for (const destinationChainId of chainIds) {
       spyLogger.debug({ message: `Verifying gas multiplier for chainId ${destinationChainId}.` });
       const deposit = { destinationChainId, message } as Deposit;
 
-      const nativeGasCost = await profitClient.getTotalGasCost(deposit, deposit.amount);
-      expect(nativeGasCost.gt(0)).to.be.true;
+      const { tokenGasCost } = await profitClient.getTotalGasCost(deposit, deposit.amount);
+      expect(tokenGasCost.gt(0)).to.be.true;
 
-      const gasMultipliers = [0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0];
       for (const gasMultiplier of gasMultipliers) {
-        profitClient.setGasMultiplier(toBNWei(gasMultiplier));
+        profitClient.setGasMultiplier(gasMultiplier);
 
         const gasTokenAddr = GAS_TOKEN_BY_CHAIN_ID[destinationChainId];
         let gasToken = Object.values(tokens).find((token) => gasTokenAddr === token.address);
         expect(gasToken).to.not.be.undefined;
         gasToken = gasToken as L1Token;
 
-        const expectedFillCostUsd = nativeGasCost
+        const expectedFillCostUsd = tokenGasCost
           .mul(tokenPrices[gasToken.symbol])
           .mul(toBNWei(gasMultiplier))
           .div(fixedPoint)
@@ -211,7 +238,9 @@ describe("ProfitClient: Consider relay profit", () => {
     const destinationChainId = 137;
     profitClient.setGasCost(destinationChainId, undefined);
     const deposit = { amount: bnOne, destinationChainId, message } as Deposit;
-    expect(await profitClient.getTotalGasCost(deposit)).to.equal(bnZero);
+    const { nativeGasCost, tokenGasCost } = await profitClient.getTotalGasCost(deposit);
+    expect(nativeGasCost.eq(bnZero)).to.be.true;
+    expect(tokenGasCost.eq(bnZero)).to.be.true;
   });
 
   it("Verify token price and gas cost lookup failures", async () => {


### PR DESCRIPTION
This change introduces a new configurable RELAYER_GAS_PADDING, which is applied by the ProfitClient to raw gas estimates before they are fed into profitability calculations. This is effectively a way of accounting for marginally worse-than-estimated gas consumption when a simulated fill is ultimately executed on-chain.

There is some unfortunate overlap with the pre-existing RELAYER_GAS_MULTIPLIER, which is currently used to discount the estimated fill cost to account for gas price volatilility (i.e. to allow prioritisation of service over profitability at the margins).