### PR TITLE
refactor: Reduce use of disposable BigNumber instances

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -12,7 +12,7 @@ import { SpokePoolClient } from "../clients";
 import {
   winston,
   BigNumber,
-  toBN,
+  bnZero,
   assignValidFillToFillsToRefund,
   getRefundInformationFromFill,
   updateTotalRefundAmount,
@@ -144,7 +144,7 @@ export class BundleDataClient {
           // refunds in the bundle calculation. If relayer refund leaves are executed later and all the executions are
           // within the lookback period but the corresponding deposits/fills are not, we can run into cases where
           // executedAmount > refunds[relayer].
-          refunds[relayer] = executedAmount.gt(refunds[relayer]) ? toBN(0) : refunds[relayer].sub(executedAmount);
+          refunds[relayer] = executedAmount.gt(refunds[relayer]) ? bnZero : refunds[relayer].sub(executedAmount);
         }
       }
     }
@@ -162,7 +162,7 @@ export class BundleDataClient {
   getTotalRefund(refunds: FillsToRefund[], relayer: string, chainId: number, refundToken: string): BigNumber {
     return refunds.reduce((totalRefund, refunds) => {
       return totalRefund.add(this.getRefundsFor(refunds, relayer, chainId, refundToken));
-    }, toBN(0));
+    }, bnZero);
   }
 
   // Common data re-formatting logic shared across all data worker public functions.

