### PR TITLE
refactor(ProfitClient): Support token lookup by symbol

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -96,7 +96,8 @@ const { acrossApi, coingecko, defiLlama } = priceClient.adapters;
 export class ProfitClient {
   private readonly priceClient;
   protected minRelayerFees: { [route: string]: BigNumber } = {};
-  protected tokenPrices: { [l1Token: string]: BigNumber } = {};
+  protected tokenSymbolMap: { [symbol: string]: string } = {};
+  protected tokenPrices: { [address: string]: BigNumber } = {};
   private unprofitableFills: { [chainId: number]: UnprofitableFill[] } = {};
 
   // Track total gas costs of a relay on each chain.
@@ -157,15 +158,34 @@ export class ProfitClient {
     return this.tokenPrices;
   }
 
+  /**
+   * Convenience function to resolve a token symbol to its underlying address.
+   * @notice In case that an address is supplied, it will simply be returned as-is.
+   * @param token Token address or symbol to resolve.
+   * @returns Address corresponding to token.
+   */
+  resolveTokenAddress(token: string): string {
+    const address = ethersUtils.isAddress(token) ? token : this.tokenSymbolMap[token];
+    assert(isDefined(address), `Unable to resolve address for token ${token}`);
+    return address;
+  }
+
+  /**
+   * Return the cached price for token.
+   * @param token Token identifier. May be a token symbol or token address on the HubPool chain.
+   * @returns Token token price for token.
+   */
   getPriceOfToken(token: string): BigNumber {
     // Warn on this initially, and move to an assert() once any latent issues are resolved.
     // assert(this.tokenPrices[token] !== undefined, `Token ${token} not in price list.`);
-    if (this.tokenPrices[token] === undefined && !this.isTestnet) {
-      this.logger.warn({ at: "ProfitClient#getPriceOfToken", message: `Token ${token} not in price list.` });
+    const address = this.resolveTokenAddress(token);
+    const price = this.tokenPrices[address];
+    if (!isDefined(price)) {
+      this.logger.warn({ at: "ProfitClient#getPriceOfToken", message: `Token ${token} not in price list.`, address });
       return bnZero;
     }
 
-    return this.tokenPrices[token];
+    return price;
   }
 
   // @todo: Factor in the gas cost of submitting the RefundRequest on alt refund chains.
@@ -263,7 +283,7 @@ export class ProfitClient {
     minRelayerFeePct: BigNumber
   ): Promise<FillProfit> {
     assert(fillAmount.gt(0), `Unexpected fillAmount: ${fillAmount}`);
-    const tokenPriceUsd = this.getPriceOfToken(l1Token.address);
+    const tokenPriceUsd = this.getPriceOfToken(l1Token.symbol);
     if (tokenPriceUsd.lte(0)) {
       throw new Error(`Unable to determine ${l1Token.symbol} L1 token price`);
     }
@@ -321,7 +341,7 @@ export class ProfitClient {
         `ProfitClient::isFillProfitable missing l1TokenInfo for deposit with origin token: ${deposit.originToken}`
       );
     }
-    const tokenPriceInUsd = this.getPriceOfToken(l1TokenInfo.address);
+    const tokenPriceInUsd = this.getPriceOfToken(l1TokenInfo.symbol);
     return fillAmount.mul(tokenPriceInUsd).div(toBN(10).pow(l1TokenInfo.decimals));
   }
 
@@ -403,7 +423,11 @@ export class ProfitClient {
   protected async updateTokenPrices(): Promise<void> {
     // Generate list of tokens to retrieve.
     const l1Tokens: { [k: string]: L1Token } = Object.fromEntries(
-      this.hubPoolClient.getL1Tokens().map((token) => [token.address, token])
+      this.hubPoolClient.getL1Tokens().map(({ symbol }) => {
+        const { decimals, addresses } = TOKEN_SYMBOLS_MAP[symbol];
+        const address = addresses[1];
+        return [address, { symbol, decimals, address }];
+      })
     );
 
     // Also ensure all gas tokens are included in the lookup.
@@ -417,7 +441,10 @@ export class ProfitClient {
     this.logger.debug({ at: "ProfitClient", message: "Updating Profit client", tokens: Object.values(l1Tokens) });
 
     // Pre-populate any new addresses.
-    Object.values(l1Tokens).forEach(({ address }) => (this.tokenPrices[address] ??= bnZero));
+    Object.values(l1Tokens).forEach(({ symbol, address }) => {
+      this.tokenSymbolMap[symbol] ??= address;
+      this.tokenPrices[address] ??= bnZero;
+    });
 
     try {
       const tokenPrices = await this.priceClient.getPricesByAddress(Object.keys(l1Tokens), "usd");
@@ -427,7 +454,7 @@ export class ProfitClient {
       const errMsg = `Failed to update token prices (${err})`;
       let mrkdwn = `${errMsg}:\n`;
       Object.entries(l1Tokens).forEach(([, l1Token]) => {
-        mrkdwn += `- Using last known ${l1Token.symbol} price of ${this.getPriceOfToken(l1Token.address)}.\n`;
+        mrkdwn += `- Using last known ${l1Token.symbol} price of ${this.getPriceOfToken(l1Token.symbol)}.\n`;
       });
       this.logger.warn({ at: "ProfitClient", message: "Could not fetch all token prices 💳", mrkdwn });
       throw new Error(errMsg);
@@ -436,6 +463,7 @@ export class ProfitClient {
 
   private async updateGasCosts(): Promise<void> {
     const { enabledChainIds, hubPoolClient, relayerFeeQueries } = this;
+
     const depositId = random(bnUint32Max.toNumber()); // random depositId + "" originToken => ~impossible to collide.
     const fillAmount = bnOne;
     const quoteTimestamp = getCurrentTime();

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -85,12 +85,12 @@ describe("ProfitClient: Consider relay profit", () => {
     })
   );
 
-  const tokenPrices: { [symbol: string]: BigNumber } = {
-    MATIC: toBNWei("0.4"),
-    USDC: toBNWei(1),
-    WBTC: toBNWei(21000),
-    WETH: toBNWei(3000),
-  };
+  const tokenPrices = Object.fromEntries(
+    Object.keys(tokens).map((symbol) => {
+      const { decimals } = TOKEN_SYMBOLS_MAP[symbol];
+      return [symbol, toBNWei(random(0.1, 21000, true).toFixed(decimals))];
+    })
+  );
 
   // Quirk: Use the chainId as the gas price in Gwei. This gives a range of
   // gas prices to test with, since there's a spread in the chainId numbers.
@@ -102,25 +102,16 @@ describe("ProfitClient: Consider relay profit", () => {
     })
   );
 
-  const setDefaultTokenPrices = (profitClient: MockProfitClient): void => {
-    // Load ERC20 token prices in USD.
-    profitClient.setTokenPrices(
-      Object.fromEntries(Object.entries(tokenPrices).map(([symbol, price]) => [tokens[symbol].address, price]))
-    );
-  };
-
   beforeEach(async () => {
     const [owner] = await ethers.getSigners();
     const logger = createSpyLogger().spyLogger;
 
     const { configStore } = await deployConfigStore(owner, []);
     const configStoreClient = new ConfigStoreClient(logger, configStore);
-
     await configStoreClient.update();
 
     const { hubPool } = await hubPoolFixture();
     hubPoolClient = new MockHubPoolClient(logger, hubPool, configStoreClient);
-
     await hubPoolClient.update();
 
     const chainIds = [originChainId, destinationChainId];
@@ -156,7 +147,7 @@ describe("ProfitClient: Consider relay profit", () => {
 
     // Load per-chain gas cost (gas consumed * gas price in Wei), in native gas token.
     profitClient.setGasCosts(gasCost);
-    setDefaultTokenPrices(profitClient);
+    profitClient.setTokenPrices(tokenPrices);
   });
 
   // Verify gas cost calculation first, so we can leverage it in all subsequent tests.
@@ -265,7 +256,6 @@ describe("ProfitClient: Consider relay profit", () => {
    */
   it("Considers gas cost when computing profitability", async () => {
     const fillAmounts = [".001", "0.1", 1, 10, 100, 1_000, 100_000];
-
     for (const destinationChainId of chainIds) {
       const deposit = { amount: bnOne, destinationChainId, message } as Deposit;
 

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -127,13 +127,15 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     await configStoreClient.update();
 
     ubaClient = new MockUBAClient(
-      hubPoolClient.getL1Tokens().map((x) => x.symbol),
+      hubPoolClient.getL1Tokens().map(({ symbol }) => symbol),
       hubPoolClient,
       generateNoOpSpokePoolClientsForDefaultChainIndices(spokePoolClients)
     );
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
-    profitClient.setTokenPrice(l1Token.address, bnOne);
+    for (const erc20 of [l1Token]) {
+      await profitClient.initToken(erc20);
+    }
 
     relayerInstance = new Relayer(
       relayer.address,

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -3,7 +3,6 @@ import {
   ConfigStoreClient,
   HubPoolClient,
   MultiCallerClient,
-  ProfitClient,
   SpokePoolClient,
   TokenClient,
 } from "../src/clients";
@@ -41,6 +40,7 @@ import {
 import { Relayer } from "../src/relayer/Relayer";
 import { RelayerConfig } from "../src/relayer/RelayerConfig"; // Tested
 import { MockedMultiCallerClient } from "./mocks/MockMultiCallerClient";
+import { MockProfitClient } from "./mocks/MockProfitClient";
 
 let spokePool_1: Contract, erc20_1: Contract, spokePool_2: Contract, erc20_2: Contract;
 let hubPool: Contract, configStore: Contract, l1Token: Contract;
@@ -50,7 +50,7 @@ let spy: sinon.SinonSpy, spyLogger: winston.Logger;
 let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
 let configStoreClient: ConfigStoreClient, hubPoolClient: HubPoolClient, tokenClient: TokenClient;
 let relayerInstance: Relayer;
-let multiCallerClient: MultiCallerClient, profitClient: ProfitClient;
+let multiCallerClient: MultiCallerClient, profitClient: MockProfitClient;
 let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
 describe("Relayer: Zero sized fill for slow relay", async function () {
@@ -113,7 +113,11 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
     );
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
-    profitClient = new ProfitClient(spyLogger, hubPoolClient, spokePoolClients, [], relayer.address);
+    profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, [], relayer.address);
+    for (const erc20 of [l1Token]) {
+      await profitClient.initToken(erc20);
+    }
+
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -1,4 +1,3 @@
-import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import {
   AcrossApiClient,
   ConfigStoreClient,
@@ -110,7 +109,9 @@ describe("Relayer: Token balance shortfall", async function () {
     const spokePoolClients = { [originChainId]: spokePoolClient_1, [destinationChainId]: spokePoolClient_2 };
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
-    profitClient.setTokenPrice(l1Token.address, sdkUtils.bnOne);
+    for (const erc20 of [l1Token]) {
+      await profitClient.initToken(erc20);
+    }
 
     relayerInstance = new Relayer(
       relayer.address,

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -1,3 +1,4 @@
+import { clients } from "@across-protocol/sdk-v2";
 import { AcrossApiClient, ConfigStoreClient, MultiCallerClient, TokenClient, UBAClient } from "../src/clients";
 import {
   CHAIN_ID_TEST_LIST,
@@ -27,7 +28,6 @@ import {
   simpleDeposit,
   toBNWei,
 } from "./utils";
-import { clients } from "@across-protocol/sdk-v2";
 
 // Tested
 import { Relayer } from "../src/relayer/Relayer";
@@ -109,6 +109,10 @@ describe("Relayer: Unfilled Deposits", async function () {
     multiCallerClient = new MockedMultiCallerClient(spyLogger);
     tokenClient = new TokenClient(spyLogger, relayer.address, spokePoolClients, hubPoolClient);
     profitClient = new MockProfitClient(spyLogger, hubPoolClient, spokePoolClients, []);
+    for (const erc20 of [l1Token]) {
+      await profitClient.initToken(erc20);
+    }
+
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,


### PR DESCRIPTION
This is a follow-up change to allow the ProfitClient to work primarily with token symbols, rather than their underlying addresses. This is especially helpful on testnets, where token prices for the underlying HubPool address are not available.

Fixes ACX-1663