### PR TITLE
fix: Correct zkSync finalizer

### DIFF
--- a/src/finalizer/utils/zkSync.ts
+++ b/src/finalizer/utils/zkSync.ts
@@ -49,6 +49,7 @@ export async function zkSyncFinalizer(
   const withdrawals = candidates.map(({ l2TokenAddress, amountToReturn }) => {
     const l1TokenCounterpart = hubPoolClient.getL1TokenForL2TokenAtBlock(
       l2TokenAddress,
+      l2ChainId,
       hubPoolClient.latestBlockSearched
     );
     const { decimals, symbol: l1TokenSymbol } = hubPoolClient.getTokenInfo(l1ChainId, l1TokenCounterpart);


### PR DESCRIPTION
A recent update to the way Hub -> Spoke tokens are resolved broke the zkSync finalizer. This only shows up now because it's the first time in several weeks.