### PR TITLE
fix: Use disputer address in validateRootBundle script

### DIFF
--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -202,7 +202,10 @@ export async function validate(_logger: winston.Logger, baseSigner: Signer): Pro
 
 export async function run(_logger: winston.Logger): Promise<void> {
   try {
-    const baseSigner = await getSigner({ keyType: "void", cleanEnv: true });
+    // This script inherits the TokenClient, and it attempts to update token approvals.
+    // The disputer bot already has the necessary token approvals in place, so use its address.
+    const roAddress = "0xf7bac63fc7ceacf0589f25454ecf5c2ce904997c";
+    const baseSigner = await getSigner({ keyType: "void", cleanEnv: true, roAddress });
     await validate(_logger, baseSigner);
   } finally {
     await disconnectRedisClients(logger);

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -204,7 +204,7 @@ export async function run(_logger: winston.Logger): Promise<void> {
   try {
     // This script inherits the TokenClient, and it attempts to update token approvals.
     // The disputer bot already has the necessary token approvals in place, so use its address.
-    const roAddress = "0xf7bac63fc7ceacf0589f25454ecf5c2ce904997c";
+    const roAddress = "0xf7bAc63fc7CEaCf0589F25454Ecf5C2ce904997c";
     const baseSigner = await getSigner({ keyType: "void", cleanEnv: true, roAddress });
     await validate(_logger, baseSigner);
   } finally {

--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -204,8 +204,8 @@ export async function run(_logger: winston.Logger): Promise<void> {
   try {
     // This script inherits the TokenClient, and it attempts to update token approvals.
     // The disputer bot already has the necessary token approvals in place, so use its address.
-    const roAddress = "0xf7bAc63fc7CEaCf0589F25454Ecf5C2ce904997c";
-    const baseSigner = await getSigner({ keyType: "void", cleanEnv: true, roAddress });
+    const voidSigner = "0xf7bAc63fc7CEaCf0589F25454Ecf5C2ce904997c";
+    const baseSigner = await getSigner({ keyType: "void", cleanEnv: true, roAddress: voidSigner });
     await validate(_logger, baseSigner);
   } finally {
     await disconnectRedisClients(logger);


### PR DESCRIPTION
The validateRootBundle script inherits a lot of core functionality, including the TokenClient. The TokenClient automatically seeks to put the necessary token approvals in place for handling the ABT token, but that's not strictly required for the validateRootBundle script since it never actually makes any transactions. Work around this by specifying the proposer address when instantiating the VoidSigner instance.