### PR TITLE
feat(rebalancer): Add toggle to send rebalances.

### DIFF
--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -117,7 +117,7 @@ export async function constructRelayerClients(
     adapterManager,
     crossChainTransferClient,
     config.bundleRefundLookback,
-    !config.sendingRelaysEnabled
+    !config.sendingRebalancesEnabled
   );
 
   return { ...commonClients, spokePoolClients, ubaClient, tokenClient, profitClient, inventoryClient, acrossApiClient };

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -13,6 +13,7 @@ export class RelayerConfig extends CommonConfig {
   readonly skipRelays: boolean;
   readonly skipRebalancing: boolean;
   readonly sendingRelaysEnabled: boolean;
+  readonly sendingRebalancesEnabled: boolean;
   readonly sendingMessageRelaysEnabled: boolean;
   readonly sendingSlowRelaysEnabled: boolean;
   readonly sendingRefundRequestsEnabled: boolean;
@@ -47,6 +48,7 @@ export class RelayerConfig extends CommonConfig {
       RELAYER_INVENTORY_CONFIG,
       RELAYER_TOKENS,
       SEND_RELAYS,
+      SEND_REBALANCES,
       SEND_MESSAGE_RELAYS,
       SKIP_RELAYS,
       SKIP_REBALANCING,
@@ -138,6 +140,7 @@ export class RelayerConfig extends CommonConfig {
     this.debugProfitability = DEBUG_PROFITABILITY === "true";
     this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
+    this.sendingRebalancesEnabled = SEND_REBALANCES === "true";
     this.sendingMessageRelaysEnabled = SEND_MESSAGE_RELAYS === "true";
     this.skipRelays = SKIP_RELAYS === "true";
     this.skipRebalancing = SKIP_REBALANCING === "true";


### PR DESCRIPTION
Can be used to split up relayer functionality into two bots:
- fast bot that sends relays and doesn't rebalance
- slow bot that runs entire relayer logic but doesn't execute anything and does rebalance