### PR TITLE
refactor(Dataworker): Replace ProfitClient with PriceClient

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -409,7 +409,7 @@ export class Dataworker {
       // Exit early if volume of pool rebalance leaves exceeds USD threshold. Volume includes netSendAmounts only since
       // that is the actual amount sent over bridges. This also mitigates the chance that a RelayerRefundLeaf is
       // published but its refund currency isn't sent over the bridge in a PoolRebalanceLeaf.
-      const totalUsdRefund = PoolRebalanceUtils.computePoolRebalanceUsdVolume(
+      const totalUsdRefund = await PoolRebalanceUtils.computePoolRebalanceUsdVolume(
         rootBundleData.poolRebalanceLeaves,
         this.clients
       );

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -1,6 +1,8 @@
-import { utils as sdkUtils } from "@across-protocol/sdk-v2";
+import * as sdk from "@across-protocol/sdk-v2";
 
-export class BlockFinder extends sdkUtils.BlockFinder {}
+export class BlockFinder extends sdk.utils.BlockFinder {}
+export class PriceClient extends sdk.priceClient.PriceClient {}
+export const { acrossApi, coingecko, defiLlama } = sdk.priceClient.adapters;
 
 export const {
   toBN,
@@ -18,4 +20,4 @@ export const {
   blockExplorerLink,
   blockExplorerLinks,
   createShortHexString: shortenHexString,
-} = sdkUtils;
+} = sdk.utils;


### PR DESCRIPTION
The Dataworker only relies indirectly on the ProfitClient for its ability to query token prices. This imposes some test/mock burden on the ProfitClient. This change hoists the ProfitClient out of the Dataworker and instead subs in the underlying PriceClient, which the ProfitClient also uses directly.

As a side benefit, the proposer is currently the only component dependent on token prices, so token price lookups can be relegated to the code that actually needs it.