### PR TITLE
chore: Bump sdk-v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.7",
     "@across-protocol/contracts-v2": "2.4.7",
-    "@across-protocol/sdk-v2": "0.17.16",
+    "@across-protocol/sdk-v2": "0.17.17",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.7",
     "@across-protocol/contracts-v2": "2.4.7",
-    "@across-protocol/sdk-v2": "0.17.15",
+    "@across-protocol/sdk-v2": "0.17.16",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -36,7 +36,7 @@ export class HubPoolClient extends clients.HubPoolClient {
     deposit: Pick<
       DepositWithBlock,
       "quoteTimestamp" | "amount" | "originChainId" | "originToken" | "destinationChainId" | "blockNumber"
-    >,
+    >
   ): Promise<interfaces.RealizedLpFee> {
     if (deposit.quoteTimestamp > this.currentTime) {
       throw new Error(

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -1,5 +1,5 @@
 import { clients, interfaces } from "@across-protocol/sdk-v2";
-import { BigNumber, Contract } from "ethers";
+import { Contract } from "ethers";
 import winston from "winston";
 import { MakeOptional, EventSearchConfig } from "../utils";
 import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES } from "../common";
@@ -35,16 +35,15 @@ export class HubPoolClient extends clients.HubPoolClient {
   async computeRealizedLpFeePct(
     deposit: Pick<
       DepositWithBlock,
-      "quoteTimestamp" | "amount" | "destinationChainId" | "originChainId" | "blockNumber"
+      "quoteTimestamp" | "amount" | "originChainId" | "originToken" | "destinationChainId" | "blockNumber"
     >,
-    l1Token: string
-  ): Promise<{ realizedLpFeePct: BigNumber | undefined; quoteBlock: number }> {
+  ): Promise<interfaces.RealizedLpFee> {
     if (deposit.quoteTimestamp > this.currentTime) {
       throw new Error(
         `Cannot compute lp fee percent for quote timestamp ${deposit.quoteTimestamp} in the future. Current time: ${this.currentTime}.`
       );
     }
 
-    return await super.computeRealizedLpFeePct(deposit, l1Token);
+    return await super.computeRealizedLpFeePct(deposit);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.17.16":
-  version "0.17.16"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.16.tgz#2bbf9143bb701d92183700b540b650f1b2d8cff1"
-  integrity sha512-mWzNxWovSw5HkjQfvWj9Yh91S+Yi9wttbMlwhJpF7bloMhBwftYlcfAam6wE+xTDqtQyErYjnFKd4VY9Uw0fzA==
+"@across-protocol/sdk-v2@0.17.17":
+  version "0.17.17"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.17.tgz#1cd191dd835b7546419d31b64c5195bb973639e4"
+  integrity sha512-N5EkPOJIOoUkO4/JNeRlQw7h9GRHrTQQ+ptua2cjF9i+cicukNLKrLPUTWrBXIgjsr5nXEAZl17KyeOqvXNafg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.17.15":
-  version "0.17.15"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.15.tgz#ff5c4eb8c70cc94f3cf24b865af8fea7d2855e38"
-  integrity sha512-77Fs6lvtr/FSeXtx8bzpgktxT1qDEj8TZXhsRU5WjemLzAaxi2/44zKXrXQsWEvb7XaNAc03cUKycZWkQja+Lg==
+"@across-protocol/sdk-v2@0.17.16":
+  version "0.17.16"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.17.16.tgz#2bbf9143bb701d92183700b540b650f1b2d8cff1"
+  integrity sha512-mWzNxWovSw5HkjQfvWj9Yh91S+Yi9wttbMlwhJpF7bloMhBwftYlcfAam6wE+xTDqtQyErYjnFKd4VY9Uw0fzA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.7"


### PR DESCRIPTION
This update optimises HubPool realizedLpFeePct computations to minimise RPC requests.