### PR TITLE
fix: Pad gas for mainnet deposits to Arbitrum

### DIFF
--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -181,7 +181,7 @@ export class ArbitrumAdapter extends BaseAdapter {
       this.l2GasPrice, // gasPriceBid
       this.transactionSubmissionData, // data
     ];
-    // Pad gas for deposits to Arbitrum to account for under-estimation in GETH. Offchain Labs confirm that this is
+    // Pad gas for deposits to Arbitrum to account for under-estimation in Geth. Offchain Labs confirm that this is
     // due to their use of BASEFEE to trigger conditional logic. https://github.com/ethereum/go-ethereum/pull/28470.
     const gasMultiplier = 1.2;
     return await this._sendTokenToTargetChain(

--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -181,6 +181,9 @@ export class ArbitrumAdapter extends BaseAdapter {
       this.l2GasPrice, // gasPriceBid
       this.transactionSubmissionData, // data
     ];
+    // Pad gas for deposits to Arbitrum to account for under-estimation in GETH. Offchain Labs confirm that this is
+    // due to their use of BASEFEE to trigger conditional logic. https://github.com/ethereum/go-ethereum/pull/28470.
+    const gasMultiplier = 1.2;
     return await this._sendTokenToTargetChain(
       l1Token,
       l2Token,
@@ -188,7 +191,7 @@ export class ArbitrumAdapter extends BaseAdapter {
       this.getL1GatewayRouter(),
       "outboundTransfer",
       args,
-      1,
+      gasMultiplier,
       this.l1SubmitValue,
       simMode
     );


### PR DESCRIPTION
Infura are currently under-estimating the gas cost of deposits into the Arbitrum contracts on mainnet. This is causing OoG failures when the transactions are executed. Offchain Labs recommend to pad the gas by 5%, but there are limited downsides to padding by more.

Fixes ACX-1763