### PR TITLE
refactor: Minor updates post SDK-v2 bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.8",
     "@across-protocol/contracts-v2": "2.4.7",
-    "@across-protocol/sdk-v2": "0.20.3",
+    "@across-protocol/sdk-v2": "0.20.5",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -61,12 +61,12 @@ export type TokensBridged = interfaces.TokensBridged;
 export type CachingMechanismInterface = interfaces.CachingMechanismInterface;
 
 // V2 / V3 interfaces
-export type V2Deposit = interfaces.v2Deposit;
-export type V2DepositWithBlock = interfaces.v2DepositWithBlock;
-export type V2SpeedUp = interfaces.v2SpeedUp;
-export type V2Fill = interfaces.v2Fill;
-export type V2FillWithBlock = interfaces.v2FillWithBlock;
-export type V2RelayData = interfaces.v2RelayData;
-export type V3RelayData = interfaces.v3RelayData;
-export type V2SlowFillLeaf = interfaces.v2SlowFillLeaf;
-export type V3SlowFillLeaf = interfaces.v3SlowFillLeaf;
+export type V2Deposit = interfaces.V2Deposit;
+export type V2DepositWithBlock = interfaces.V2DepositWithBlock;
+export type V2SpeedUp = interfaces.V2SpeedUp;
+export type V2Fill = interfaces.V2Fill;
+export type V2FillWithBlock = interfaces.V2FillWithBlock;
+export type V2RelayData = interfaces.V2RelayData;
+export type V3RelayData = interfaces.V3RelayData;
+export type V2SlowFillLeaf = interfaces.V2SlowFillLeaf;
+export type V3SlowFillLeaf = interfaces.V3SlowFillLeaf;

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,10 +43,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.20.3":
-  version "0.20.3"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.20.3.tgz#087976dbc2d1334d19354afaf332754439fb9fae"
-  integrity sha512-mmpMjv4cPaDzwso9bS34Kw/SR7UW6oo1kSCGtq/2kbCXHoZgDsjIFYHHo2neaAozDV8Hhqp0ZVYDEc7Uaf9hBQ==
+"@across-protocol/sdk-v2@0.20.5":
+  version "0.20.5"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.20.5.tgz#d55f3229aa0ab48979079a275370b8d5ab59b424"
+  integrity sha512-uTTyCu6qx99cjSfeG/ytHPFcf4pIoiOFQ2/ZzfdxAtAK5FFGC0mWOhz4vJA7jckzm2WxPPJXJqVxKYCeFQioqw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.8"


### PR DESCRIPTION
This includes the recent SDK change to remove `latestBlockNumber` from the {Hub,Spoke}PoolClient implementations.