### PR TITLE
refactor: Remove redundant type definition

### DIFF
--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -46,7 +46,6 @@ export type Fill = interfaces.Fill;
 export type FillWithBlock = interfaces.FillWithBlock;
 export type SpeedUp = interfaces.SpeedUp;
 export type SlowFillRequestWithBlock = interfaces.SlowFillRequestWithBlock;
-export type SlowFill = interfaces.SlowFill;
 export type SlowFillLeaf = interfaces.SlowFillLeaf;
 export type RootBundleRelay = interfaces.RootBundleRelay;
 export type RootBundleRelayWithBlock = interfaces.RootBundleRelayWithBlock;


### PR DESCRIPTION
This type is not used anywhere in this repository.