### PR TITLE
fix(Dataworker): Set SpokePool end blocks more conservatively

### DIFF
--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -24,7 +24,6 @@ import {
   formatFeePct,
   getFillDataForSlowFillFromPreviousRootBundle,
   getRefund,
-  isDefined,
   shortenHexString,
   shortenHexStrings,
   toBN,
@@ -476,13 +475,8 @@ export function getWidestPossibleExpectedBlockRange(
   // to fully fill the deposit and reduces the chance that the data worker includes a slow fill payment that gets
   // filled during the challenge period.
   const latestPossibleBundleEndBlockNumbers = chainIdListForBundleEvaluationBlockNumbers.map(
-    (chainId: number, index) => {
-      const spokePoolClient = spokeClients[chainId];
-      if (!isDefined(spokePoolClient)) {
-        return undefined;
-      }
-      return Math.max(spokePoolClient.latestBlockSearched - endBlockBuffers[index], 0);
-    }
+    (chainId: number, index) =>
+      spokeClients[chainId] && Math.max(spokeClients[chainId].latestBlockSearched - endBlockBuffers[index], 0)
   );
   return chainIdListForBundleEvaluationBlockNumbers.map((chainId: number, index) => {
     const lastEndBlockForChain = clients.hubPoolClient.getLatestBundleEndBlockForChain(

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -481,8 +481,7 @@ export function getWidestPossibleExpectedBlockRange(
       if (!isDefined(spokePoolClient)) {
         return undefined;
       }
-      const toBlock = spokePoolClient.eventSearchConfig.toBlock ?? spokePoolClient.latestBlockNumber;
-      return Math.max(toBlock - endBlockBuffers[index], 0);
+      return Math.max(spokePoolClient.latestBlockSearched - endBlockBuffers[index], 0);
     }
   );
   return chainIdListForBundleEvaluationBlockNumbers.map((chainId: number, index) => {

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -24,6 +24,7 @@ import {
   formatFeePct,
   getFillDataForSlowFillFromPreviousRootBundle,
   getRefund,
+  isDefined,
   shortenHexString,
   shortenHexStrings,
   toBN,
@@ -475,8 +476,14 @@ export function getWidestPossibleExpectedBlockRange(
   // to fully fill the deposit and reduces the chance that the data worker includes a slow fill payment that gets
   // filled during the challenge period.
   const latestPossibleBundleEndBlockNumbers = chainIdListForBundleEvaluationBlockNumbers.map(
-    (chainId: number, index) =>
-      spokeClients[chainId] && Math.max(spokeClients[chainId].latestBlockNumber - endBlockBuffers[index], 0)
+    (chainId: number, index) => {
+      const spokePoolClient = spokeClients[chainId];
+      if (!isDefined(spokePoolClient)) {
+        return undefined;
+      }
+      const toBlock = spokePoolClient.eventSearchConfig.toBlock ?? spokePoolClient.latestBlockNumber;
+      return Math.max(toBlock - endBlockBuffers[index], 0);
+    }
   );
   return chainIdListForBundleEvaluationBlockNumbers.map((chainId: number, index) => {
     const lastEndBlockForChain = clients.hubPoolClient.getLatestBundleEndBlockForChain(


### PR DESCRIPTION
This change ensures that Dataworker proposal block range identification is set realistically relative to the event search config for each SpokePoolClient.

HubPoolClient and SpokePoolClient instantiation was recently updated such that their search configs are now synchronised, and determined close to startup. Previously, the SpokePoolClient's search config would be determined much later because it had to wait for the initial HubPoolClient update to complete, and that can span several mainnet blocks. This meant that there was typically a 0 delta between the `toBlock` search config for each SpokePoolClient and its recorded `latestBlockNumber`. After the recent update, these values are now divergent.

This divergence can result in a situation where each SpokePoolClient may not have sufficient data to correctly match each fill with a deposit, and this has resulted in several disputes over the past few days.

Fixes ACX-1755