### PR TITLE
fix(zksync-finalizer): Identify correct log index of ZkSync withdrawal when there are multiple withdrawals in same L2 transaction

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -173,8 +173,8 @@ export async function finalize(
         gasLimit: gasEstimation,
         gasLimitMultiplier: 2,
         unpermissioned: true,
-        message: `Batch finalized ${finalizerTxns.length} withdrawals and/or proofs`,
-        mrkdwn: `Batch finalized ${finalizerTxns.length} withdrawals and/or proofs`,
+        message: `Batch finalized ${finalizerTxns.length} txns`,
+        mrkdwn: `Batch finalized ${finalizerTxns.length} txns`,
       };
       multicallerClient.enqueueTransaction(txnToSubmit);
       [txnHash] = await multicallerClient.executeTransactionQueue();

--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -7,6 +7,7 @@ import {
   groupObjectCountsByProp,
   Contract,
   getCachedProvider,
+  getUniqueLogIndex,
 } from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
@@ -131,14 +132,7 @@ async function getAllMessageStatuses(
 > {
   // For each token bridge event, store a unique log index for the event within the arbitrum transaction hash.
   // This is important for bridge transactions containing multiple events.
-  const uniqueTokenhashes = {};
-  const logIndexesForMessage = [];
-  for (const event of tokensBridged) {
-    uniqueTokenhashes[event.transactionHash] = uniqueTokenhashes[event.transactionHash] ?? 0;
-    const logIndex = uniqueTokenhashes[event.transactionHash];
-    logIndexesForMessage.push(logIndex);
-    uniqueTokenhashes[event.transactionHash] += 1;
-  }
+  const logIndexesForMessage = getUniqueLogIndex(tokensBridged);
   return (
     await Promise.all(
       tokensBridged.map((e, i) => getMessageOutboxStatusAndProof(logger, e, mainnetSigner, logIndexesForMessage[i]))

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -8,6 +8,7 @@ import {
   convertFromWei,
   getCachedProvider,
   getNetworkName,
+  getUniqueLogIndex,
   groupObjectCountsByProp,
   Wallet,
   winston,
@@ -107,14 +108,7 @@ async function getCrossChainMessages(
 ): Promise<CrossChainMessageWithEvent[]> {
   // For each token bridge event, store a unique log index for the event within the optimism transaction hash.
   // This is important for bridge transactions containing multiple events.
-  const uniqueTokenhashes = {};
-  const logIndexesForMessage = [];
-  for (const event of tokensBridged) {
-    uniqueTokenhashes[event.transactionHash] = uniqueTokenhashes[event.transactionHash] ?? 0;
-    const logIndex = uniqueTokenhashes[event.transactionHash];
-    logIndexesForMessage.push(logIndex);
-    uniqueTokenhashes[event.transactionHash] += 1;
-  }
+  const logIndexesForMessage = getUniqueLogIndex(tokensBridged);
 
   return (
     await Promise.all(

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -219,6 +219,25 @@ export function isEventOlder<T extends SortableEvent>(ex: T, ey: T): boolean {
   return ex.logIndex < ey.logIndex;
 }
 
+/**
+ * Returns an array with the same length as the passed in Event array where each index is assigned a new index
+ * that states its relative position to other events with the same transaction hash. If two or more of the input
+ * events have the same transaction hash, they will be assigned unique indices starting at 0 and counting up based
+ * on the order of events passed in.
+ * @param events
+ */
+export function getUniqueLogIndex(events: { transactionHash: string }[]): number[] {
+  const uniqueTokenhashes = {};
+  const logIndexesForMessage = [];
+  for (const event of events) {
+    uniqueTokenhashes[event.transactionHash] = uniqueTokenhashes[event.transactionHash] ?? 0;
+    const logIndex = uniqueTokenhashes[event.transactionHash];
+    logIndexesForMessage.push(logIndex);
+    uniqueTokenhashes[event.transactionHash] += 1;
+  }
+  return logIndexesForMessage;
+}
+
 export function getTransactionHashes(events: SortableEvent[]): string[] {
   return [...new Set(events.map((e) => e.transactionHash))];
 }

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -230,10 +230,9 @@ export function getUniqueLogIndex(events: { transactionHash: string }[]): number
   const uniqueTokenhashes = {};
   const logIndexesForMessage = [];
   for (const event of events) {
-    uniqueTokenhashes[event.transactionHash] = uniqueTokenhashes[event.transactionHash] ?? 0;
-    const logIndex = uniqueTokenhashes[event.transactionHash];
+    const logIndex = uniqueTokenhashes[event.transactionHash] ?? 0;
     logIndexesForMessage.push(logIndex);
-    uniqueTokenhashes[event.transactionHash] += 1;
+    uniqueTokenhashes[event.transactionHash] = logIndex + 1;
   }
   return logIndexesForMessage;
 }

--- a/src/utils/EventUtils.ts
+++ b/src/utils/EventUtils.ts
@@ -220,11 +220,13 @@ export function isEventOlder<T extends SortableEvent>(ex: T, ey: T): boolean {
 }
 
 /**
- * Returns an array with the same length as the passed in Event array where each index is assigned a new index
+ * @notice Returns an array with the same length as the passed in Event array where each index is assigned a new index
  * that states its relative position to other events with the same transaction hash. If two or more of the input
  * events have the same transaction hash, they will be assigned unique indices starting at 0 and counting up based
  * on the order of events passed in.
- * @param events
+ * @param events List of objects to pass in that contain a transaction hash.
+ * @return Index for each event based on the # of other input events with the same transaction hash. The order of the
+ * input events is preserved in the output array.
  */
 export function getUniqueLogIndex(events: { transactionHash: string }[]): number[] {
   const uniqueTokenhashes = {};


### PR DESCRIPTION
The current code doesn't handle the case where there are multiple `TokensBridged` events within a single ZkSync transaction. This is because it always returns the `withdrawalIdx = 0` for all batched `TokensBridged`.

I believe this is because the `.reverse()` always causes the subsequent `.find()` to return index 0.

This PR simplifies the logic a lot and simply:
- Find all `L1MessageSentEvents` preceding the `TokensBridged` event.
- Return `withdrawalIdx` equal to the # of above preceding `L1MessageSentEvents`. This should return a unique withdrawal index per TokensBridged