### PR TITLE
fix: Resolve lint warnings

### DIFF
--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -18,7 +18,6 @@ import {
 } from "./constants";
 import { MockInventoryClient } from "./mocks";
 import {
-  BigNumber,
   Contract,
   SignerWithAddress,
   createSpyLogger,
@@ -203,7 +202,7 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
     expect(lastSpyLogIncludes(spy, "Insufficient balance to fill all deposits")).to.be.true;
   });
   describe("Sends zero fills only if it won't rebalance to fast fill deposit", function () {
-    let deposit1: Record<string, number | string | BigNumber> | null = null;
+    let deposit1: Record<string, unknown> | null = null;
     let partialRebalance: Pick<Rebalance, "thresholdPct" | "targetPct" | "currentAllocPct" | "cumulativeBalance">;
     beforeEach(async function () {
       // Transfer away a lot of the relayers funds to simulate the relayer having insufficient funds.

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -3,6 +3,7 @@ import {
   ConfigStoreClient,
   HubPoolClient,
   MultiCallerClient,
+  Rebalance,
   SpokePoolClient,
   TokenClient,
 } from "../src/clients";
@@ -17,6 +18,7 @@ import {
 } from "./constants";
 import { MockInventoryClient } from "./mocks";
 import {
+  BigNumber,
   Contract,
   SignerWithAddress,
   createSpyLogger,
@@ -201,7 +203,8 @@ describe("Relayer: Zero sized fill for slow relay", async function () {
     expect(lastSpyLogIncludes(spy, "Insufficient balance to fill all deposits")).to.be.true;
   });
   describe("Sends zero fills only if it won't rebalance to fast fill deposit", function () {
-    let deposit1: any, partialRebalance: any;
+    let deposit1: Record<string, number | string | BigNumber> | null = null;
+    let partialRebalance: Pick<Rebalance, "thresholdPct" | "targetPct" | "currentAllocPct" | "cumulativeBalance">;
     beforeEach(async function () {
       // Transfer away a lot of the relayers funds to simulate the relayer having insufficient funds.
       const balance = await erc20_1.balanceOf(relayer.address);


### PR DESCRIPTION
Addresses the following:

  dev/across-protocol/relayer-v2/test/Relayer.SlowFill.ts
    204:19  warning  Unexpected any. Specify a different type
    204:42  warning  Unexpected any. Specify a different type