--- a/src/clients/TokenClient.ts
+++ b/src/clients/TokenClient.ts
@@ -2,6 +2,8 @@ import { HubPoolClient, SpokePoolClient } from ".";
 import { Deposit } from "../interfaces";
 import {
   BigNumber,
+  bnZero,
+  bnOne,
   Contract,
   ERC20,
   MAX_SAFE_ALLOWANCE,
@@ -37,7 +39,7 @@ export class TokenClient {
 
   getBalance(chainId: number, token: string): BigNumber {
     if (!this._hasTokenPairData(chainId, token)) {
-      return toBN(0);
+      return bnZero;
     }
     return this.tokenData[chainId][token].balance;
   }
@@ -47,7 +49,7 @@ export class TokenClient {
   }
 
   getShortfallTotalRequirement(chainId: number, token: string): BigNumber {
-    return this.tokenShortfall?.[chainId]?.[token]?.totalRequirement || toBN(0);
+    return this.tokenShortfall?.[chainId]?.[token]?.totalRequirement ?? bnZero;
   }
 
   getTokensNeededToCoverShortfall(chainId: number, token: string): BigNumber {
@@ -63,7 +65,7 @@ export class TokenClient {
   }
 
   hasBalanceForZeroFill(deposit: Deposit): boolean {
-    return this.getBalance(deposit.destinationChainId, deposit.destinationToken).gte(toBN(1));
+    return this.getBalance(deposit.destinationChainId, deposit.destinationToken).gte(bnOne);
   }
 
   // If the relayer tries to execute a relay but does not have enough tokens to fully fill it it will capture the

--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -6,6 +6,7 @@ import { AugmentedTransaction, SpokePoolClient, TransactionClient } from "../../
 import {
   AnyObject,
   BigNumber,
+  bnZero,
   Contract,
   DefaultLogLevels,
   ERC20,
@@ -199,7 +200,7 @@ export abstract class BaseAdapter {
           continue;
         }
 
-        const totalAmount = pendingDeposits.reduce((acc, curr) => acc.add(curr.amount), toBN(0));
+        const totalAmount = pendingDeposits.reduce((acc, curr) => acc.add(curr.amount), bnZero);
         const depositTxHashes = pendingDeposits.map((deposit) => deposit.transactionHash);
         outstandingTransfers[monitoredAddress][l1Token] = {
           totalAmount,

--- a/src/clients/bridges/CrossChainTransferClient.ts
+++ b/src/clients/bridges/CrossChainTransferClient.ts
@@ -1,4 +1,4 @@
-import { BigNumber, winston, assign, toBN, DefaultLogLevels, AnyObject } from "../../utils";
+import { BigNumber, bnZero, winston, assign, toBN, DefaultLogLevels, AnyObject } from "../../utils";
 import { AdapterManager } from "./AdapterManager";
 import { OutstandingTransfers } from "../../interfaces";
 
@@ -14,7 +14,7 @@ export class CrossChainTransferClient {
   // Get any funds currently in the canonical bridge.
   getOutstandingCrossChainTransferAmount(address: string, chainId: number | string, l1Token: string): BigNumber {
     const amount = this.outstandingCrossChainTransfers[Number(chainId)]?.[address]?.[l1Token]?.totalAmount;
-    return amount ? toBN(amount) : toBN(0);
+    return amount ? toBN(amount) : bnZero;
   }
 
   getOutstandingCrossChainTransferTxs(address: string, chainId: number | string, l1Token: string): string[] {
@@ -40,7 +40,7 @@ export class CrossChainTransferClient {
     }
     if (transfers[address][l1Token] === undefined) {
       transfers[address][l1Token] = {
-        totalAmount: toBN(0),
+        totalAmount: bnZero,
         depositTxHashes: [],
       };
     }

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -16,6 +16,7 @@ import {
 } from "../interfaces";
 import {
   AnyObject,
+  bnZero,
   buildPoolRebalanceLeafTree,
   buildRelayerRefundTree,
   buildSlowRelayTree,
@@ -25,7 +26,6 @@ import {
   groupObjectCountsByTwoProps,
   isDefined,
   MerkleTree,
-  toBN,
   winston,
 } from "../utils";
 import { PoolRebalanceRoot } from "./Dataworker";
@@ -217,7 +217,7 @@ export function _buildRelayerRefundRoot(
       // If UBA model, set amount to return to 0 for now until we match this leaf against a pool rebalance leaf. In
       // the UBA model, the amount to return is simpler to compute: simply set it equal to the negative
       // net send amount value if the net send amount is negative.
-      let amountToReturn = toBN(0);
+      let amountToReturn = bnZero;
       if (!isUBA) {
         const l1TokenCounterpart = clients.hubPoolClient.getL1TokenCounterpartAtBlock(
           repaymentChainId,
@@ -241,7 +241,7 @@ export function _buildRelayerRefundRoot(
         relayerRefundLeaves.push({
           groupIndex: i, // Will delete this group index after using it to sort leaves for the same chain ID and
           // L2 token address
-          amountToReturn: i === 0 ? amountToReturn : toBN(0),
+          amountToReturn: i === 0 ? amountToReturn : bnZero,
           chainId: Number(repaymentChainId),
           refundAmounts: sortedRefundAddresses.slice(i, i + maxRefundCount).map((address) => refunds[address]),
           leafId: 0, // Will be updated before inserting into tree when we sort all leaves.
@@ -256,7 +256,7 @@ export function _buildRelayerRefundRoot(
   // since we need to return tokens from SpokePool to HubPool.
   poolRebalanceLeaves.forEach((leaf) => {
     leaf.netSendAmounts.forEach((netSendAmount, index) => {
-      if (netSendAmount.gte(toBN(0))) {
+      if (netSendAmount.gte(bnZero)) {
         return;
       }
 
@@ -371,7 +371,7 @@ export async function _buildPoolRebalanceRoot(
   // deposit events lock funds in the spoke pool and should decrease running balances accordingly. However,
   // its important that `deposits` are all in this current block range.
   deposits.forEach((deposit: DepositWithBlock) => {
-    updateRunningBalanceForDeposit(runningBalances, clients.hubPoolClient, deposit, deposit.amount.mul(toBN(-1)));
+    updateRunningBalanceForDeposit(runningBalances, clients.hubPoolClient, deposit, deposit.amount.mul(-1));
   });
 
   earlyDeposits.forEach((earlyDeposit) => {
@@ -383,7 +383,7 @@ export async function _buildPoolRebalanceRoot(
       // Because cloneDeep drops the non-array elements of args, we have to use the index rather than the name.
       // As a fix, earlyDeposits should be treated similarly to other events and transformed at ingestion time
       // into a type that is more digestable rather than a raw event.
-      earlyDeposit.args[0].mul(toBN(-1))
+      earlyDeposit.args[0].mul(-1)
     );
   });
 

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -113,7 +113,7 @@ export function addLastRunningBalance(
         Number(repaymentChainId),
         l1TokenAddress
       );
-      if (!runningBalance.eq(toBN(0))) {
+      if (!runningBalance.eq(bnZero)) {
         updateRunningBalance(runningBalances, Number(repaymentChainId), l1TokenAddress, runningBalance);
       }
     });
@@ -146,7 +146,7 @@ export function initializeRunningBalancesFromRelayerRepayments(
         if (totalRefundAmount) {
           assign(runningBalances, [repaymentChainId, l1TokenCounterpart], totalRefundAmount);
         } else {
-          assign(runningBalances, [repaymentChainId, l1TokenCounterpart], toBN(0));
+          assign(runningBalances, [repaymentChainId, l1TokenCounterpart], bnZero);
         }
       }
     );
@@ -279,7 +279,7 @@ export async function subtractExcessFromPreviousSlowFillsFromRunningBalances(
             : preFeeAmountSentForSlowFill,
           fill.realizedLpFeePct
         );
-        if (excess.eq(toBN(0))) {
+        if (excess.eq(bnZero)) {
           return;
         }
 
@@ -300,7 +300,7 @@ export async function subtractExcessFromPreviousSlowFillsFromRunningBalances(
           finalFill: fill,
         });
 
-        updateRunningBalanceForFill(mainnetBundleEndBlock, runningBalances, hubPoolClient, fill, excess.mul(toBN(-1)));
+        updateRunningBalanceForFill(mainnetBundleEndBlock, runningBalances, hubPoolClient, fill, excess.mul(-1));
       })
   );
 
@@ -356,7 +356,7 @@ export function constructPoolRebalanceLeaves(
           if (realizedLpFees[chainId]?.[l1Token]) {
             return realizedLpFees[chainId][l1Token];
           } else {
-            return toBN(0);
+            return bnZero;
           }
         });
         const leafNetSendAmounts = l1TokensToIncludeInThisLeaf.map((l1Token, index) => {
@@ -365,7 +365,7 @@ export function constructPoolRebalanceLeaves(
           } else if (runningBalances[chainId] && runningBalances[chainId][l1Token]) {
             return getNetSendAmountForL1Token(spokeTargetBalances[index], runningBalances[chainId][l1Token]);
           } else {
-            return toBN(0);
+            return bnZero;
           }
         });
         const leafRunningBalances = l1TokensToIncludeInThisLeaf.map((l1Token, index) => {
@@ -379,7 +379,7 @@ export function constructPoolRebalanceLeaves(
               return getRunningBalanceForL1Token(spokeTargetBalances[index], runningBalances[chainId][l1Token]);
             }
           } else {
-            return toBN(0);
+            return bnZero;
           }
         });
         const incentiveBalances =
@@ -389,7 +389,7 @@ export function constructPoolRebalanceLeaves(
             if (incentivePoolBalances[chainId]?.[l1Token]) {
               return incentivePoolBalances[chainId][l1Token];
             } else {
-              return toBN(0);
+              return bnZero;
             }
           });
 
@@ -421,7 +421,7 @@ export function computeDesiredTransferAmountToSpoke(
   // Running balance is negative, but its absolute value is less than the spoke pool target balance threshold.
   // In this case, we transfer nothing.
   if (runningBalance.abs().lt(spokePoolTargetBalance.threshold)) {
-    return toBN(0);
+    return bnZero;
   }
 
   // We are left with the case where the spoke pool is beyond the threshold.
@@ -432,7 +432,7 @@ export function computeDesiredTransferAmountToSpoke(
   // This can only happen if the threshold is less than the target. This is likely due to a misconfiguration.
   // In this case, we transfer nothing until the target is exceeded.
   if (transferSize.lt(0)) {
-    return toBN(0);
+    return bnZero;
   }
 
   // Negate the transfer size because a transfer from spoke to hub is indicated by a negative number.

--- a/src/dataworker/RelayerRefundUtils.ts
+++ b/src/dataworker/RelayerRefundUtils.ts
@@ -1,5 +1,5 @@
 import { Refund, RelayerRefundLeaf, RelayerRefundLeafWithGroup, SpokePoolTargetBalance } from "../interfaces";
-import { BigNumber, compareAddresses, toBN } from "../utils";
+import { BigNumber, bnZero, compareAddresses } from "../utils";
 import { getNetSendAmountForL1Token } from "./PoolRebalanceUtils";
 
 export function getAmountToReturnForRelayerRefundLeaf(
@@ -7,7 +7,7 @@ export function getAmountToReturnForRelayerRefundLeaf(
   runningBalanceForLeaf: BigNumber
 ): BigNumber {
   const netSendAmountForLeaf = getNetSendAmountForL1Token(spokePoolTargetBalance, runningBalanceForLeaf);
-  return netSendAmountForLeaf.mul(toBN(-1)).gt(toBN(0)) ? netSendAmountForLeaf.mul(toBN(-1)) : toBN(0);
+  return netSendAmountForLeaf.lt(bnZero) ? netSendAmountForLeaf.mul(-1) : bnZero;
 }
 
 export function sortRefundAddresses(refunds: Refund): string[] {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -4,6 +4,7 @@ import { constants as ethersConstants, utils as ethersUtils } from "ethers";
 import { Deposit, DepositWithBlock, FillWithBlock, L1Token, RefundRequestWithBlock } from "../interfaces";
 import {
   BigNumber,
+  bnZero,
   bnOne,
   RelayerUnfilledDeposit,
   blockExplorerLink,
@@ -17,7 +18,6 @@ import {
   getRedisCache,
   getUnfilledDeposits,
   isDefined,
-  toBN,
   toBNWei,
   winston,
 } from "../utils";
@@ -194,7 +194,7 @@ export class Relayer {
     const unfilledDepositAmountsPerChain: { [chainId: number]: BigNumber } = unfilledDeposits.reduce((agg, curr) => {
       const unfilledAmountUsd = profitClient.getFillAmountInUsd(curr.deposit, curr.unfilledAmount);
       if (!agg[curr.deposit.originChainId]) {
-        agg[curr.deposit.originChainId] = toBN(0);
+        agg[curr.deposit.originChainId] = bnZero;
       }
       agg[curr.deposit.originChainId] = agg[curr.deposit.originChainId].add(unfilledAmountUsd);
       return agg;
@@ -675,7 +675,7 @@ export class Relayer {
 
   protected computeRefundFee(version: number, deposit: DepositWithBlock): BigNumber {
     if (!sdkUtils.isUBA(version)) {
-      return toBN(0);
+      return bnZero;
     }
 
     const { hubPoolClient, ubaClient } = this.clients;

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -20,6 +20,7 @@
 //  - excess_t_c_{i,i+1,i+2,...} should therefore be consistent unless tokens are dropped onto the spoke pool.
 
 import {
+  bnZero,
   Wallet,
   winston,
   config,
@@ -147,14 +148,14 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
               previousLeafExecution.blockNumber > bundleEndBlockForChain.toNumber();
             mrkdwn += `\n\t\t- Previous relayer refund leaf executed after bundle end block for chain: ${previousLeafExecutedAfterBundleEndBlockForChain}`;
             if (previousLeafExecutedAfterBundleEndBlockForChain) {
-              const previousLeafRefundAmount = previousLeafExecution.refundAmounts.reduce((a, b) => a.add(b), toBN(0));
+              const previousLeafRefundAmount = previousLeafExecution.refundAmounts.reduce((a, b) => a.add(b), bnZero);
               mrkdwn += `\n\t\t- Subtracting previous leaf's amountToReturn (${fromWei(
                 previousLeafExecution.amountToReturn.toString(),
                 decimals
               )}) and refunds (${fromWei(previousLeafRefundAmount.toString(), decimals)}) from token balance`;
               tokenBalanceAtBundleEndBlock = tokenBalanceAtBundleEndBlock
                 .sub(previousLeafExecution.amountToReturn)
-                .sub(previousLeafExecution.refundAmounts.reduce((a, b) => a.add(b), toBN(0)));
+                .sub(previousLeafExecution.refundAmounts.reduce((a, b) => a.add(b), bnZero));
             }
           }
 
@@ -182,7 +183,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
               const previousNetSendAmount =
                 previousPoolRebalanceLeaf.netSendAmounts[previousPoolRebalanceLeaf.l1Tokens.indexOf(l1Token)];
               mrkdwn += `\n\t\t- Previous net send amount: ${fromWei(previousNetSendAmount.toString(), decimals)}`;
-              if (previousNetSendAmount.gt(toBN(0))) {
+              if (previousNetSendAmount.gt(bnZero)) {
                 console.log(
                   `Looking for previous net send amount between  blocks ${previousBundleEndBlockForChain.toNumber()} and ${bundleEndBlockForChain.toNumber()}`
                 );
@@ -337,7 +338,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
             throw new Error(`No relayed root for chain ID ${leaf.chainId} and token ${l2Token}`);
           }
         } else {
-          const executedRelayerRefund = Object.values(relayedRoot[l2Token]).reduce((a, b) => a.add(b), toBN(0));
+          const executedRelayerRefund = Object.values(relayedRoot[l2Token]).reduce((a, b) => a.add(b), bnZero);
           excess = excess.sub(executedRelayerRefund);
           mrkdwn += `\n\t\t- executedRelayerRefund: ${fromWei(executedRelayerRefund.toString(), decimals)}`;
         }

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -1,6 +1,7 @@
 import { Deposit, DepositWithBlock, Fill, UnfilledDeposit, UnfilledDepositsForOriginChain } from "../interfaces";
 import { SpokePoolClient } from "../clients";
-import { assign, toBN, isFirstFillForDeposit, getRedisCache } from "./";
+import { assign, isFirstFillForDeposit, getRedisCache } from "./";
+import { bnZero } from "./SDKUtils";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 import { utils, typechain } from "@across-protocol/sdk-v2";
 
@@ -38,7 +39,7 @@ export function flattenAndFilterUnfilledDepositsByOriginChain(
       .map((_unfilledDeposits: UnfilledDeposit[]): UnfilledDeposit => {
         // Remove deposits with no matched fills.
         if (_unfilledDeposits.length === 0) {
-          return { unfilledAmount: toBN(0), deposit: undefined };
+          return { unfilledAmount: bnZero, deposit: undefined };
         }
         // Remove deposits where there isn't a fill with fillAmount == totalFilledAmount && fillAmount > 0. This ensures
         // that we'll only be slow relaying deposits where the first fill (i.e. the one with
@@ -47,7 +48,7 @@ export function flattenAndFilterUnfilledDepositsByOriginChain(
         if (
           !_unfilledDeposits.some((_unfilledDeposit: UnfilledDeposit) => _unfilledDeposit.hasFirstPartialFill === true)
         ) {
-          return { unfilledAmount: toBN(0), deposit: undefined };
+          return { unfilledAmount: bnZero, deposit: undefined };
         }
         // For each deposit, identify the smallest unfilled amount remaining after a fill since each fill can
         // only decrease the unfilled amount.

--- a/src/utils/FillMathUtils.ts
+++ b/src/utils/FillMathUtils.ts
@@ -1,20 +1,21 @@
 import { Fill } from "../interfaces";
-import { BigNumber, toBN, toBNWei } from ".";
+import { bnZero, fixedPointAdjustment as fixedPoint } from "./SDKUtils";
+import { BigNumber } from ".";
 
 export function _getRefundForFill(fill: Fill): BigNumber {
-  return fill.fillAmount.mul(toBNWei(1).sub(fill.realizedLpFeePct)).div(toBNWei(1));
+  return fill.fillAmount.mul(fixedPoint.sub(fill.realizedLpFeePct)).div(fixedPoint);
 }
 
 export function _getFeeAmount(fillAmount: BigNumber, feePct: BigNumber): BigNumber {
-  return fillAmount.mul(feePct).div(toBNWei(1));
+  return fillAmount.mul(feePct).div(fixedPoint);
 }
 
 export function _getRealizedLpFeeForFill(fill: Fill): BigNumber {
-  return fill.fillAmount.mul(fill.realizedLpFeePct).div(toBNWei(1));
+  return fill.fillAmount.mul(fill.realizedLpFeePct).div(fixedPoint);
 }
 
 export function getRefund(fillAmount: BigNumber, realizedLpFeePct: BigNumber): BigNumber {
-  return fillAmount.mul(toBNWei(1).sub(realizedLpFeePct)).div(toBNWei(1));
+  return fillAmount.mul(fixedPoint.sub(realizedLpFeePct)).div(fixedPoint);
 }
 
 export function getFillAmountMinusFees(
@@ -22,17 +23,13 @@ export function getFillAmountMinusFees(
   realizedLpFeePct: BigNumber,
   relayerFeePct: BigNumber
 ): BigNumber {
-  return fillAmount.mul(toBNWei(1).sub(realizedLpFeePct).sub(relayerFeePct)).div(toBNWei(1));
+  return fillAmount.mul(fixedPoint.sub(realizedLpFeePct).sub(relayerFeePct)).div(fixedPoint);
 }
 
 export function getRefundForFills(fills: Fill[]): BigNumber {
-  let accumulator = toBN(0);
-  fills.forEach((fill) => (accumulator = accumulator.add(_getRefundForFill(fill))));
-  return accumulator;
+  return fills.reduce((acc, fill) => acc.add(_getRefundForFill(fill)), bnZero);
 }
 
 export function getRealizedLpFeeForFills(fills: Fill[]): BigNumber {
-  let accumulator = toBN(0);
-  fills.forEach((fill) => (accumulator = accumulator.add(_getRealizedLpFeeForFill(fill))));
-  return accumulator;
+  return fills.reduce((acc, fill) => acc.add(_getRealizedLpFeeForFill(fill)), bnZero);
 }

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -4,13 +4,13 @@ import { DepositWithBlock, Fill, FillsToRefund, FillWithBlock, SpokePoolClientsB
 import { getBlockForTimestamp, getRedisCache, queryHistoricalDepositForFill } from "../utils";
 import {
   BigNumber,
+  bnZero,
   assign,
   getRealizedLpFeeForFills,
   getRefundForFills,
   isDefined,
   sortEventsDescending,
   sortEventsAscending,
-  toBN,
 } from "./";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
 import { clients } from "@across-protocol/sdk-v2";
@@ -108,7 +108,7 @@ export function updateTotalRefundAmountRaw(
 }
 
 export function isFirstFillForDeposit(fill: Fill): boolean {
-  return fill.fillAmount.eq(fill.totalFilledAmount) && fill.fillAmount.gt(toBN(0));
+  return fill.fillAmount.eq(fill.totalFilledAmount) && fill.fillAmount.gt(bnZero);
 }
 
 export function filledSameDeposit(fillA: Fill, fillB: Fill): boolean {

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -6,13 +6,14 @@ import { DEFAULT_GAS_FEE_SCALERS, multicall3Addresses } from "../common";
 import { EthersError } from "../interfaces";
 import {
   BigNumber,
+  bnZero,
   Contract,
+  fixedPointAdjustment as fixedPoint,
   isDefined,
   TransactionResponse,
   Wallet,
   ethers,
   getContractInfoFromAddress,
-  toBN,
   toBNWei,
   winston,
 } from "../utils";
@@ -48,7 +49,7 @@ export async function runTransaction(
   contract: Contract,
   method: string,
   args: unknown,
-  value: BigNumber = toBN(0),
+  value = bnZero,
   gasLimit: BigNumber | null = null,
   nonce: number | null = null,
   retriesRemaining = 2
@@ -196,5 +197,5 @@ export function getTarget(targetAddress: string):
 }
 
 function scaleByNumber(amount: ethers.BigNumber, scaling: number) {
-  return amount.mul(toBNWei(scaling)).div(toBNWei("1"));
+  return amount.mul(toBNWei(scaling)).div(fixedPoint);
 }


### PR DESCRIPTION
ethers provides predefined BNs for 0 and 1, and we import these via the Across SDK. Roll these out as far and wide as possible, so as to reduce the unnecessary instantiation of new short-lived BNs. This will admittedly only have a small impact on memory and CPU consumption, but is still worth doing (especially in cases where the BNs were previously instantiated in a tight loop).