### PR TITLE
improve: Use voidSigner in validateRunningBalances script

### DIFF
--- a/src/scripts/validateRootBundle.ts
+++ b/src/scripts/validateRootBundle.ts
@@ -202,8 +202,8 @@ export async function validate(_logger: winston.Logger, baseSigner: Signer): Pro
 
 export async function run(_logger: winston.Logger): Promise<void> {
   try {
-    // This script inherits the TokenClient, and it attempts to update token approvals.
-    // The disputer bot already has the necessary token approvals in place, so use its address.
+    // This script inherits the TokenClient, and it attempts to update token approvals. The disputer already has the
+    // necessary token approvals in place, so use its address. nb. This implies the script can only be used on mainnet.
     const voidSigner = "0xf7bAc63fc7CEaCf0589F25454Ecf5C2ce904997c";
     const baseSigner = await getSigner({ keyType: "void", cleanEnv: true, roAddress: voidSigner });
     await validate(_logger, baseSigner);

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -37,6 +37,7 @@ import {
   getRefund,
   disconnectRedisClients,
   Signer,
+  getSigner,
 } from "../utils";
 import { createDataworker } from "../dataworker";
 import { getWidestPossibleExpectedBlockRange } from "../dataworker/PoolRebalanceUtils";
@@ -44,7 +45,6 @@ import { getBlockForChain, getEndBlockBuffers } from "../dataworker/DataworkerUt
 import { ProposedRootBundle, SlowFillLeaf, SpokePoolClientsByChain } from "../interfaces";
 import { CONTRACT_ADDRESSES, constructSpokePoolClientsWithStartBlocks, updateSpokePoolClients } from "../common";
 import { createConsoleTransport } from "@uma/financial-templates-lib";
-import { retrieveSignerFromCLIArgs } from "../utils/CLIUtils";
 
 config();
 let logger: winston.Logger;
@@ -486,7 +486,10 @@ export async function runScript(_logger: winston.Logger, baseSigner: Signer): Pr
 
 export async function run(_logger: winston.Logger): Promise<void> {
   try {
-    const baseSigner = await retrieveSignerFromCLIArgs();
+    // This script inherits the TokenClient, and it attempts to update token approvals.
+    // The disputer bot already has the necessary token approvals in place, so use its address.
+    const voidSigner = "0xf7bAc63fc7CEaCf0589F25454Ecf5C2ce904997c";
+    const baseSigner = await getSigner({ keyType: "void", cleanEnv: true, roAddress: voidSigner });
     await runScript(_logger, baseSigner);
   } finally {
     await disconnectRedisClients(logger);

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -500,8 +500,8 @@ export async function runScript(_logger: winston.Logger, baseSigner: Signer): Pr
 
 export async function run(_logger: winston.Logger): Promise<void> {
   try {
-    // This script inherits the TokenClient, and it attempts to update token approvals.
-    // The disputer bot already has the necessary token approvals in place, so use its address.
+    // This script inherits the TokenClient, and it attempts to update token approvals. The disputer already has the
+    // necessary token approvals in place, so use its address. nb. This implies the script can only be used on mainnet.
     const voidSigner = "0xf7bAc63fc7CEaCf0589F25454Ecf5C2ce904997c";
     const baseSigner = await getSigner({ keyType: "void", cleanEnv: true, roAddress: voidSigner });
     await runScript(_logger, baseSigner);


### PR DESCRIPTION
Token approvals are incidentally needed via the TokenClient, but since the proposer/disputer address already has those in place it's possible to use a voidSigner with that address.

This is the same pattern as used in the validateRootBundle script.