### PR TITLE
feat(MultiCallerClient): gasLimit plumbing

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -315,9 +315,7 @@ export class MultiCallerClient {
 
       // Aggregate the individual gasLimits. If a transaction does not have a gasLimit defined then it has not been
       // simulated. In this case, drop the aggregation and revert to undefined to force estimation on submission.
-      gasLimit = isDefined(gasLimit) && isDefined(txn.gasLimit)
-        ? gasLimit.add(txn.gasLimit)
-        : undefined;
+      gasLimit = isDefined(gasLimit) && isDefined(txn.gasLimit) ? gasLimit.add(txn.gasLimit) : undefined;
     });
 
     this.logger.debug({

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -7,6 +7,7 @@ import { EthersError } from "../interfaces";
 import {
   BigNumber,
   Contract,
+  isDefined,
   TransactionResponse,
   Wallet,
   ethers,
@@ -162,9 +163,11 @@ export async function getGasPrice(
 }
 
 export async function willSucceed(transaction: AugmentedTransaction): Promise<TransactionSimulationResult> {
-  if (transaction.canFailInSimulation) {
+  // If the transaction already has a gasLimit, it should have been simulated in advance.
+  if (transaction.canFailInSimulation || isDefined(transaction.gasLimit)) {
     return { transaction, succeed: true };
   }
+
   try {
     const { contract, method } = transaction;
     const args = transaction.value ? [...transaction.args, { value: transaction.value }] : transaction.args;

--- a/test/MultiCallerClient.ts
+++ b/test/MultiCallerClient.ts
@@ -5,7 +5,7 @@ import {
   unknownRevertReason,
   unknownRevertReasonMethodsToIgnore,
 } from "../src/clients";
-import { TransactionSimulationResult } from "../src/utils";
+import { BigNumber, TransactionSimulationResult } from "../src/utils";
 import { MockedTransactionClient, txnClientPassResult } from "./mocks/MockTransactionClient";
 import { CHAIN_ID_TEST_LIST as chainIds } from "./constants";
 import { createSpyLogger, Contract, expect, randomAddress, winston, toBN, smock, assertPromiseError } from "./utils";
@@ -54,16 +54,14 @@ function encodeFunctionData(_method: string, args: ReadonlyArray<unknown> = []):
   return args.join(" ");
 }
 
-const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
-const multiCaller: DummyMultiCallerClient = new DummyMultiCallerClient(spyLogger);
-const address = randomAddress(); // Test contract address
-
 describe("MultiCallerClient", async function () {
-  beforeEach(async function () {
-    multiCaller.clearTransactionQueue();
-    expect(multiCaller.transactionCount()).to.equal(0);
+  const { spyLogger }: { spyLogger: winston.Logger } = createSpyLogger();
+  const address = randomAddress(); // Test contract address
+  let multiCaller: DummyMultiCallerClient;
 
-    multiCaller.clearSimulationFailures();
+  beforeEach(async function () {
+    multiCaller = new DummyMultiCallerClient(spyLogger);
+    expect(multiCaller.transactionCount()).to.equal(0);
     expect(multiCaller.simulationFailureCount()).to.equal(0);
   });
 
@@ -87,11 +85,71 @@ describe("MultiCallerClient", async function () {
   it("Correctly enqueues mixed transactions", async function () {
     chainIds.forEach((chainId) => {
       multiCaller.enqueueTransaction({ chainId } as AugmentedTransaction);
-      multiCaller.enqueueTransaction({ chainId, value: toBN(1) } as AugmentedTransaction);
+      multiCaller.enqueueTransaction({ chainId, value: sdkUtils.bnOne } as AugmentedTransaction);
     });
     expect(multiCaller.valueTxnCount()).to.equal(chainIds.length);
     expect(multiCaller.multiCallTransactionCount()).to.equal(chainIds.length);
     expect(multiCaller.transactionCount()).to.equal(2 * chainIds.length);
+  });
+
+  it("Propagates input transaction gasLimits: internal multicall", async function () {
+    const fakeMultisender = await smock.fake(await sdkUtils.getABI("Multicall3"), { address: randomAddress() });
+    multiCaller = new DummyMultiCallerClient(spyLogger, {}, fakeMultisender as unknown as Contract);
+
+    const nTxns = 10;
+    const gasLimit = toBN(99_999);
+
+    const txns: AugmentedTransaction[] = [];
+    for (let i = 0; i < nTxns; ++i) {
+      const txn: AugmentedTransaction = {
+        chainId: 1,
+        contract: {
+          address,
+          interface: { encodeFunctionData },
+        } as Contract,
+        method: "gasLimitTest",
+        args: [{ txnClientPassResult }],
+        gasLimit,
+        message: `Test transaction with gasLimit ${gasLimit}`,
+        unpermissioned: true,
+      };
+      txns.push(txn);
+    }
+
+    const txnBundle = multiCaller.buildMultiCallBundle(txns)[0];
+    expect(txnBundle.gasLimit).to.not.be.undefined;
+    const _gasLimit = txnBundle.gasLimit as BigNumber;
+    expect(_gasLimit.eq(gasLimit.mul(nTxns))).to.be.true;
+  });
+
+  it("Propagates input transaction gasLimits: external multicall", async function () {
+    const fakeMultisender = await smock.fake(await sdkUtils.getABI("Multicall3"), { address: randomAddress() });
+    multiCaller = new DummyMultiCallerClient(spyLogger, {}, fakeMultisender as unknown as Contract);
+
+    const nTxns = 10;
+    const gasLimit = toBN(99_999);
+
+    const txns: AugmentedTransaction[] = [];
+    for (let i = 0; i < nTxns; ++i) {
+      const txn: AugmentedTransaction = {
+        chainId: 1,
+        contract: {
+          address,
+          interface: { encodeFunctionData },
+        } as Contract,
+        method: "gasLimitTest",
+        args: [{ txnClientPassResult }],
+        gasLimit,
+        message: `Test transaction with gasLimit ${gasLimit}`,
+        unpermissioned: true,
+      };
+      txns.push(txn);
+    }
+
+    const txnBundle = await multiCaller.buildMultiSenderBundle(txns);
+    expect(txnBundle.gasLimit).to.not.be.undefined;
+    const _gasLimit = txnBundle.gasLimit as BigNumber;
+    expect(_gasLimit.eq(gasLimit.mul(nTxns))).to.be.true;
   });
 
   it("Correctly excludes simulation failures", async function () {


### PR DESCRIPTION
This change modifies the MultiCallerClient such that it will be more respectful of an enqueued transaction that has had a gasLimit applied.

There is one edge case that's not handled here: when an enqueued transaction with gasLimit is bundled together with other transactions that do not have a gasLimit, the gasLimit on the individual transaction reverts to undefined. This is because it's not possible to accurately set a gasLimit on the bundle without simulating each transaction on the fly, and that's actually what we try to avoid by bundling in the first place.

The caller can avoid this by ensuring that all enqueued transactions are simulated in advance. The relayer itself should implement this once some residual issues with higher-than-average ERC20 gas consumption on specific tokens has been resolved.