### PR TITLE
chore(ProviderUtils): Drop timeout 60s -> 10s

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -70,7 +70,7 @@ class RateLimitedProvider extends ethers.providers.StaticJsonRpcProvider {
   }
 }
 
-const defaultTimeout = 60 * 1000;
+const defaultTimeout = 10 * 1000;
 
 function formatProviderError(provider: ethers.providers.StaticJsonRpcProvider, rawErrorText: string) {
   return `Provider ${provider.connection.url} failed with error: ${rawErrorText}`;


### PR DESCRIPTION
The 60s timeout is a source of latent notification storms during provider outages. This often results in a high number of long-running bot instances.

Improve notification time and recovery time by dropping the timeouts.