### PR TITLE
fix: fix the eth_getLogs field ignore

### DIFF
--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -89,14 +89,18 @@ function deleteIgnoredKeys(ignoredKeys: string[], obj: any) {
 }
 
 export function compareResultsAndFilterIgnoredKeys(ignoredKeys: string[], _objA: any, _objB: any): boolean {
-  // Deep copy objects so we don't mutate original inputs.
-  const objA = { ..._objA };
-  const objB = { ..._objB };
-
   // Remove ignored keys from objects and store them in ignoredMappings.
-  const newObjA = deleteIgnoredKeys(ignoredKeys, objA);
-  const newObjB = deleteIgnoredKeys(ignoredKeys, objB);
+  const filteredA = deleteIgnoredKeys(ignoredKeys, _objA);
+  const filteredB = deleteIgnoredKeys(ignoredKeys, _objB);
 
   // Compare objects without the ignored keys.
-  return lodash.isEqual(newObjA, newObjB);
+  return lodash.isEqual(filteredA, filteredB);
+}
+
+export function compareArrayResultsWithIgnoredKeys(ignoredKeys: string[], _objA: any[], _objB: any[]): boolean {
+  const filteredA = _objA.map((obj) => deleteIgnoredKeys(ignoredKeys, obj));
+  const filteredB = _objB.map((obj) => deleteIgnoredKeys(ignoredKeys, obj));
+
+  // Compare objects without the ignored keys.
+  return lodash.isEqual(filteredA, filteredB);
 }

--- a/src/utils/ObjectUtils.ts
+++ b/src/utils/ObjectUtils.ts
@@ -89,7 +89,7 @@ function deleteIgnoredKeys(ignoredKeys: string[], obj: any) {
 }
 
 export function compareResultsAndFilterIgnoredKeys(ignoredKeys: string[], _objA: any, _objB: any): boolean {
-  // Remove ignored keys from objects and store them in ignoredMappings.
+  // Remove ignored keys from copied objects.
   const filteredA = deleteIgnoredKeys(ignoredKeys, _objA);
   const filteredB = deleteIgnoredKeys(ignoredKeys, _objB);
 
@@ -98,6 +98,7 @@ export function compareResultsAndFilterIgnoredKeys(ignoredKeys: string[], _objA:
 }
 
 export function compareArrayResultsWithIgnoredKeys(ignoredKeys: string[], _objA: any[], _objB: any[]): boolean {
+  // Remove ignored keys from each element of copied arrays.
   const filteredA = _objA.map((obj) => deleteIgnoredKeys(ignoredKeys, obj));
   const filteredB = _objB.map((obj) => deleteIgnoredKeys(ignoredKeys, obj));
 

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -12,7 +12,7 @@ import {
   BLOCK_NUMBER_TTL,
 } from "../common";
 import { delay, getOriginFromURL, Logger } from "./";
-import { compareResultsAndFilterIgnoredKeys } from "./ObjectUtils";
+import { compareArrayResultsWithIgnoredKeys, compareResultsAndFilterIgnoredKeys } from "./ObjectUtils";
 
 const logger = Logger;
 
@@ -100,7 +100,7 @@ function compareRpcResults(method: string, rpcResultA: any, rpcResultB: any): bo
     // JSON RPC spec: https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getfilterchanges
     // Additional reference: https://github.com/ethers-io/ethers.js/issues/1721
     // 2023-08-31 Added blockHash because of upstream zkSync provider disagreements. Consider removing later.
-    return compareResultsAndFilterIgnoredKeys(["transactionLogIndex"], rpcResultA, rpcResultB);
+    return compareArrayResultsWithIgnoredKeys(["transactionLogIndex"], rpcResultA, rpcResultB);
   } else {
     return lodash.isEqual(rpcResultA, rpcResultB);
   }


### PR DESCRIPTION
This fixes an issue where we weren't actually dropping the field from the array elements of the eth_getlogs response. We were operating on the array, itself, which doesn't contain the fields we are trying to remove.