### PR TITLE
fix(ProfitClient): Support non-unique token addresses

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -470,9 +470,7 @@ export class ProfitClient {
     this.enabledChainIds.forEach((chainId) => {
       const symbol = getNativeTokenSymbol(chainId);
       if (!isDefined(tokens[symbol])) {
-        const { addresses } = TOKEN_SYMBOLS_MAP[symbol];
-        const address = addresses[1];
-        tokens[symbol] = address;
+        tokens[symbol] = TOKEN_SYMBOLS_MAP[symbol].addresses[1];
       }
     });
 

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -485,7 +485,7 @@ export class ProfitClient {
     try {
       const tokenAddrs = Array.from(new Set(Object.values(tokens)));
       const tokenPrices = await this.priceClient.getPricesByAddress(tokenAddrs, "usd");
-      tokenPrices.forEach(({ address, price }) => this.tokenPrices[address] = toBNWei(price));
+      tokenPrices.forEach(({ address, price }) => (this.tokenPrices[address] = toBNWei(price)));
       this.logger.debug({ at: "ProfitClient", message: "Updated token prices", tokenPrices: this.tokenPrices });
     } catch (err) {
       const errMsg = `Failed to update token prices (${err})`;

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -467,11 +467,13 @@ export class ProfitClient {
     );
 
     // Also ensure all gas tokens are included in the lookup.
-    Array.from(new Set(this.enabledChainIds)).forEach((chainId) => {
+    this.enabledChainIds.forEach((chainId) => {
       const symbol = getNativeTokenSymbol(chainId);
-      const { addresses } = TOKEN_SYMBOLS_MAP[symbol];
-      const address = addresses[1];
-      tokens[symbol] ??= address;
+      if (!isDefined(tokens[symbol])) {
+        const { addresses } = TOKEN_SYMBOLS_MAP[symbol];
+        const address = addresses[1];
+        tokens[symbol] = address;
+      }
     });
 
     this.logger.debug({ at: "ProfitClient", message: "Updating Profit client", tokens });

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -467,9 +467,9 @@ export class ProfitClient {
     );
 
     // Also ensure all gas tokens are included in the lookup.
-    this.enabledChainIds.forEach((chainId) => {
+    Array.from(new Set(this.enabledChainIds)).forEach((chainId) => {
       const symbol = getNativeTokenSymbol(chainId);
-      const addresses = TOKEN_SYMBOLS_MAP[symbol];
+      const { addresses } = TOKEN_SYMBOLS_MAP[symbol];
       const address = addresses[1];
       tokens[symbol] ??= address;
     });

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -469,9 +469,7 @@ export class ProfitClient {
     // Also ensure all gas tokens are included in the lookup.
     this.enabledChainIds.forEach((chainId) => {
       const symbol = getNativeTokenSymbol(chainId);
-      if (!isDefined(tokens[symbol])) {
-        tokens[symbol] = TOKEN_SYMBOLS_MAP[symbol].addresses[1];
-      }
+      tokens[symbol] ??= TOKEN_SYMBOLS_MAP[symbol].addresses[1];
     });
 
     this.logger.debug({ at: "ProfitClient", message: "Updating Profit client", tokens });


### PR DESCRIPTION
In cases like ETH/WETH, the underlying mainnet contract address used to resolve the token price is the same. Therefore, mapping from contract address to L1Token doesn't work very well for this purpose. Invert the token mapping so that the token symbol is unique, allowing for multiple symbols to map to a single address. This also helps in the case of test tokens that are temporarily mapped to an existing token.