### PR TITLE
feat: Dynamically adjust proposal block ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.8",
     "@across-protocol/contracts-v2": "2.4.7",
-    "@across-protocol/sdk-v2": "0.20.0",
+    "@across-protocol/sdk-v2": "0.20.1",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -6,6 +6,7 @@ import {
   DepositWithBlock,
   FillsToRefund,
   FillWithBlock,
+  InvalidFill,
   PoolRebalanceLeaf,
   RelayerRefundLeaf,
   RelayerRefundLeafWithGroup,
@@ -104,10 +105,10 @@ export function prettyPrintSpokePoolEvents(
   allValidFills: FillWithBlock[],
   allRelayerRefunds: { repaymentChain: number; repaymentToken: string }[],
   unfilledDeposits: UnfilledDeposit[],
-  allInvalidFills: FillWithBlock[]
+  allInvalidFills: InvalidFill[]
 ): AnyObject {
   const allInvalidFillsInRange = getFillsInRange(
-    allInvalidFills,
+    allInvalidFills.map(({ fill }) => fill),
     blockRangesForChains,
     chainIdListForBundleEvaluationBlockNumbers
   );

--- a/src/interfaces/SpokePool.ts
+++ b/src/interfaces/SpokePool.ts
@@ -1,5 +1,15 @@
+import { interfaces } from "@across-protocol/sdk-v2";
 import { SpokePoolClient } from "../clients";
+import * as utils from "../utils/SDKUtils";
 
 export interface SpokePoolClientsByChain {
   [chainId: number]: SpokePoolClient;
 }
+
+export const { InvalidFill } = utils;
+
+export type InvalidFill = {
+  fill: interfaces.FillWithBlock;
+  code: utils.InvalidFillEnum;
+  reason: string;
+};

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -40,6 +40,7 @@ export type PendingRootBundle = interfaces.PendingRootBundle;
 
 // SpokePool interfaces
 export type FundsDepositedEvent = interfaces.FundsDepositedEvent;
+export type RelayData = interfaces.RelayData;
 export type Deposit = interfaces.Deposit;
 export type DepositWithBlock = interfaces.DepositWithBlock;
 export type Fill = interfaces.Fill;

--- a/src/utils/SDKUtils.ts
+++ b/src/utils/SDKUtils.ts
@@ -6,6 +6,8 @@ export type BlockFinderHints = sdk.utils.BlockFinderHints;
 export class PriceClient extends sdk.priceClient.PriceClient {}
 export const { acrossApi, coingecko, defiLlama } = sdk.priceClient.adapters;
 
+export type InvalidFillEnum = sdk.utils.InvalidFill;
+
 export const {
   bnZero,
   bnOne,
@@ -19,6 +21,7 @@ export const {
   toGWei,
   toBNWei,
   formatFeePct,
+  InvalidFill,
   shortenHexStrings,
   convertFromWei,
   max,

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -103,9 +103,11 @@ describe("Dataworker: Load data used in all functions", async function () {
       deposits: [],
       fillsToRefund: {},
       allValidFills: [],
+      allInvalidFills: [],
       earlyDeposits: [],
     });
   });
+
   describe("Computing refunds for bundles", function () {
     let fill1: Fill;
     let deposit1: Deposit;

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,10 +48,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.20.0":
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.20.0.tgz#6f7a49f140138c76b5c1e0668c4796ff9d6e8286"
-  integrity sha512-akWjmm/okF2W2hQN+9GUa1GMWTBcFAxHA7ElXbnGV5h4UDEP1j7Z8kpf3cL+kaz/BqEluuBifu+arehpuhdfBg==
+"@across-protocol/sdk-v2@0.20.1":
+  version "0.20.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.20.1.tgz#6dcf18bf1291b0aef936325fcc18cc348dee0c97"
+  integrity sha512-t1iDG84yBcgRO3AufptKQgOf6lgnWjeLmA8/X2X2nE95G5io1WG7Xz2ymj6FX6Bpk/JcCkBoN8sKIi6N03OwYg==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.8"


### PR DESCRIPTION
This commit introduces dynamic adjustment of the block ranges that the proposer will propose. The intention of this change is to make the proposer more robust to incomplete or inconsistent data being supplied by one or more RPC providers.

Dynamic adjustment is enacted in the event that any of the following conditions are detected:
 - An invalid fill traces to a missing deposit (no deposit found for the specified depositId).
 - A deposit is known to be filled, without any associated FilledRelay event.

In the first case, this results in narrowing of the block range on both the origin and destination chains. For the latter, only the destination chain is narrowed.