### PR TITLE
feat(multicaller): Enable MulticallerClient user to specify which transactions should never be sent as a batch txn

### DIFF
--- a/src/clients/TransactionClient.ts
+++ b/src/clients/TransactionClient.ts
@@ -23,8 +23,10 @@ export interface AugmentedTransaction {
   message?: string;
   mrkdwn?: string;
   value?: BigNumber;
+  unbatched?: boolean; // If true, the transaction will not be batched in simulation or in production.
   unpermissioned?: boolean; // If false, the transaction must be sent from the enqueuer of the method.
-  // If true, then can be sent from the MakerDAO multisender contract.
+  // If true, then can be sent from the MakerDAO multisender contract because anyone can call this
+  // function.
   canFailInSimulation?: boolean;
 }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2127,6 +2127,9 @@ export class Dataworker {
           // If simulating mainnet execution, can fail as it may require funds to be sent from
           // pool rebalance leaf.
           canFailInSimulation: leaf.chainId === this.clients.hubPoolClient.chainId,
+          // @dev: If txn is to be sumbmitted to networkId=137, do not batch with other txns as this function call
+          // must be executed from EOA.
+          unbatched: Number(chainId) === 137,
         });
       } else {
         this.logger.debug({ at: "Dataworker#executeRelayerRefundLeaves", message: mrkdwn });


### PR DESCRIPTION
Unbatched txns can be forced to be sent from EOA rather than through Multicall3 contract
