### PR TITLE
chore: Bump SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.8",
     "@across-protocol/contracts-v2": "2.4.7",
-    "@across-protocol/sdk-v2": "0.19.0",
+    "@across-protocol/sdk-v2": "0.20.0",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -286,8 +286,8 @@ export class BundleDataClient {
         // to find the deposit if it exists.
         const spokePoolClient = spokePoolClients[fill.originChainId];
         const historicalDeposit = await queryHistoricalDepositForFill(spokePoolClient, fill);
-        if (historicalDeposit) {
-          addRefundForValidFill(fill, historicalDeposit, blockRangeForChain);
+        if (historicalDeposit.found) {
+          addRefundForValidFill(fill, historicalDeposit.deposit, blockRangeForChain);
         } else {
           allInvalidFills.push(fill);
         }

--- a/src/utils/DepositUtils.ts
+++ b/src/utils/DepositUtils.ts
@@ -124,6 +124,6 @@ export function getUniqueEarlyDepositsInRange(
 export async function queryHistoricalDepositForFill(
   spokePoolClient: SpokePoolClient,
   fill: Fill
-): Promise<DepositWithBlock | undefined> {
+): Promise<utils.DepositSearchResult> {
   return utils.queryHistoricalDepositForFill(spokePoolClient, fill, await getRedisCache(spokePoolClient.logger));
 }

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -166,7 +166,7 @@ export async function getFillDataForSlowFillFromPreviousRootBundle(
     const depositForFill = await queryHistoricalDepositForFill(spokePoolClientsByChain[fill.originChainId], fill);
     const matchingFills = await spokePoolClientsByChain[fill.destinationChainId].queryHistoricalMatchingFills(
       fill,
-      depositForFill,
+      depositForFill.found ? depositForFill.deposit : undefined,
       allMatchingFills[0].blockNumber
     );
     spokePoolClientsByChain[fill.destinationChainId].logger.debug({

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.19.0.tgz#95d6151030bbe8bcd3737abca7564749d22bf892"
-  integrity sha512-l1TjbUhH5RWd5CJq5QPax+49d4cAjB/bQRvN3tArRyxPwD/Fbei6oFUInjTYSZzWBOlrWYlfO/Ni1xaJS/2R3w==
+"@across-protocol/sdk-v2@0.20.0":
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.20.0.tgz#6f7a49f140138c76b5c1e0668c4796ff9d6e8286"
+  integrity sha512-akWjmm/okF2W2hQN+9GUa1GMWTBcFAxHA7ElXbnGV5h4UDEP1j7Z8kpf3cL+kaz/BqEluuBifu+arehpuhdfBg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.8"


### PR DESCRIPTION
This includes the minimum changes necessary to get over the hurdle to use the new queryHistoricalDepositForFill() return type. No functional change is imposed as part of this bump.