### PR TITLE
refactor(relayer): Don't require ubaClient before UBA

### DIFF
--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -51,7 +51,8 @@ export async function constructSpokePoolClientsWithLookback(
   configStoreClient: ConfigStoreClient,
   config: CommonConfig,
   baseSigner: Wallet,
-  initialLookBackOverride: number
+  initialLookBackOverride: number,
+  enabledChains?: number[]
 ): Promise<SpokePoolClientsByChain> {
   // Construct spoke pool clients for all chains that were enabled at least once in the block range.
   // Caller can optionally override the disabled chains list, which is useful for executing leaves or validating
@@ -72,7 +73,7 @@ export async function constructSpokePoolClientsWithLookback(
   const blockFinder = undefined;
   const redis = await getRedisCache(logger);
   const fromBlock_1 = await getBlockForTimestamp(hubPoolChainId, lookback, blockFinder, redis);
-  const enabledChains = getEnabledChainsInBlockRange(configStoreClient, config.spokePoolChainsOverride, fromBlock_1);
+  enabledChains ??= getEnabledChainsInBlockRange(configStoreClient, config.spokePoolChainsOverride, fromBlock_1);
 
   // Get full list of fromBlocks now for chains that are enabled. This way we don't send RPC requests to
   // chains that are not enabled.
@@ -136,14 +137,12 @@ export async function constructSpokePoolClientsWithStartBlocks(
   toBlockOverride: { [chainId: number]: number } = {},
   enabledChains?: number[]
 ): Promise<SpokePoolClientsByChain> {
-  if (!enabledChains) {
-    enabledChains = getEnabledChainsInBlockRange(
-      hubPoolClient.configStoreClient,
-      config.spokePoolChainsOverride,
-      startBlocks[hubPoolClient.chainId],
-      toBlockOverride[hubPoolClient.chainId]
-    );
-  }
+  enabledChains ??= getEnabledChainsInBlockRange(
+    hubPoolClient.configStoreClient,
+    config.spokePoolChainsOverride,
+    startBlocks[hubPoolClient.chainId],
+    toBlockOverride[hubPoolClient.chainId]
+  );
 
   logger.debug({
     at: "ClientHelper#constructSpokePoolClientsWithStartBlocks",

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { constants as ethersConstants, utils as ethersUtils } from "ethers";
 import { Deposit, DepositWithBlock, FillWithBlock, L1Token, RefundRequestWithBlock } from "../interfaces";
@@ -453,6 +454,8 @@ export class Relayer {
   // The remaining fills are eligible for new requests.
   async requestRefunds(sendRefundRequests = true): Promise<void> {
     const { multiCallerClient, ubaClient } = this.clients;
+    assert(isDefined(ubaClient), "No ubaClient");
+
     const spokePoolClients = Object.values(this.clients.spokePoolClients);
     this.logger.debug({
       at: "Relayer::requestRefunds",
@@ -532,6 +535,9 @@ export class Relayer {
     refundRequests: RefundRequestWithBlock[],
     fromBlock: number
   ): Promise<FillWithBlock[]> {
+    const { ubaClient } = this.clients;
+    assert(isDefined(ubaClient), "No ubaClient");
+
     const depositIds: { [chainId: number]: number[] } = {};
 
     refundRequests.forEach(({ originChainId, depositId }) => {
@@ -541,7 +547,7 @@ export class Relayer {
 
     // Find fills where repayment was requested on another chain.
     const filter = { relayer: this.relayerAddress, fromBlock };
-    const fills = (await this.clients.ubaClient.getFills(destinationChainId, filter)).filter((fill) => {
+    const fills = (await ubaClient.getFills(destinationChainId, filter)).filter((fill) => {
       const { depositId, originChainId, destinationChainId, repaymentChainId } = fill;
       return repaymentChainId !== destinationChainId && !depositIds[originChainId]?.includes(depositId);
     });
@@ -643,15 +649,18 @@ export class Relayer {
   }
 
   protected async computeRealizedLpFeePct(version: number, deposit: DepositWithBlock): Promise<BigNumber> {
+    const { depositId, originChainId } = deposit;
     if (!sdkUtils.isUBA(version)) {
       if (deposit.realizedLpFeePct === undefined) {
-        throw new Error(`Deposit ${deposit.depositId} is missing realizedLpFeePct`);
+        throw new Error(`Chain ${originChainId} deposit ${depositId} is missing realizedLpFeePct`);
       }
       return deposit.realizedLpFeePct;
     }
 
-    const { depositId } = deposit;
-    const { depositBalancingFee, lpFee } = this.clients.ubaClient.computeFeesForDeposit(deposit);
+    const { ubaClient } = this.clients;
+    assert(isDefined(ubaClient), "No ubaClient");
+
+    const { depositBalancingFee, lpFee } = ubaClient.computeFeesForDeposit(deposit);
     const realizedLpFeePct = depositBalancingFee.add(lpFee);
 
     const chain = getNetworkName(deposit.originChainId);
@@ -667,11 +676,12 @@ export class Relayer {
     if (!sdkUtils.isUBA(version)) {
       return toBN(0);
     }
-    const tokenSymbol = this.clients.hubPoolClient.getL1TokenInfoForL2Token(
-      deposit.originToken,
-      deposit.originChainId
-    )?.symbol;
-    const relayerBalancingFee = this.clients.ubaClient.computeBalancingFeeForNextRefund(
+
+    const { hubPoolClient, ubaClient } = this.clients;
+    assert(isDefined(ubaClient), "No ubaClient");
+
+    const tokenSymbol = hubPoolClient.getL1TokenInfoForL2Token(deposit.originToken, deposit.originChainId)?.symbol;
+    const relayerBalancingFee = ubaClient.computeBalancingFeeForNextRefund(
       deposit.destinationChainId,
       tokenSymbol,
       deposit.amount

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { clients as sdkClients, utils as sdkUtils } from "@across-protocol/sdk-v2";
 import winston from "winston";
 import { AcrossApiClient, BundleDataClient, InventoryClient, ProfitClient, TokenClient, UBAClient } from "../clients";
@@ -11,12 +12,12 @@ import {
   updateSpokePoolClients,
 } from "../common";
 import { SpokePoolClientsByChain } from "../interfaces";
-import { Wallet, getRedisCache } from "../utils";
+import { isDefined, Wallet, getRedisCache } from "../utils";
 import { RelayerConfig } from "./RelayerConfig";
 
 export interface RelayerClients extends Clients {
   spokePoolClients: SpokePoolClientsByChain;
-  ubaClient: UBAClient;
+  ubaClient?: UBAClient;
   tokenClient: TokenClient;
   profitClient: ProfitClient;
   inventoryClient: InventoryClient;
@@ -29,26 +30,31 @@ export async function constructRelayerClients(
   baseSigner: Wallet
 ): Promise<RelayerClients> {
   const commonClients = await constructClients(logger, config, baseSigner);
+  const { configStoreClient, hubPoolClient } = commonClients;
   await updateClients(commonClients, config);
+
 
   // Construct spoke pool clients for all chains that are not *currently* disabled. Caller can override
   // the disabled chain list by setting the DISABLED_CHAINS_OVERRIDE environment variable.
   const spokePoolClients = await constructSpokePoolClientsWithLookback(
     logger,
-    commonClients.hubPoolClient,
-    commonClients.configStoreClient,
+    hubPoolClient,
+    configStoreClient,
     config,
     baseSigner,
-    config.maxRelayerLookBack
+    config.maxRelayerLookBack,
+    sdkUtils.dedupArray([...config.relayerOriginChains, ...config.relayerDestinationChains])
   );
 
-  const ubaClient = new UBAClient(
-    new sdkClients.UBAClientConfig(),
-    commonClients.hubPoolClient.getL1Tokens().map((token) => token.symbol),
-    commonClients.hubPoolClient,
-    spokePoolClients,
-    await getRedisCache(logger)
-  );
+  const ubaClient: UBAClient | undefined = !sdkUtils.isUBA(commonClients.configStoreClient.configStoreVersion)
+    ? undefined
+    : new UBAClient(
+        new sdkClients.UBAClientConfig(),
+        commonClients.hubPoolClient.getL1Tokens().map((token) => token.symbol),
+        commonClients.hubPoolClient,
+        spokePoolClients,
+        await getRedisCache(logger)
+      );
 
   // We only use the API client to load /limits for chains so we should remove any chains that are not included in the
   // destination chain list.
@@ -61,23 +67,18 @@ export async function constructRelayerClients(
             .map((chainId) => [chainId, spokePoolClients[chainId]])
         );
 
-  const acrossApiClient = new AcrossApiClient(
-    logger,
-    commonClients.hubPoolClient,
-    destinationSpokePoolClients,
-    config.relayerTokens
-  );
-  const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, commonClients.hubPoolClient);
+  const acrossApiClient = new AcrossApiClient(logger, hubPoolClient, destinationSpokePoolClients, config.relayerTokens);
+  const tokenClient = new TokenClient(logger, baseSigner.address, spokePoolClients, hubPoolClient);
 
   // If `relayerDestinationChains` is a non-empty array, then copy its value, otherwise default to all chains.
   const enabledChainIds = (
     config.relayerDestinationChains.length > 0
       ? config.relayerDestinationChains
-      : commonClients.configStoreClient.getChainIdIndicesForBlock()
+      : configStoreClient.getChainIdIndicesForBlock()
   ).filter((chainId) => Object.keys(spokePoolClients).includes(chainId.toString()));
   const profitClient = new ProfitClient(
     logger,
-    commonClients.hubPoolClient,
+    hubPoolClient,
     spokePoolClients,
     enabledChainIds,
     baseSigner.address,
@@ -90,12 +91,12 @@ export async function constructRelayerClients(
 
   // The relayer will originate cross chain rebalances from both its own EOA address and the atomic depositor address
   // so we should track both for accurate cross-chain inventory management.
-  const atomicDepositor = CONTRACT_ADDRESSES[commonClients.hubPoolClient.chainId]?.atomicDepositor;
+  const atomicDepositor = CONTRACT_ADDRESSES[hubPoolClient.chainId]?.atomicDepositor;
   const monitoredAddresses = [baseSigner.address, atomicDepositor?.address];
   const adapterManager = new AdapterManager(
     logger,
     spokePoolClients,
-    commonClients.hubPoolClient,
+    hubPoolClient,
     monitoredAddresses.filter(() => sdkUtils.isDefined)
   );
 
@@ -103,7 +104,7 @@ export async function constructRelayerClients(
     logger,
     commonClients,
     spokePoolClients,
-    commonClients.configStoreClient.getChainIdIndicesForBlock(),
+    configStoreClient.getChainIdIndicesForBlock(),
     config.blockRangeEndBlockBuffer
   );
   const crossChainTransferClient = new CrossChainTransferClient(logger, enabledChainIds, adapterManager);
@@ -113,7 +114,7 @@ export async function constructRelayerClients(
     config.inventoryConfig,
     tokenClient,
     enabledChainIds,
-    commonClients.hubPoolClient,
+    hubPoolClient,
     bundleDataClient,
     adapterManager,
     crossChainTransferClient,
@@ -126,11 +127,13 @@ export async function constructRelayerClients(
 
 export async function updateRelayerClients(clients: RelayerClients, config: RelayerConfig): Promise<void> {
   // SpokePoolClient client requires up to date HubPoolClient and ConfigStore client.
-  const { configStoreClient, spokePoolClients, ubaClient } = clients;
+  const { configStoreClient, spokePoolClients } = clients;
 
   await configStoreClient.update();
   const version = configStoreClient.getConfigStoreVersionForTimestamp();
   if (sdkUtils.isUBA(version)) {
+    const { ubaClient } = clients;
+    assert(isDefined(ubaClient), "No ubaClient");
     await ubaClient.update();
   } else {
     // TODO: the code below can be refined by grouping with promise.all. however you need to consider the inter


### PR DESCRIPTION
The ubaClient currently imposes a requirement that the relayer has a SpokePoolClient instance for each supported chain, even if the relayer has no particular interest in that chain. This prevents relay operators from opting out of specific chains and requires them to have an RPC provider defined for all supported chains. This is undesirable for scenarios like the SNX relayer, where the only supported chains are mainnet and Optimism.

This change defers ubaClient instantiation until the relayer actually indicates support for the UBA via a configuration change, and places appropriate guards around the use of the ubaClient to ensure it is defined.