### PR TITLE
improve(relayer): Don't zero-fill when relayer expects to rebalance to fast fill deposit

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -22,7 +22,7 @@ import { CONTRACT_ADDRESSES } from "../common";
 
 type TokenDistributionPerL1Token = { [l1Token: string]: { [chainId: number]: BigNumber } };
 
-type Rebalance = {
+export type Rebalance = {
   chainId: number;
   l1Token: string;
   thresholdPct: BigNumber;
@@ -328,7 +328,7 @@ export class InventoryClient {
         // If the amount required in the rebalance is less than the total amount of this token on L1 then we can execute
         // the rebalance to this particular chain. Note that if the sum of all rebalances required exceeds the l1
         // balance then this logic ensures that we only fill the first n number of chains where we can.
-        if (amount.lt(balance)) {
+        if (amount.lte(balance)) {
           // As a precautionary step before proceeding, check that the token balance for the token we're about to send
           // hasn't changed on L1. It's possible its changed since we updated the inventory due to one or more of the
           // RPC's returning slowly, leading to concurrent/overlapping instances of the bot running.

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -304,7 +304,6 @@ export class InventoryClient {
     // Note: these types are just used inside this method, so they are declared in-line.
     type ExecutedRebalance = Rebalance & { hash: string };
 
-    const rebalancesRequired: Rebalance[] = [];
     const possibleRebalances: Rebalance[] = [];
     const unexecutedRebalances: Rebalance[] = [];
     const executedTransactions: ExecutedRebalance[] = [];
@@ -438,7 +437,7 @@ export class InventoryClient {
     } catch (error) {
       this.log(
         "Something errored during inventory rebalance",
-        { error, rebalancesRequired, possibleRebalances, unexecutedRebalances, executedTransactions }, // include all info to help debugging.
+        { error, possibleRebalances, unexecutedRebalances, executedTransactions }, // include all info to help debugging.
         "error"
       );
     }

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -301,11 +301,6 @@ export class InventoryClient {
   // Trigger a rebalance if the current balance on any L2 chain, including shortfalls, is less than the threshold
   // allocation.
   async rebalanceInventoryIfNeeded(): Promise<void> {
-    const tokenDistributionPerL1Token = this.getTokenDistributionPerL1Token();
-    this.constructConsideringRebalanceDebugLog(tokenDistributionPerL1Token);
-    if (!this.isInventoryManagementEnabled()) {
-      return;
-    }
     // Note: these types are just used inside this method, so they are declared in-line.
     type ExecutedRebalance = Rebalance & { hash: string };
 
@@ -314,6 +309,12 @@ export class InventoryClient {
     const unexecutedRebalances: Rebalance[] = [];
     const executedTransactions: ExecutedRebalance[] = [];
     try {
+      if (!this.isInventoryManagementEnabled()) {
+        return;
+      }
+      const tokenDistributionPerL1Token = this.getTokenDistributionPerL1Token();
+      this.constructConsideringRebalanceDebugLog(tokenDistributionPerL1Token);
+
       const rebalancesRequired = this._getPossibleRebalances(tokenDistributionPerL1Token);
       if (rebalancesRequired.length === 0) {
         this.log("No rebalances required");

--- a/src/clients/bridges/CrossChainTransferClient.ts
+++ b/src/clients/bridges/CrossChainTransferClient.ts
@@ -9,8 +9,7 @@ export class CrossChainTransferClient {
     readonly logger: winston.Logger,
     readonly chainIdList: number[],
     readonly adapterManager: AdapterManager
-  ) {
-  }
+  ) {}
 
   // Get any funds currently in the canonical bridge.
   getOutstandingCrossChainTransferAmount(address: string, chainId: number | string, l1Token: string): BigNumber {

--- a/src/clients/bridges/CrossChainTransferClient.ts
+++ b/src/clients/bridges/CrossChainTransferClient.ts
@@ -10,11 +10,6 @@ export class CrossChainTransferClient {
     readonly chainIdList: number[],
     readonly adapterManager: AdapterManager
   ) {
-    logger.debug({
-      at: "CrossChainTransferClient#constructor",
-      message: "Initialized CrossChainTransferClient",
-      chainIdList,
-    });
   }
 
   // Get any funds currently in the canonical bridge.

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -298,27 +298,33 @@ export class Relayer {
 
         // Sanity check:
         if (newChainBalance.gte(unfilledAmount)) {
-          throw new Error(`TokenClient.getBalance returned a balance greater than the unfilled amount`)
+          throw new Error("TokenClient.getBalance returned a balance greater than the unfilled amount");
         }
 
         // If there are any outstanding rebalances to this chain, add them to new chain balance.
-        const outstandingCrossChainTransferAmount = inventoryClient.crossChainTransferClient.getOutstandingCrossChainTransferAmount(
-          this.relayerAddress,
-          destinationChainId,
-          l1Token.address
-        )
-        newChainBalance = newChainBalance.add(outstandingCrossChainTransferAmount)
+        const outstandingCrossChainTransferAmount =
+          inventoryClient.crossChainTransferClient.getOutstandingCrossChainTransferAmount(
+            this.relayerAddress,
+            destinationChainId,
+            l1Token.address
+          );
+        newChainBalance = newChainBalance.add(outstandingCrossChainTransferAmount);
         if (newChainBalance.gte(unfilledAmount)) {
           this.logger.debug({
             at: "Relayer",
-            message: "Skipping zero fills for this token because there are outstanding cross chain transfers that can be used to fast fill this deposit",
+            message:
+              "Skipping zero fills for this token because there are outstanding cross chain transfers that can be used to fast fill this deposit",
             outstandingCrossChainTransferAmount,
             newChainBalance,
-            crossChainTxns: inventoryClient.crossChainTransferClient.getOutstandingCrossChainTransferTxs(this.relayerAddress, destinationChainId, l1Token.address)
+            crossChainTxns: inventoryClient.crossChainTransferClient.getOutstandingCrossChainTransferTxs(
+              this.relayerAddress,
+              destinationChainId,
+              l1Token.address
+            ),
           });
           continue;
         }
-        
+
         // Check for upcoming rebalances.
         const rebalances = inventoryClient.getPossibleRebalances();
         const rebalanceForFilledToken = rebalances.find(
@@ -354,11 +360,7 @@ export class Relayer {
         }
         // If we don't have enough balance to fill the unfilled amount and the fill count on the deposit is 0 then send a
         // 1 wei sized fill to ensure that the deposit is slow relayed. This only needs to be done once.
-        if (
-          sendSlowRelays &&
-          tokenClient.hasBalanceForZeroFill(deposit) &&
-          fillCount === 0
-        ) {
+        if (sendSlowRelays && tokenClient.hasBalanceForZeroFill(deposit) && fillCount === 0) {
           this.zeroFillDeposit(deposit);
         }
       }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -111,7 +111,8 @@ export class Relayer {
   async checkForUnfilledDepositsAndFill(sendSlowRelays = true): Promise<void> {
     // Fetch all unfilled deposits, order by total earnable fee.
     const { config } = this;
-    const { acrossApiClient, hubPoolClient, profitClient, spokePoolClients, tokenClient } = this.clients;
+    const { acrossApiClient, hubPoolClient, profitClient, spokePoolClients, tokenClient, inventoryClient } =
+      this.clients;
 
     // Flush any pre-existing enqueued transactions that might not have been executed.
     this.clients.multiCallerClient.clearTransactionQueue();
@@ -283,18 +284,52 @@ export class Relayer {
         // expensive fills on (for example) mainnet.
         this.fillRelay(deposit, unfilledAmount, destinationChainId);
       } else {
+        tokenClient.captureTokenShortfallForFill(deposit, unfilledAmount);
+
+        // Before deciding whether to zero fill, first determine if the inventory manager will subsequently send
+        // funds to the destination chain to cover the shortfall. If it will, then check if the new balance
+        // will be enough for the relayer to submit a fast fill. If so, then don't zero fill so that the
+        // relayer can send this full fill and elect where to take repayment. This is assuming the contract
+        // enforces that partial fills must take  repayment on the destination which can lead to over-allocations
+        // on the destination chain if we always sent zero/partial fills here.
+        let willFastFillAfterRebalance = false;
+        const currentChainBalance = tokenClient.getBalance(destinationChainId, deposit.destinationToken);
+        let newChainBalance = currentChainBalance;
+        const rebalances = inventoryClient.getPossibleRebalances();
+        const rebalanceForFilledToken = rebalances.find(
+          ({ l1Token: l1TokenForFill, chainId, amount, balance }) =>
+            l1TokenForFill === l1Token.address && chainId === destinationChainId && amount.lt(balance) // It's important we count only rebalances that are executable based on current L1 balance.
+        );
+        if (rebalanceForFilledToken !== undefined) {
+          newChainBalance = newChainBalance.add(rebalanceForFilledToken.amount);
+          willFastFillAfterRebalance = newChainBalance.gte(unfilledAmount);
+          this.logger.debug({
+            at: "Relayer",
+            message:
+              "Inventory manager will rebalance to this chain after capturing token shortfall. Will skip zero fill if this deposit will be fillable after rebalance.",
+            currentChainBalance,
+            newChainBalance,
+            rebalanceForFilledToken,
+            rebalances,
+            willFastFillAfterRebalance,
+          });
+        } else {
+          this.logger.debug({
+            at: "Relayer",
+            message: "No rebalances for filled token, proceeding to evaluate zero fill",
+            currentChainBalance,
+            rebalances,
+          });
+        }
         // If we don't have enough balance to fill the unfilled amount and the fill count on the deposit is 0 then send a
         // 1 wei sized fill to ensure that the deposit is slow relayed. This only needs to be done once.
-        if (sendSlowRelays && tokenClient.hasBalanceForZeroFill(deposit) && fillCount === 0) {
+        if (
+          !willFastFillAfterRebalance &&
+          sendSlowRelays &&
+          tokenClient.hasBalanceForZeroFill(deposit) &&
+          fillCount === 0
+        ) {
           this.zeroFillDeposit(deposit);
-        } else {
-          // If we are slow filling this relay then there is no need to capture a "token shortfall" for it since it'll
-          // get slow filled. Conversely, if we don't slow fill it then we should capture the token shortfall so that
-          // the inventory manager can account for it when deciding to bridge funds over the chain.
-          // @dev the shortfall is accounted for when computing the allocation % of a token on a chain, so adding
-          // a shortfall for this fill means that the allocation % would be lower on the destination chain which
-          // increases the likelihood of the inventory manager subsequently wanting to send tokens to that chain.
-          tokenClient.captureTokenShortfallForFill(deposit, unfilledAmount);
         }
       }
     }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -317,6 +317,7 @@ export class Relayer {
           this.logger.debug({
             at: "Relayer",
             message: "No rebalances for filled token, proceeding to evaluate zero fill",
+            depositL1Token: l1Token.address,
             currentDestinationChainBalance,
             rebalances,
           });

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -293,12 +293,12 @@ export class Relayer {
         // enforces that partial fills must take  repayment on the destination which can lead to over-allocations
         // on the destination chain if we always sent zero/partial fills here.
         let willFastFillAfterRebalance = false;
-        const currentChainBalance = tokenClient.getBalance(destinationChainId, deposit.destinationToken);
-        let newChainBalance = currentChainBalance;
+        const currentDestinationChainBalance = tokenClient.getBalance(destinationChainId, deposit.destinationToken);
+        let newChainBalance = currentDestinationChainBalance;
         const rebalances = inventoryClient.getPossibleRebalances();
         const rebalanceForFilledToken = rebalances.find(
           ({ l1Token: l1TokenForFill, chainId, amount, balance }) =>
-            l1TokenForFill === l1Token.address && chainId === destinationChainId && amount.lt(balance) // It's important we count only rebalances that are executable based on current L1 balance.
+            l1TokenForFill === l1Token.address && chainId === destinationChainId && amount.lte(balance) // It's important we count only rebalances that are executable based on current L1 balance.
         );
         if (rebalanceForFilledToken !== undefined) {
           newChainBalance = newChainBalance.add(rebalanceForFilledToken.amount);
@@ -307,7 +307,7 @@ export class Relayer {
             at: "Relayer",
             message:
               "Inventory manager will rebalance to this chain after capturing token shortfall. Will skip zero fill if this deposit will be fillable after rebalance.",
-            currentChainBalance,
+            currentDestinationChainBalance,
             newChainBalance,
             rebalanceForFilledToken,
             rebalances,
@@ -317,7 +317,7 @@ export class Relayer {
           this.logger.debug({
             at: "Relayer",
             message: "No rebalances for filled token, proceeding to evaluate zero fill",
-            currentChainBalance,
+            currentDestinationChainBalance,
             rebalances,
           });
         }

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -198,7 +198,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
     expect(multiCallerClient.transactionCount()).to.equal(0); // no Transactions to send.
     expect(lastSpyLogIncludes(spy, "Insufficient balance to fill all deposits")).to.be.true;
   });
-  describe.only("Sends zero fills only if it won't rebalance to fast fill deposit", function () {
+  describe("Sends zero fills only if it won't rebalance to fast fill deposit", function () {
     let deposit1: any, partialRebalance: any;
     beforeEach(async function () {
       // Transfer away a lot of the relayers funds to simulate the relayer having insufficient funds.

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -34,6 +34,7 @@ import {
   setupTokensForWallet,
   sinon,
   spyLogIncludes,
+  toBN,
   winston,
 } from "./utils";
 
@@ -50,7 +51,7 @@ let spy: sinon.SinonSpy, spyLogger: winston.Logger;
 let spokePoolClient_1: SpokePoolClient, spokePoolClient_2: SpokePoolClient;
 let configStoreClient: ConfigStoreClient, hubPoolClient: HubPoolClient, tokenClient: TokenClient;
 let relayerInstance: Relayer;
-let multiCallerClient: MultiCallerClient, profitClient: MockProfitClient;
+let multiCallerClient: MultiCallerClient, profitClient: MockProfitClient, mockInventoryClient: MockInventoryClient;
 let spokePool1DeploymentBlock: number, spokePool2DeploymentBlock: number;
 
 describe("Relayer: Zero sized fill for slow relay", async function () {
@@ -118,6 +119,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
       await profitClient.initToken(erc20);
     }
 
+    mockInventoryClient = new MockInventoryClient();
     relayerInstance = new Relayer(
       relayer.address,
       spyLogger,
@@ -128,7 +130,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
         tokenClient,
         profitClient,
         multiCallerClient,
-        inventoryClient: new MockInventoryClient(),
+        inventoryClient: mockInventoryClient,
         acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
         ubaClient: null,
       },
@@ -195,6 +197,73 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
     await relayerInstance.checkForUnfilledDepositsAndFill();
     expect(multiCallerClient.transactionCount()).to.equal(0); // no Transactions to send.
     expect(lastSpyLogIncludes(spy, "Insufficient balance to fill all deposits")).to.be.true;
+  });
+  describe.only("Sends zero fills only if it won't rebalance to fast fill deposit", function () {
+    let deposit1: any, partialRebalance: any;
+    beforeEach(async function () {
+      // Transfer away a lot of the relayers funds to simulate the relayer having insufficient funds.
+      const balance = await erc20_1.balanceOf(relayer.address);
+      await erc20_1.connect(relayer).transfer(owner.address, balance.sub(amountToDeposit));
+      await erc20_2.connect(relayer).transfer(owner.address, balance.sub(amountToDeposit));
+      // The relayer wallet was seeded with 5x the deposit amount. Make the deposit 6x this size.
+      await spokePool_1.setCurrentTime(await getLastBlockTime(spokePool_1.provider));
+      deposit1 = await deposit(
+        spokePool_1,
+        erc20_1,
+        depositor,
+        depositor,
+        destinationChainId,
+        amountToDeposit.mul(2) // 2x the normal deposit size. Bot only has 1x the deposit amount.
+      );
+      await updateAllClients();
+
+      partialRebalance = {
+        // These parameters don't matter, as the relayer only checks that the rebalance matches
+        // the deposit destination chain and L1 token. The amount must be greater than the unfilled
+        // deposit amount too.
+        thresholdPct: toBN(0),
+        targetPct: toBN(0),
+        currentAllocPct: toBN(0),
+        cumulativeBalance: await l1Token.balanceOf(relayer.address),
+      };
+    });
+    it("Skips zero fill if there is a rebalance that will fast fill the deposit", async function () {
+      // Add a rebalance to the inventory client to trick relayer into thinking it will be able to fill
+      // the deposit post rebalance.
+      mockInventoryClient.addPossibleRebalance({
+        ...partialRebalance,
+        balance: deposit1.amount,
+        amount: deposit1.amount,
+        chainId: deposit1.destinationChainId,
+        l1Token: l1Token.address,
+      });
+
+      await relayerInstance.checkForUnfilledDepositsAndFill();
+      expect(multiCallerClient.transactionCount()).to.equal(0);
+    });
+    describe("Sends zero fill if no rebalance for deposit", function () {
+      it("rebalance amount is too low", async function () {
+        mockInventoryClient.addPossibleRebalance({
+          ...partialRebalance,
+          balance: toBN(0), // No balance
+          amount: deposit1.amount,
+          chainId: deposit1.destinationChainId,
+          l1Token: l1Token.address,
+        });
+        await relayerInstance.checkForUnfilledDepositsAndFill();
+        expect(multiCallerClient.transactionCount()).to.equal(1);
+      });
+      it("rebalance doesn't match deposit", async function () {
+        mockInventoryClient.addPossibleRebalance({
+          ...partialRebalance,
+          amount: deposit1.amount,
+          chainId: deposit1.originChainId, // Wrong chain
+          l1Token: l1Token.address,
+        });
+        await relayerInstance.checkForUnfilledDepositsAndFill();
+        expect(multiCallerClient.transactionCount()).to.equal(1);
+      });
+    });
   });
 });
 

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -266,7 +266,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
         expect(multiCallerClient.transactionCount()).to.equal(1);
       });
       it("Skips zero fill if outstanding transfer amount is greater than deposit amount", async function () {
-        mockCrossChainTransferClient.setCrossChainTransferAmount(deposit1.amount);
+        mockInventoryClient.setBalanceOnChainForL1Token(deposit1.amount);
         await relayerInstance.checkForUnfilledDepositsAndFill();
         expect(multiCallerClient.transactionCount()).to.equal(0);
       });

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -269,7 +269,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
         mockCrossChainTransferClient.setCrossChainTransferAmount(deposit1.amount);
         await relayerInstance.checkForUnfilledDepositsAndFill();
         expect(multiCallerClient.transactionCount()).to.equal(0);
-      })
+      });
     });
   });
 });

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -17,6 +17,7 @@ import {
   repaymentChainId,
 } from "./constants";
 import { MockInventoryClient, MockProfitClient } from "./mocks";
+import { MockCrossChainTransferClient } from "./mocks/MockCrossChainTransferClient";
 import { MockedMultiCallerClient } from "./mocks/MockMultiCallerClient";
 import {
   Contract,
@@ -123,7 +124,7 @@ describe("Relayer: Token balance shortfall", async function () {
         tokenClient,
         profitClient,
         multiCallerClient,
-        inventoryClient: new MockInventoryClient(),
+        inventoryClient: new MockInventoryClient(new MockCrossChainTransferClient()),
         acrossApiClient: new AcrossApiClient(spyLogger, hubPoolClient, spokePoolClients),
         ubaClient: null,
       },

--- a/test/mocks/MockCrossChainTransferClient.ts
+++ b/test/mocks/MockCrossChainTransferClient.ts
@@ -1,0 +1,29 @@
+import { BigNumber } from "ethers";
+import { CrossChainTransferClient } from "../../src/clients/bridges";
+export class MockCrossChainTransferClient extends CrossChainTransferClient {
+    crossChainTransferAmount: BigNumber = BigNumber.from(0);
+  constructor(
+  ) {
+    super(
+      null,
+      null,
+      null
+    );
+  }
+
+
+
+setCrossChainTransferAmount(amount: BigNumber): void {
+    this.crossChainTransferAmount = amount;
+}
+
+getOutstandingCrossChainTransferAmount(): BigNumber {
+    return this.crossChainTransferAmount;
+}
+
+
+getOutstandingCrossChainTransferTxs(): string[] {
+    return [];
+}
+
+}

--- a/test/mocks/MockCrossChainTransferClient.ts
+++ b/test/mocks/MockCrossChainTransferClient.ts
@@ -1,29 +1,20 @@
 import { BigNumber } from "ethers";
 import { CrossChainTransferClient } from "../../src/clients/bridges";
 export class MockCrossChainTransferClient extends CrossChainTransferClient {
-    crossChainTransferAmount: BigNumber = BigNumber.from(0);
-  constructor(
-  ) {
-    super(
-      null,
-      null,
-      null
-    );
+  crossChainTransferAmount: BigNumber = BigNumber.from(0);
+  constructor() {
+    super(null, null, null);
   }
 
-
-
-setCrossChainTransferAmount(amount: BigNumber): void {
+  setCrossChainTransferAmount(amount: BigNumber): void {
     this.crossChainTransferAmount = amount;
-}
+  }
 
-getOutstandingCrossChainTransferAmount(): BigNumber {
+  getOutstandingCrossChainTransferAmount(): BigNumber {
     return this.crossChainTransferAmount;
-}
+  }
 
-
-getOutstandingCrossChainTransferTxs(): string[] {
+  getOutstandingCrossChainTransferTxs(): string[] {
     return [];
-}
-
+  }
 }

--- a/test/mocks/MockInventoryClient.ts
+++ b/test/mocks/MockInventoryClient.ts
@@ -3,9 +3,7 @@ import { InventoryClient, Rebalance } from "../../src/clients";
 import { CrossChainTransferClient } from "../../src/clients/bridges";
 export class MockInventoryClient extends InventoryClient {
   possibleRebalances: Rebalance[] = [];
-  constructor(
-    crossChainTransferClient: CrossChainTransferClient | null = null
-  ) {
+  constructor(crossChainTransferClient: CrossChainTransferClient | null = null) {
     super(
       null, // relayer
       null, // logger

--- a/test/mocks/MockInventoryClient.ts
+++ b/test/mocks/MockInventoryClient.ts
@@ -1,9 +1,22 @@
 import { Deposit } from "../../src/interfaces";
 import { InventoryClient, Rebalance } from "../../src/clients";
+import { CrossChainTransferClient } from "../../src/clients/bridges";
 export class MockInventoryClient extends InventoryClient {
   possibleRebalances: Rebalance[] = [];
-  constructor() {
-    super(null, null, null, null, null, null, null, null, null);
+  constructor(
+    crossChainTransferClient: CrossChainTransferClient | null = null
+  ) {
+    super(
+      null, // relayer
+      null, // logger
+      null, // inventory config
+      null, // token client
+      null, // chain ID list
+      null, // hubPoolClient
+      null, // bundleDataClient
+      null, // adapter manager
+      crossChainTransferClient
+    );
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async determineRefundChainId(_deposit: Deposit): Promise<number> {

--- a/test/mocks/MockInventoryClient.ts
+++ b/test/mocks/MockInventoryClient.ts
@@ -1,8 +1,11 @@
 import { Deposit } from "../../src/interfaces";
 import { InventoryClient, Rebalance } from "../../src/clients";
 import { CrossChainTransferClient } from "../../src/clients/bridges";
+import { BigNumber } from "ethers";
 export class MockInventoryClient extends InventoryClient {
   possibleRebalances: Rebalance[] = [];
+  balanceOnChain: BigNumber = BigNumber.from(0);
+
   constructor(crossChainTransferClient: CrossChainTransferClient | null = null) {
     super(
       null, // relayer
@@ -31,5 +34,13 @@ export class MockInventoryClient extends InventoryClient {
 
   getPossibleRebalances(): Rebalance[] {
     return this.possibleRebalances;
+  }
+
+  setBalanceOnChainForL1Token(newBalance: BigNumber): void {
+    this.balanceOnChain = newBalance;
+  }
+
+  getBalanceOnChainForL1Token(): BigNumber {
+    return this.balanceOnChain;
   }
 }

--- a/test/mocks/MockInventoryClient.ts
+++ b/test/mocks/MockInventoryClient.ts
@@ -1,11 +1,24 @@
 import { Deposit } from "../../src/interfaces";
-import { InventoryClient } from "../../src/clients";
+import { InventoryClient, Rebalance } from "../../src/clients";
 export class MockInventoryClient extends InventoryClient {
+  possibleRebalances: Rebalance[] = [];
   constructor() {
     super(null, null, null, null, null, null, null, null, null);
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async determineRefundChainId(_deposit: Deposit): Promise<number> {
     return 1;
+  }
+
+  addPossibleRebalance(rebalance: Rebalance): void {
+    this.possibleRebalances.push(rebalance);
+  }
+
+  clearPossibleRebalances(): void {
+    this.possibleRebalances = [];
+  }
+
+  getPossibleRebalances(): Rebalance[] {
+    return this.possibleRebalances;
   }
 }


### PR DESCRIPTION
I think this can address the failure case where we submit a zero fill and send an inventory rebalance to an L2 in the same Relayer run when we're short balance there.

This PR introduces a new logical branch to the relayer when it sees a deposit that it can't fast full on the destination chain:
- First capture the token shortfall in the TokenClient. This is important so that the inventory client can accurately determine if it will need to rebalance.
- Load all possible rebalances: this is based on the relayer balances per chain, the outstanding cross chain transfers, and any shortfalls
- See if there is a rebalance that would fast fill this deposit.
- If there is, then check if the new destination chain balance plus this rebalance would be enough for the relayer to fast fill the deposit
- If so, then we shouldn't zero fill and we should let the relayer fast fill. **This way the relayer gets to choose its repayment chain after sending a full fill, as opposed to being forced to take repayment on the destination for a partial fill.**