### PR TITLE
feat: Support instantiating void signers

### DIFF
--- a/scripts/hubpool.ts
+++ b/scripts/hubpool.ts
@@ -248,7 +248,8 @@ async function run(argv: string[]): Promise<number> {
 
   let signer: Signer;
   try {
-    signer = await getSigner({ keyType: args.wallet, cleanEnv: true });
+    const keyType = ["dispute"].includes(argv[0]) ? args.wallet : "void";
+    signer = await getSigner({ keyType, cleanEnv: true });
   } catch (err) {
     return usage(args.wallet) ? NODE_SUCCESS : NODE_INPUT_ERR;
   }

--- a/scripts/hubpool.ts
+++ b/scripts/hubpool.ts
@@ -1,7 +1,7 @@
 import minimist from "minimist";
 import { WETH9__factory as WETH9 } from "@across-protocol/contracts-v2";
 import { constants as sdkConsts } from "@across-protocol/sdk-v2";
-import { BigNumber, ethers, Wallet } from "ethers";
+import { BigNumber, ethers, Signer } from "ethers";
 import { config } from "dotenv";
 import { getNetworkName, getSigner } from "../src/utils";
 import * as utils from "./utils";
@@ -20,9 +20,10 @@ function bnMax(a: BigNumber, b: BigNumber): BigNumber {
   return result.isZero() || result.gt(0) ? a : b;
 }
 
-async function dispute(args: Record<string, number | string>, signer: Wallet): Promise<boolean> {
+async function dispute(args: Record<string, number | string>, signer: Signer): Promise<boolean> {
   const ethBuffer = "0.1"; // Spare ether required to pay for gas.
 
+  const signerAddr = await signer.getAddress();
   const chainId = Number(args.chainId);
   const { force, txnHash } = args;
 
@@ -42,10 +43,10 @@ async function dispute(args: Record<string, number | string>, signer: Wallet): P
   const fromBlock = Math.floor(latestBlock.number - (liveness - avgBlockTime));
   const bondToken = WETH9.connect(bondTokenAddress, hubPool.provider);
   const [bondBalance, decimals, symbol, allowance, proposals] = await Promise.all([
-    bondToken.balanceOf(signer.address),
+    bondToken.balanceOf(signerAddr),
     bondToken.decimals(),
     bondToken.symbol(),
-    bondToken.allowance(signer.address, hubPool.address),
+    bondToken.allowance(signerAddr, hubPool.address),
     hubPool.queryFilter(filter, fromBlock, latestBlock.number),
   ]);
 
@@ -151,7 +152,7 @@ async function dispute(args: Record<string, number | string>, signer: Wallet): P
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function search(args: Record<string, number | string>, _signer: Wallet): Promise<boolean> {
+async function search(args: Record<string, number | string>, _signer: Signer): Promise<boolean> {
   const eventName = args.event as string;
   const fromBlock = Number(args.fromBlock) || undefined;
   const toBlock = Number(args.toBlock) || undefined;
@@ -245,7 +246,7 @@ async function run(argv: string[]): Promise<number> {
 
   config();
 
-  let signer: Wallet;
+  let signer: Signer;
   try {
     signer = await getSigner({ keyType: args.wallet, cleanEnv: true });
   } catch (err) {

--- a/scripts/sendTokens.ts
+++ b/scripts/sendTokens.ts
@@ -28,8 +28,9 @@ export async function run(): Promise<void> {
     throw new Error("Define `chainId` as the chain you want to connect on");
   }
   const baseSigner = await retrieveSignerFromCLIArgs();
+  const signerAddr = await baseSigner.getAddress();
   const connectedSigner = baseSigner.connect(await getProvider(Number(args.chainId)));
-  console.log("Connected to account", connectedSigner.address);
+  console.log("Connected to account", signerAddr);
   const recipient = args.to;
   const token = args.token;
   if (!ethers.utils.isAddress(recipient)) {

--- a/scripts/spokepool.ts
+++ b/scripts/spokepool.ts
@@ -300,8 +300,13 @@ async function run(argv: string[]): Promise<boolean> {
   const args = minimist(argv.slice(1), opts);
 
   config();
-  const keyType = ["deposit", "fill"].includes(argv[0]) ? args.wallet : "void";
-  const signer = await getSigner({ keyType, cleanEnv: true });
+  let signer: Signer;
+  try {
+    const keyType = ["deposit", "fill"].includes(argv[0]) ? args.wallet : "void";
+    const signer = await getSigner({ keyType, cleanEnv: true });
+  } catch (err) {
+    usage(args.wallet); // no return
+  }
 
   switch (argv[0]) {
     case "deposit":

--- a/scripts/spokepool.ts
+++ b/scripts/spokepool.ts
@@ -300,20 +300,17 @@ async function run(argv: string[]): Promise<boolean> {
   const args = minimist(argv.slice(1), opts);
 
   config();
+  const keyType = ["deposit", "fill"].includes(argv[0]) ? args.wallet : "void";
+  const signer = await getSigner({ keyType, cleanEnv: true });
 
-  let signer: Signer;
   switch (argv[0]) {
     case "deposit":
-      signer = await getSigner({ keyType: args.wallet, cleanEnv: true });
       return await deposit(args, signer);
     case "dump":
-      signer = await getSigner({ keyType: "void", cleanEnv: true });
       return await dumpConfig(args, signer);
     case "fetch":
-      signer = await getSigner({ keyType: "void", cleanEnv: true });
       return await fetchTxn(args, signer);
     case "fill":
-      signer = await getSigner({ keyType: args.wallet, cleanEnv: true });
       // @todo Not supported yet...
       usage(); // no return
       break; // ...keep the linter less dissatisfied!

--- a/scripts/spokepool.ts
+++ b/scripts/spokepool.ts
@@ -1,11 +1,11 @@
 import axios, { isAxiosError } from "axios";
 import minimist from "minimist";
-import { constants as sdkConsts, utils as sdkUtils } from "@across-protocol/sdk-v2";
-import { ExpandedERC20__factory as ERC20 } from "@across-protocol/contracts-v2";
-import { LogDescription } from "@ethersproject/abi";
-import { Contract, ethers, Wallet } from "ethers";
 import { groupBy } from "lodash";
 import { config } from "dotenv";
+import { Contract, ethers, Signer } from "ethers";
+import { LogDescription } from "@ethersproject/abi";
+import { constants as sdkConsts, utils as sdkUtils } from "@across-protocol/sdk-v2";
+import { ExpandedERC20__factory as ERC20 } from "@across-protocol/contracts-v2";
 import { BigNumber, formatFeePct, getNetworkName, getSigner, isDefined, resolveTokenSymbols, toBN } from "../src/utils";
 import * as utils from "./utils";
 
@@ -110,7 +110,7 @@ async function getRelayerQuote(
   return relayerFeePct;
 }
 
-async function deposit(args: Record<string, number | string>, signer: Wallet): Promise<boolean> {
+async function deposit(args: Record<string, number | string>, signer: Signer): Promise<boolean> {
   const depositor = await signer.getAddress();
   const [fromChainId, toChainId, baseAmount] = [Number(args.from), Number(args.to), Number(args.amount)];
   const recipient = (args.recipient as string) ?? depositor;
@@ -171,7 +171,7 @@ async function deposit(args: Record<string, number | string>, signer: Wallet): P
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function dumpConfig(args: Record<string, number | string>, _signer: Wallet): Promise<boolean> {
+async function dumpConfig(args: Record<string, number | string>, _signer: Signer): Promise<boolean> {
   const chainId = Number(args.chainId);
   const _spokePool = await utils.getSpokePoolContract(chainId);
 
@@ -216,7 +216,7 @@ async function dumpConfig(args: Record<string, number | string>, _signer: Wallet
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function fetchTxn(args: Record<string, number | string>, _signer: Wallet): Promise<boolean> {
+async function fetchTxn(args: Record<string, number | string>, _signer: Signer): Promise<boolean> {
   const { txnHash } = args;
   const chainId = Number(args.chainId);
 
@@ -301,21 +301,19 @@ async function run(argv: string[]): Promise<boolean> {
 
   config();
 
-  let signer: Wallet;
-  try {
-    signer = await getSigner({ keyType: args.wallet, cleanEnv: true });
-  } catch (err) {
-    usage(args.wallet); // no return
-  }
-
+  let signer: Signer;
   switch (argv[0]) {
     case "deposit":
+      signer = await getSigner({ keyType: args.wallet, cleanEnv: true });
       return await deposit(args, signer);
     case "dump":
+      signer = await getSigner({ keyType: "void", cleanEnv: true });
       return await dumpConfig(args, signer);
     case "fetch":
+      signer = await getSigner({ keyType: "void", cleanEnv: true });
       return await fetchTxn(args, signer);
     case "fill":
+      signer = await getSigner({ keyType: args.wallet, cleanEnv: true });
       // @todo Not supported yet...
       usage(); // no return
       break; // ...keep the linter less dissatisfied!

--- a/scripts/spokepool.ts
+++ b/scripts/spokepool.ts
@@ -303,7 +303,7 @@ async function run(argv: string[]): Promise<boolean> {
   let signer: Signer;
   try {
     const keyType = ["deposit", "fill"].includes(argv[0]) ? args.wallet : "void";
-    const signer = await getSigner({ keyType, cleanEnv: true });
+    signer = await getSigner({ keyType, cleanEnv: true });
   } catch (err) {
     usage(args.wallet); // no return
   }

--- a/scripts/unwrapWeth.ts
+++ b/scripts/unwrapWeth.ts
@@ -47,13 +47,8 @@ export async function run(): Promise<void> {
   const wrapping = args.wrap;
   if (wrapping) {
     console.log("Wrapping WETH 🎁");
-    const currentBalance = ethers.utils.formatUnits(
-      await connectedSigner.provider.getBalance(signerAddr),
-      decimals
-    );
-    console.log(
-      `Current ETH balance for account ${signerAddr} on ${getNetworkName(chainId)}: ${currentBalance}`
-    );
+    const currentBalance = ethers.utils.formatUnits(await connectedSigner.provider.getBalance(signerAddr), decimals);
+    console.log(`Current ETH balance for account ${signerAddr} on ${getNetworkName(chainId)}: ${currentBalance}`);
     if ((await connectedSigner.provider.getBalance(signerAddr)).lt(toBN(args.amount))) {
       console.log(`ETH balance < ${amountFromWei}, exiting`);
       return;

--- a/scripts/unwrapWeth.ts
+++ b/scripts/unwrapWeth.ts
@@ -33,6 +33,7 @@ export async function run(): Promise<void> {
     throw new Error("Define `amount` as how much you want to unwrap");
   }
   const baseSigner = await retrieveSignerFromCLIArgs();
+  const signerAddr = await baseSigner.getAddress();
   const chainId = Number(args.chainId);
   const connectedSigner = baseSigner.connect(await getProvider(chainId));
   if (!isKeyOf(chainId, WETH_ADDRESSES)) {
@@ -47,13 +48,13 @@ export async function run(): Promise<void> {
   if (wrapping) {
     console.log("Wrapping WETH 🎁");
     const currentBalance = ethers.utils.formatUnits(
-      await connectedSigner.provider.getBalance(baseSigner.address),
+      await connectedSigner.provider.getBalance(signerAddr),
       decimals
     );
     console.log(
-      `Current ETH balance for account ${baseSigner.address} on ${getNetworkName(chainId)}: ${currentBalance}`
+      `Current ETH balance for account ${signerAddr} on ${getNetworkName(chainId)}: ${currentBalance}`
     );
-    if ((await connectedSigner.provider.getBalance(baseSigner.address)).lt(toBN(args.amount))) {
+    if ((await connectedSigner.provider.getBalance(signerAddr)).lt(toBN(args.amount))) {
       console.log(`ETH balance < ${amountFromWei}, exiting`);
       return;
     }
@@ -68,9 +69,9 @@ export async function run(): Promise<void> {
     console.log("Transaction hash:", receipt.transactionHash);
   } else {
     console.log("Unwrapping WETH 🎊");
-    const currentBalance = ethers.utils.formatUnits(await weth.balanceOf(baseSigner.address), decimals);
-    console.log(`Current WETH balance for account ${baseSigner.address} on Mainnet: ${currentBalance}`);
-    if ((await weth.balanceOf(baseSigner.address)).lt(toBN(args.amount))) {
+    const currentBalance = ethers.utils.formatUnits(await weth.balanceOf(signerAddr), decimals);
+    console.log(`Current WETH balance for account ${signerAddr} on Mainnet: ${currentBalance}`);
+    if ((await weth.balanceOf(signerAddr)).lt(toBN(args.amount))) {
       console.log(`WETH balance < ${amountFromWei}, exiting`);
       return;
     }

--- a/scripts/zkSyncDemo.ts
+++ b/scripts/zkSyncDemo.ts
@@ -39,7 +39,7 @@ export async function run(): Promise<void> {
   const l1ChainId = Number(args.chainId);
   const l1Provider = await getProvider(l1ChainId);
   const connectedSigner = baseSigner.connect(l1Provider);
-  console.log("Connected to account", await connectedSigner.getAddress());
+  console.log(`Connected to account ${signerAddr}`);
   const recipient = args.to;
   const token = args.token;
   if (!ethers.utils.isAddress(recipient)) {

--- a/scripts/zkSyncDemo.ts
+++ b/scripts/zkSyncDemo.ts
@@ -35,6 +35,7 @@ export async function run(): Promise<void> {
   });
 
   const baseSigner = await retrieveSignerFromCLIArgs();
+  const signerAddr = await baseSigner.getAddress();
   const l1ChainId = Number(args.chainId);
   const l1Provider = await getProvider(l1ChainId);
   const connectedSigner = baseSigner.connect(l1Provider);
@@ -92,7 +93,7 @@ export async function run(): Promise<void> {
       token,
       toBN(args.amount),
       recipient,
-      await baseSigner.getAddress(),
+      signerAddr,
       l2PubdataByteLimit
     );
     const params = [recipient, args.amount, "0x", l2GasLimit.toString(), l2PubdataByteLimit, [], recipient];
@@ -141,7 +142,7 @@ export async function run(): Promise<void> {
       token,
       toBN(args.amount),
       recipient,
-      await baseSigner.getAddress(),
+      signerAddr,
       l2PubdataByteLimit
     );
 

--- a/scripts/zkSyncDemo.ts
+++ b/scripts/zkSyncDemo.ts
@@ -38,7 +38,7 @@ export async function run(): Promise<void> {
   const l1ChainId = Number(args.chainId);
   const l1Provider = await getProvider(l1ChainId);
   const connectedSigner = baseSigner.connect(l1Provider);
-  console.log("Connected to account", connectedSigner.address);
+  console.log("Connected to account", await connectedSigner.getAddress());
   const recipient = args.to;
   const token = args.token;
   if (!ethers.utils.isAddress(recipient)) {
@@ -92,7 +92,7 @@ export async function run(): Promise<void> {
       token,
       toBN(args.amount),
       recipient,
-      baseSigner.address,
+      await baseSigner.getAddress(),
       l2PubdataByteLimit
     );
     const params = [recipient, args.amount, "0x", l2GasLimit.toString(), l2PubdataByteLimit, [], recipient];
@@ -141,7 +141,7 @@ export async function run(): Promise<void> {
       token,
       toBN(args.amount),
       recipient,
-      baseSigner.address,
+      await baseSigner.getAddress(),
       l2PubdataByteLimit
     );
 

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -10,7 +10,7 @@ import {
   TransactionResponse,
   TransactionSimulationResult,
   Contract,
-  Wallet,
+  Signer,
   getMultisender,
   getProvider,
 } from "../utils";
@@ -56,7 +56,7 @@ export class MultiCallerClient {
   constructor(
     readonly logger: winston.Logger,
     readonly chunkSize: { [chainId: number]: number } = DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE,
-    readonly baseSigner?: Wallet
+    readonly baseSigner?: Signer
   ) {
     this.txnClient = new TransactionClient(logger);
   }

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -4,7 +4,7 @@ import {
   getProvider,
   getDeployedContract,
   getDeploymentBlockNumber,
-  Wallet,
+  Signer,
   Contract,
   ethers,
   getBlockForTimestamp,
@@ -22,13 +22,13 @@ export interface Clients {
   hubPoolClient: HubPoolClient;
   configStoreClient: ConfigStoreClient;
   multiCallerClient: MultiCallerClient;
-  hubSigner?: Wallet;
+  hubSigner?: Signer;
 }
 
 async function getSpokePoolSigners(
-  baseSigner: Wallet,
+  baseSigner: Signer,
   spokePoolChains: number[]
-): Promise<{ [chainId: number]: Wallet }> {
+): Promise<{ [chainId: number]: Signer }> {
   return Object.fromEntries(
     await Promise.all(
       spokePoolChains.map(async (chainId) => {
@@ -51,7 +51,7 @@ export async function constructSpokePoolClientsWithLookback(
   hubPoolClient: HubPoolClient,
   configStoreClient: ConfigStoreClient,
   config: CommonConfig,
-  baseSigner: Wallet,
+  baseSigner: Signer,
   initialLookBackOverride: number,
   enabledChains?: number[]
 ): Promise<SpokePoolClientsByChain> {
@@ -134,7 +134,7 @@ export async function constructSpokePoolClientsWithStartBlocks(
   logger: winston.Logger,
   hubPoolClient: HubPoolClient,
   config: CommonConfig,
-  baseSigner: Wallet,
+  baseSigner: Signer,
   startBlocks: { [chainId: number]: number },
   toBlockOverride: { [chainId: number]: number } = {},
   enabledChains?: number[]
@@ -264,7 +264,7 @@ export async function updateSpokePoolClients(
 export async function constructClients(
   logger: winston.Logger,
   config: CommonConfig,
-  baseSigner: Wallet
+  baseSigner: Signer
 ): Promise<Clients> {
   const hubPoolProvider = await getProvider(config.hubPoolChainId, logger);
   const hubSigner = baseSigner.connect(hubPoolProvider);

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -3,7 +3,7 @@ import {
   winston,
   config,
   startupLogLevel,
-  Wallet,
+  Signer,
   disconnectRedisClients,
   getRedisCache,
 } from "../utils";
@@ -25,7 +25,7 @@ let logger: winston.Logger;
 
 export async function createDataworker(
   _logger: winston.Logger,
-  baseSigner: Wallet
+  baseSigner: Signer
 ): Promise<{
   config: DataworkerConfig;
   clients: DataworkerClients;
@@ -53,7 +53,7 @@ export async function createDataworker(
     dataworker,
   };
 }
-export async function runDataworker(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
+export async function runDataworker(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   logger = _logger;
   let loopStart = Date.now();
   const { clients, config, dataworker } = await createDataworker(logger, baseSigner);

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -3,7 +3,6 @@ import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { BigNumber, constants } from "ethers";
 import { groupBy } from "lodash";
 import {
-  Wallet,
   config,
   startupLogLevel,
   processEndPollingLoop,
@@ -14,6 +13,7 @@ import {
   disconnectRedisClients,
   getMultisender,
   getRedisCache,
+  Signer,
   winston,
 } from "../utils";
 import { arbitrumOneFinalizer, opStackFinalizer, polygonFinalizer, zkSyncFinalizer } from "./utils";
@@ -49,7 +49,7 @@ const chainFinalizers: { [chainId: number]: ChainFinalizer } = {
 
 export async function finalize(
   logger: winston.Logger,
-  hubSigner: Wallet,
+  hubSigner: Signer,
   hubPoolClient: HubPoolClient,
   spokePoolClients: SpokePoolClientsByChain,
   configuredChainIds: number[],
@@ -224,7 +224,7 @@ export async function finalize(
 export async function constructFinalizerClients(
   _logger: winston.Logger,
   config: FinalizerConfig,
-  baseSigner: Wallet
+  baseSigner: Signer
 ): Promise<{
   commonClients: Clients;
   spokePoolClients: SpokePoolClientsByChain;
@@ -272,7 +272,7 @@ export class FinalizerConfig extends DataworkerConfig {
   }
 }
 
-export async function runFinalizer(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
+export async function runFinalizer(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   logger = _logger;
   // Same config as Dataworker for now.
   const config = new FinalizerConfig(process.env);

--- a/src/finalizer/types.ts
+++ b/src/finalizer/types.ts
@@ -1,4 +1,4 @@
-import { Wallet } from "ethers";
+import { Signer } from "ethers";
 import { HubPoolClient, SpokePoolClient } from "../clients";
 import { Multicall2Call } from "../common";
 import { winston } from "../utils";
@@ -15,7 +15,7 @@ export type FinalizerPromise = { callData: Multicall2Call[]; withdrawals: Withdr
 export interface ChainFinalizer {
   (
     logger: winston.Logger,
-    signer: Wallet,
+    signer: Signer,
     hubPoolClient: HubPoolClient,
     spokePoolClient: SpokePoolClient,
     firstBlockToFinalize: number

--- a/src/finalizer/utils/arbitrum.ts
+++ b/src/finalizer/utils/arbitrum.ts
@@ -1,6 +1,5 @@
 import { L2ToL1MessageStatus, L2TransactionReceipt, L2ToL1MessageWriter } from "@arbitrum/sdk";
 import {
-  Wallet,
   winston,
   convertFromWei,
   getNetworkName,
@@ -8,6 +7,7 @@ import {
   Contract,
   getCachedProvider,
   getUniqueLogIndex,
+  Signer,
 } from "../../utils";
 import { TokensBridged } from "../../interfaces";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
@@ -18,7 +18,7 @@ const CHAIN_ID = 42161;
 
 export async function arbitrumOneFinalizer(
   logger: winston.Logger,
-  signer: Wallet,
+  signer: Signer,
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   latestBlockToFinalize: number
@@ -40,7 +40,7 @@ export async function arbitrumOneFinalizer(
 
 async function multicallArbitrumFinalizations(
   tokensBridged: TokensBridged[],
-  hubSigner: Wallet,
+  hubSigner: Signer,
   hubPoolClient: HubPoolClient,
   logger: winston.Logger
 ): Promise<{ callData: Multicall2Call[]; withdrawals: Withdrawal[] }> {
@@ -98,7 +98,7 @@ async function finalizeArbitrum(message: L2ToL1MessageWriter): Promise<Multicall
 async function getFinalizableMessages(
   logger: winston.Logger,
   tokensBridged: TokensBridged[],
-  l1Signer: Wallet
+  l1Signer: Signer
 ): Promise<
   {
     info: TokensBridged;
@@ -122,7 +122,7 @@ async function getFinalizableMessages(
 async function getAllMessageStatuses(
   tokensBridged: TokensBridged[],
   logger: winston.Logger,
-  mainnetSigner: Wallet
+  mainnetSigner: Signer
 ): Promise<
   {
     info: TokensBridged;
@@ -150,7 +150,7 @@ async function getAllMessageStatuses(
 async function getMessageOutboxStatusAndProof(
   logger: winston.Logger,
   event: TokensBridged,
-  l1Signer: Wallet,
+  l1Signer: Signer,
   logIndex: number
 ): Promise<{
   message: L2ToL1MessageWriter;

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -11,7 +11,7 @@ import {
   getNetworkName,
   getUniqueLogIndex,
   groupObjectCountsByProp,
-  Wallet,
+  Signer,
   winston,
 } from "../../utils";
 import { Multicall2Call } from "../../common";
@@ -32,7 +32,7 @@ type OVM_CROSS_CHAIN_MESSENGER = optimismSDK.CrossChainMessenger;
 
 export async function opStackFinalizer(
   logger: winston.Logger,
-  signer: Wallet,
+  signer: Signer,
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   latestBlockToFinalize: number
@@ -92,7 +92,7 @@ function isOVMChainId(chainId: number): chainId is OVM_CHAIN_ID {
   return chainIsOPStack(chainId);
 }
 
-function getOptimismClient(chainId: OVM_CHAIN_ID, hubSigner: Wallet): OVM_CROSS_CHAIN_MESSENGER {
+function getOptimismClient(chainId: OVM_CHAIN_ID, hubSigner: Signer): OVM_CROSS_CHAIN_MESSENGER {
   return new optimismSDK.CrossChainMessenger({
     bedrock: true,
     l1ChainId: 1,

--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -1,5 +1,5 @@
 import { interfaces, utils as sdkUtils } from "@across-protocol/sdk-v2";
-import { Contract, Wallet } from "ethers";
+import { Contract, Wallet, Signer } from "ethers";
 import { groupBy } from "lodash";
 import { Provider as zksProvider, types as zkTypes, Wallet as zkWallet } from "zksync-web3";
 import { HubPoolClient, SpokePoolClient } from "../../clients";
@@ -25,7 +25,7 @@ const TransactionStatus = zkTypes.TransactionStatus;
  */
 export async function zkSyncFinalizer(
   logger: winston.Logger,
-  signer: Wallet,
+  signer: Signer,
   hubPoolClient: HubPoolClient,
   spokePoolClient: SpokePoolClient,
   oldestBlockToFinalize: number
@@ -35,7 +35,7 @@ export async function zkSyncFinalizer(
 
   const l1Provider = hubPoolClient.hubPool.provider;
   const l2Provider = zkSyncUtils.convertEthersRPCToZKSyncRPC(spokePoolClient.spokePool.provider);
-  const wallet = new zkWallet(signer.privateKey, l2Provider, l1Provider);
+  const wallet = new zkWallet((signer as Wallet).privateKey, l2Provider, l1Provider);
 
   // Any block younger than latestBlockToFinalize is ignored.
   const withdrawalsToQuery = spokePoolClient

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -1,5 +1,5 @@
 import { MonitorConfig } from "./MonitorConfig";
-import { Wallet, winston } from "../utils";
+import { Signer, winston } from "../utils";
 import { BundleDataClient, HubPoolClient, TokenTransferClient } from "../clients";
 import { AdapterManager, CrossChainTransferClient } from "../clients/bridges";
 import {
@@ -22,8 +22,9 @@ export interface MonitorClients extends Clients {
 export async function constructMonitorClients(
   config: MonitorConfig,
   logger: winston.Logger,
-  baseSigner: Wallet
+  baseSigner: Signer
 ): Promise<MonitorClients> {
+  const signerAddr = await baseSigner.getAddress();
   const commonClients = await constructClients(logger, config, baseSigner);
   await updateClients(commonClients, config);
 
@@ -51,7 +52,7 @@ export async function constructMonitorClients(
   // Cross-chain transfers will originate from the HubPool's address and target SpokePool addresses, so
   // track both.
   const adapterManager = new AdapterManager(logger, spokePoolClients, commonClients.hubPoolClient, [
-    baseSigner.address,
+    signerAddr,
     commonClients.hubPoolClient.hubPool.address,
     ...spokePoolAddresses,
   ]);

--- a/src/monitor/index.ts
+++ b/src/monitor/index.ts
@@ -1,11 +1,11 @@
-import { winston, processEndPollingLoop, config, startupLogLevel, Wallet, disconnectRedisClients } from "../utils";
+import { winston, processEndPollingLoop, config, startupLogLevel, Signer, disconnectRedisClients } from "../utils";
 import { Monitor } from "./Monitor";
 import { MonitorConfig } from "./MonitorConfig";
 import { constructMonitorClients } from "./MonitorClientHelper";
 config();
 let logger: winston.Logger;
 
-export async function runMonitor(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
+export async function runMonitor(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   logger = _logger;
   const config = new MonitorConfig(process.env);
   let clients;

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -115,7 +115,7 @@ export async function constructRelayerClients(
   );
   const crossChainTransferClient = new CrossChainTransferClient(logger, enabledChainIds, adapterManager);
   const inventoryClient = new InventoryClient(
-    await baseSigner.getAddress(),
+    signerAddr,
     logger,
     config.inventoryConfig,
     tokenClient,

--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -1,12 +1,12 @@
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
-import { processEndPollingLoop, winston, config, startupLogLevel, Wallet, disconnectRedisClients } from "../utils";
+import { processEndPollingLoop, winston, config, startupLogLevel, Signer, disconnectRedisClients } from "../utils";
 import { Relayer } from "./Relayer";
 import { RelayerConfig } from "./RelayerConfig";
 import { constructRelayerClients, RelayerClients, updateRelayerClients } from "./RelayerClientHelper";
 config();
 let logger: winston.Logger;
 
-export async function runRelayer(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
+export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   logger = _logger;
   const config = new RelayerConfig(process.env);
   let relayerClients: RelayerClients;
@@ -17,7 +17,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Wallet): P
     relayerClients = await constructRelayerClients(logger, config, baseSigner);
     const { configStoreClient } = relayerClients;
 
-    const relayer = new Relayer(baseSigner.address, logger, relayerClients, config);
+    const relayer = new Relayer(await baseSigner.getAddress(), logger, relayerClients, config);
 
     logger.debug({ at: "Relayer#index", message: "Relayer components initialized. Starting execution loop" });
 

--- a/src/scripts/testUBAClient.ts
+++ b/src/scripts/testUBAClient.ts
@@ -9,7 +9,6 @@
  * Run with `ts-node ./src/scripts/testUBAClient.ts --wallet mnemonic`
  */
 import {
-  Wallet,
   winston,
   config,
   retrieveSignerFromCLIArgs,
@@ -18,6 +17,7 @@ import {
   disconnectRedisClients,
   REDIS_URL,
   getRedisCache,
+  Signer,
 } from "../utils";
 import {
   constructSpokePoolClientsForFastDataworker,
@@ -35,7 +35,7 @@ const { isDefined } = sdkUtils;
 
 let logger: winston.Logger;
 
-export async function testUBAClient(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
+export async function testUBAClient(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   logger = _logger;
 
   // Override default config with sensible defaults:
@@ -144,7 +144,7 @@ export async function testUBAClient(_logger: winston.Logger, baseSigner: Wallet)
 
 export async function run(_logger: winston.Logger): Promise<void> {
   try {
-    const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
+    const baseSigner = await retrieveSignerFromCLIArgs();
     await testUBAClient(_logger, baseSigner);
   } finally {
     await disconnectRedisClients(logger);

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -6,14 +6,13 @@
 //    NODE_URL_10=https://optimism-mainnet.infura.io/v3/KEY
 //    NODE_URL_137=https://polygon-mainnet.infura.io/v3/KEY
 //    NODE_URL_42161=https://arb-mainnet.g.alchemy.com/v2/KEY
-// 2. Example of invalid bundle: REQUEST_TIME=1653594774 ts-node ./src/scripts/validateRootBundle.ts --wallet mnemonic
-// 2. Example of valid bundle:   REQUEST_TIME=1653516226 ts-node ./src/scripts/validateRootBundle.ts --wallet mnemonic
+// 2. To validate the proposal at timestamp 1653594774:
+//    REQUEST_TIME=1653594774 ts-node ./src/scripts/validateRootBundle.ts
 
 import {
-  Wallet,
   winston,
   config,
-  retrieveSignerFromCLIArgs,
+  getSigner,
   startupLogLevel,
   Logger,
   getDvmContract,
@@ -22,6 +21,7 @@ import {
   sortEventsDescending,
   getDisputeForTimestamp,
   disconnectRedisClients,
+  Signer
 } from "../utils";
 import {
   constructSpokePoolClientsForFastDataworker,
@@ -35,7 +35,7 @@ import { getBlockForChain, getEndBlockBuffers } from "../dataworker/DataworkerUt
 config();
 let logger: winston.Logger;
 
-export async function validate(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
+export async function validate(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   logger = _logger;
   if (!process.env.REQUEST_TIME) {
     throw new Error("Must set environment variable 'REQUEST_TIME=<NUMBER>' to disputed price request time");
@@ -202,7 +202,7 @@ export async function validate(_logger: winston.Logger, baseSigner: Wallet): Pro
 
 export async function run(_logger: winston.Logger): Promise<void> {
   try {
-    const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
+    const baseSigner = await getSigner({ keyType: "void", cleanEnv: true });
     await validate(_logger, baseSigner);
   } finally {
     await disconnectRedisClients(logger);

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -21,7 +21,7 @@ import {
   sortEventsDescending,
   getDisputeForTimestamp,
   disconnectRedisClients,
-  Signer
+  Signer,
 } from "../utils";
 import {
   constructSpokePoolClientsForFastDataworker,

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -20,7 +20,6 @@
 //  - excess_t_c_{i,i+1,i+2,...} should therefore be consistent unless tokens are dropped onto the spoke pool.
 
 import {
-  Wallet,
   winston,
   config,
   Logger,
@@ -36,6 +35,7 @@ import {
   ZERO_ADDRESS,
   getRefund,
   disconnectRedisClients,
+  Signer,
 } from "../utils";
 import { createDataworker } from "../dataworker";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
@@ -50,7 +50,7 @@ let logger: winston.Logger;
 
 const slowRootCache = {};
 
-export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Promise<void> {
+export async function runScript(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   logger = _logger;
 
   const { clients, dataworker, config } = await createDataworker(logger, baseSigner);
@@ -485,7 +485,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Wallet): Pr
 
 export async function run(_logger: winston.Logger): Promise<void> {
   try {
-    const baseSigner: Wallet = await retrieveSignerFromCLIArgs();
+    const baseSigner = await retrieveSignerFromCLIArgs();
     await runScript(_logger, baseSigner);
   } finally {
     await disconnectRedisClients(logger);

--- a/src/utils/CLIUtils.ts
+++ b/src/utils/CLIUtils.ts
@@ -1,12 +1,12 @@
 import minimist from "minimist";
+import { Signer } from "ethers";
 import { SignerOptions, getSigner } from "./SignerUtils";
-import { Wallet } from "ethers";
 
 /**
  * Retrieves a signer based on both the CLI args and the env.
  * @returns A signer based on the CLI args.
  */
-export function retrieveSignerFromCLIArgs(): Promise<Wallet> {
+export function retrieveSignerFromCLIArgs(): Promise<Signer> {
   // Call into the process' argv to retrieve the CLI args.
   const args = minimist(process.argv.slice(2));
   // Resolve the wallet type & verify that it is valid.

--- a/src/utils/CLIUtils.ts
+++ b/src/utils/CLIUtils.ts
@@ -30,6 +30,6 @@ export function retrieveSignerFromCLIArgs(): Promise<Signer> {
  * @param keyType The key type to check.
  * @returns True if the key type is valid, false otherwise.
  */
-function isValidKeyType(keyType: unknown): keyType is "secret" | "mnemonic" | "privateKey" | "gckms" {
-  return ["secret", "mnemonic", "privateKey", "gckms"].includes(keyType as string);
+function isValidKeyType(keyType: unknown): keyType is "secret" | "mnemonic" | "privateKey" | "gckms" | "void" {
+  return ["secret", "mnemonic", "privateKey", "gckms", "void"].includes(keyType as string);
 }

--- a/src/utils/ContractUtils.ts
+++ b/src/utils/ContractUtils.ts
@@ -1,9 +1,9 @@
-import { getNetworkName, Contract, Wallet, getDeployedAddress, getDeployedBlockNumber } from ".";
+import { getNetworkName, Contract, Signer, getDeployedAddress, getDeployedBlockNumber } from ".";
 
 import * as typechain from "@across-protocol/contracts-v2"; // TODO: refactor once we've fixed export from contract repo
 
 // Return an ethers contract instance for a deployed contract, imported from the Across-protocol contracts repo.
-export function getDeployedContract(contractName: string, networkId: number, signer?: Wallet): Contract {
+export function getDeployedContract(contractName: string, networkId: number, signer?: Signer): Contract {
   try {
     const address = getDeployedAddress(contractName, networkId);
     // If the contractName is SpokePool then we need to modify it to find the correct contract factory artifact.

--- a/src/utils/SignerUtils.ts
+++ b/src/utils/SignerUtils.ts
@@ -8,8 +8,8 @@ import { Signer, Wallet, retrieveGckmsKeys, getGckmsConfig, isDefined } from "./
  */
 export type SignerOptions = {
   /*
-   * The type of wallet to use.
-   * @note If using a GCKMS wallet, the gckmsKeys parameter must be set.
+   * The type of signer to use.
+   * @note If using a GCKMS signer, the gckmsKeys parameter must be set.
    */
   keyType: string;
   /**
@@ -29,41 +29,41 @@ export type SignerOptions = {
 };
 
 /**
- * Retrieves a signer based on the wallet type defined in the args.
+ * Retrieves a signer based on the signer type defined in the args.
  * @param cleanEnv If true, clears the mnemonic and private key from the env after retrieving the signer.
  * @returns A signer.
- * @throws If the wallet type is not defined or the mnemonic/private key is not set.
+ * @throws If the signer type is not defined or the mnemonic/private key is not set.
  * @note If cleanEnv is true, the mnemonic and private key will be cleared from the env after retrieving the signer.
  * @note This function will throw if called a second time after the first call with cleanEnv = true.
  */
 export async function getSigner({ keyType, gckmsKeys, cleanEnv, roAddress }: SignerOptions): Promise<Signer> {
-  let wallet: Signer | undefined = undefined;
+  let signer: Signer | undefined = undefined;
   switch (keyType) {
     case "mnemonic":
-      wallet = getMnemonicSigner();
+      signer = getMnemonicSigner();
       break;
     case "privateKey":
-      wallet = getPrivateKeySigner();
+      signer = getPrivateKeySigner();
       break;
     case "gckms":
-      wallet = await getGckmsSigner(gckmsKeys);
+      signer = await getGckmsSigner(gckmsKeys);
       break;
     case "secret":
-      wallet = await getSecretSigner();
+      signer = await getSecretSigner();
       break;
     case "void":
-      wallet = new VoidSigner(roAddress ?? ethersConsts.AddressZero);
+      signer = new VoidSigner(roAddress ?? ethersConsts.AddressZero);
       break;
     default:
-      throw new Error(`getSigner: Unsupported key type (${keyType})`);
+      throw new Error(`getSigner: Unsupported signer key type (${keyType})`);
   }
-  if (!wallet) {
-    throw new Error("Must define secret, mnemonic, privateKey, gckms or void for wallet");
+  if (!signer) {
+    throw new Error('Must specify "secret", "mnemonic", "privateKey", "gckms" or "void" for keyType');
   }
   if (cleanEnv) {
     cleanKeysFromEnvironment();
   }
-  return wallet;
+  return signer;
 }
 
 /**
@@ -85,7 +85,7 @@ function getPrivateKeySigner(): Signer {
  */
 async function getGckmsSigner(keys?: string[]): Promise<Signer> {
   if (!isDefined(keys) || keys.length === 0) {
-    throw new Error("Wallet GCKSM selected but no keys parameter set! Set GCKMS key to use");
+    throw new Error("Wallet GCKMS selected but no keys parameter set! Set GCKMS key to use");
   }
   const privateKeys = await retrieveGckmsKeys(getGckmsConfig(keys));
   return new Wallet(privateKeys[0]); // GCKMS retrieveGckmsKeys returns multiple keys. For now we only support 1.

--- a/src/utils/TransactionUtils.ts
+++ b/src/utils/TransactionUtils.ts
@@ -9,9 +9,9 @@ import {
   Contract,
   isDefined,
   TransactionResponse,
-  Wallet,
   ethers,
   getContractInfoFromAddress,
+  Signer,
   toBN,
   toBNWei,
   winston,
@@ -34,7 +34,7 @@ const txnRetryable = (error?: unknown): boolean => {
   return expectedRpcErrorMessages.has((error as Error)?.message);
 };
 
-export async function getMultisender(chainId: number, baseSigner: Wallet): Promise<Contract | undefined> {
+export async function getMultisender(chainId: number, baseSigner: Signer): Promise<Contract | undefined> {
   if (!multicall3Addresses[chainId] || !baseSigner) {
     return undefined;
   }


### PR DESCRIPTION
tldr there are various scripts that don't need a real signer, so don't require a private key or mnemonic to be loaded in these cases. This makes life easier for people who just want to pull down the repo and run a script (i.e. validateRootBundle.ts).

The ethers Wallet type inherits from Signer, but it imposes additional requirements like having a private key. By deferring to the Signer type, we also permit void signers. This is nice for scenarios where a private key is not needed, which is in fact the vast majority of the usage in the bot.