### PR TITLE
feat(CLI): allow togglable finalizations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,15 @@ NODE_MAX_CONCURRENCY=25
 SEND_RELAYS=false
 
 
+# Permit the finalizer to submit transactions for finalizing cross-chain actions. 
+# This is disabled by default and must be explicitly enabled for the finalizer to
+# submit transactions via the MultiCaller client. When SEND_FINALIZATIONS is not
+# set to "true", the bot will simulate making finalizations and will log the
+# results, but will not submit transactions to the RPC provider. It is recommended
+# to test with this before setting SEND_FINALIZATIONS to "true".
+SEND_FINALIZATIONS=false
+
+
 # List of origin and destination chains to be supported by the relayer. If set
 # to a non-empty list, only transfers complying with the specified origin and
 # destination chains will be filled. For example:

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -30,6 +30,7 @@ export class DataworkerConfig extends CommonConfig {
   readonly sendingDisputesEnabled: boolean;
   readonly sendingProposalsEnabled: boolean;
   readonly sendingExecutionsEnabled: boolean;
+  readonly sendingFinalizationsEnabled: boolean;
 
   // These variables allow the user to optimize dataworker run-time, which can slow down drastically because of all the
   // historical events it needs to fetch and parse.
@@ -49,6 +50,7 @@ export class DataworkerConfig extends CommonConfig {
       SPOKE_ROOTS_LOOKBACK_COUNT,
       SEND_DISPUTES,
       SEND_PROPOSALS,
+      SEND_FINALIZATIONS,
       SEND_EXECUTIONS,
       FINALIZER_ENABLED,
       BUFFER_TO_PROPOSE,
@@ -89,6 +91,7 @@ export class DataworkerConfig extends CommonConfig {
     this.sendingDisputesEnabled = SEND_DISPUTES === "true";
     this.sendingProposalsEnabled = SEND_PROPOSALS === "true";
     this.sendingExecutionsEnabled = SEND_EXECUTIONS === "true";
+    this.sendingFinalizationsEnabled = SEND_FINALIZATIONS === "true";
     this.finalizerEnabled = FINALIZER_ENABLED === "true";
 
     this.forcePropose = FORCE_PROPOSAL === "true";

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -56,6 +56,7 @@ export async function finalize(
   hubPoolClient: HubPoolClient,
   spokePoolClients: SpokePoolClientsByChain,
   configuredChainIds: number[],
+  submitFinalizationTransactions: boolean,
   optimisticRollupFinalizationWindow: number = 5 * oneDaySeconds,
   polygonFinalizationWindow: number = oneDaySeconds
 ): Promise<void> {
@@ -186,7 +187,9 @@ export async function finalize(
         mrkdwn: `Batch finalized ${finalizerTxns.length} txns`,
       };
       multicallerClient.enqueueTransaction(txnToSubmit);
-      [txnHash] = await multicallerClient.executeTransactionQueue();
+      // We want to send the opposite of the `submitFinalizationTransactions` flag because
+      // setting to true will simulate the transaction and not actually submit it.
+      [txnHash] = await multicallerClient.executeTransactionQueue(!submitFinalizationTransactions);
     } catch (_error) {
       const error = _error as Error;
       logger.warn({
@@ -298,7 +301,8 @@ export async function runFinalizer(_logger: winston.Logger, baseSigner: Signer):
           spokePoolClients,
           process.env.FINALIZER_CHAINS
             ? JSON.parse(process.env.FINALIZER_CHAINS)
-            : commonClients.configStoreClient.getChainIdIndicesForBlock()
+            : commonClients.configStoreClient.getChainIdIndicesForBlock(),
+          config.sendingFinalizationsEnabled
         );
       } else {
         logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Finalizer disabled" });


### PR DESCRIPTION
This PR adds a new ENV variable that allows the user to toggle whether to submit finalization transactions to an RPC. When `SEND_FINALIZATIONS` is set to false, our call to execute the multicall queue is done in simulation mode.

**Note: this will require bot config changes.**