### PR TITLE
fix: Supply cache instance to getCachedBlockForTimestamp()

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -13,6 +13,7 @@ import {
   getCurrentTime,
   disconnectRedisClients,
   getMultisender,
+  getRedisCache,
   winston,
 } from "../utils";
 import { arbitrumOneFinalizer, opStackFinalizer, polygonFinalizer, zkSyncFinalizer } from "./utils";
@@ -93,7 +94,10 @@ export async function finalize(
     const finalizationWindow = finalizationWindows[chainId];
     assert(finalizationWindow !== undefined, `No finalization window defined for chain ${chainId}`);
 
-    const latestBlockToFinalize = await getBlockForTimestamp(chainId, getCurrentTime() - finalizationWindow);
+    const lookback = getCurrentTime() - finalizationWindow;
+    const blockFinder = undefined;
+    const redis = await getRedisCache(logger);
+    const latestBlockToFinalize = await getBlockForTimestamp(chainId, lookback, blockFinder, redis);
 
     const network = getNetworkName(chainId);
     logger.debug({ at: "finalize", message: `Spawning ${network} finalizer.`, latestBlockToFinalize });

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -1,5 +1,8 @@
-import { BlockFinder, getProvider, isDefined } from "./";
-import { utils } from "@across-protocol/sdk-v2";
+import { interfaces, utils } from "@across-protocol/sdk-v2";
+import { isDefined } from "./";
+import { BlockFinder } from "./SDKUtils";
+import { getProvider } from "./ProviderUtils";
+import { getRedisCache } from "./RedisUtils";
 
 const blockFinders: { [chainId: number]: BlockFinder } = {};
 
@@ -29,8 +32,10 @@ export async function getBlockFinder(chainId: number): Promise<BlockFinder> {
 export async function getBlockForTimestamp(
   chainId: number,
   timestamp: number,
-  _blockFinder?: BlockFinder
+  blockFinder?: BlockFinder,
+  redisCache?: interfaces.CachingMechanismInterface,
 ): Promise<number> {
-  const blockFinder = _blockFinder ?? (await getBlockFinder(chainId));
-  return utils.getCachedBlockForTimestamp(chainId, timestamp, blockFinder);
+  blockFinder ??= await getBlockFinder(chainId);
+  redisCache ??= await getRedisCache();
+  return utils.getCachedBlockForTimestamp(chainId, timestamp, blockFinder, redisCache);
 }

--- a/src/utils/BlockUtils.ts
+++ b/src/utils/BlockUtils.ts
@@ -33,7 +33,7 @@ export async function getBlockForTimestamp(
   chainId: number,
   timestamp: number,
   blockFinder?: BlockFinder,
-  redisCache?: interfaces.CachingMechanismInterface,
+  redisCache?: interfaces.CachingMechanismInterface
 ): Promise<number> {
   blockFinder ??= await getBlockFinder(chainId);
   redisCache ??= await getRedisCache();


### PR DESCRIPTION
Without this we don't cache the timestamp -> blocknumber mappings, so we rely on the underlying RPC caching to retain the responses to the eth_getBlock queries that we issue. The are two reasons this is less desirable:
- Cached RPC queries are typically ejected much more regularly (default 1 hour, vs 1 week for cached block timestamps).
- Timestamp to block number resolution usually takes a different search path on each query, so there is a high chance of RPC cache misses even when trying to resolve the same timestamp.

This is one of the underlying reasons for the elevated RPC consumption of late.