### PR TITLE
refactor: Remove relayerFeePct ordering in relayer

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -239,25 +239,15 @@ export class Relayer {
       minDepositConfirmations: config.minDepositConfirmations,
     });
 
-    // Filter out deposits whose block time does not meet the minimum number of confirmations for the
-    // corresponding origin chain. Finally, sort the deposits by the total earnable fee for the relayer.
-    const confirmedUnfilledDeposits = unfilledDeposits
-      .filter(
-        ({ deposit: { originChainId, blockNumber } }) =>
-          blockNumber <= spokePoolClients[originChainId].latestBlockSearched - mdcPerChain[originChainId]
-      )
-      .sort((a, b) =>
-        a.unfilledAmount.mul(a.deposit.relayerFeePct).lt(b.unfilledAmount.mul(b.deposit.relayerFeePct)) ? 1 : -1
-      );
-    if (confirmedUnfilledDeposits.length > 0) {
-      this.logger.debug({
-        at: "Relayer",
-        message: "Unfilled deposits found",
-        number: confirmedUnfilledDeposits.length,
-      });
-    } else {
-      this.logger.debug({ at: "Relayer", message: "No unfilled deposits" });
-    }
+    // Filter out deposits whose block time does not meet the minimum number of confirmations for the origin chain.
+    const confirmedUnfilledDeposits = unfilledDeposits.filter(
+      ({ deposit: { originChainId, blockNumber } }) =>
+        blockNumber <= spokePoolClients[originChainId].latestBlockSearched - mdcPerChain[originChainId]
+    );
+    this.logger.debug({
+      at: "Relayer::checkForUnfilledDepositsAndFill",
+      message: `${confirmedUnfilledDeposits.length} unfilled deposits found`,
+    });
 
     // Iterate over all unfilled deposits. For each unfilled deposit: a) check that the token balance client has enough
     // balance to fill the unfilled amount. b) the fill is profitable. If both hold true then fill the unfilled amount.

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -192,7 +192,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     await Promise.all([spokePoolClient_1.update(), spokePoolClient_2.update(), hubPoolClient.update()]);
     await relayerInstance.checkForUnfilledDepositsAndFill();
     expect(multiCallerClient.transactionCount()).to.equal(0); // no Transactions to send.
-    expect(lastSpyLogIncludes(spy, "No unfilled deposits")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "0 unfilled deposits")).to.be.true;
   });
 
   it("Correctly validates self-relays", async function () {
@@ -236,7 +236,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
 
     await updateAllClients();
     await relayerInstance.checkForUnfilledDepositsAndFill();
-    expect(lastSpyLogIncludes(spy, "No unfilled deposits")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "0 unfilled deposits")).to.be.true;
   });
 
   it("Ignores deposits with quote times in future", async function () {
@@ -246,7 +246,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     await updateAllClients();
     hubPoolClient.currentTime = quoteTimestamp - 1;
     await relayerInstance.checkForUnfilledDepositsAndFill();
-    expect(lastSpyLogIncludes(spy, "No unfilled deposits")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "0 unfilled deposits")).to.be.true;
 
     // If we reset the timestamp, the relayer will fill the deposit:
     hubPoolClient.currentTime = quoteTimestamp;
@@ -414,7 +414,7 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
     await Promise.all([spokePoolClient_1.update(), spokePoolClient_2.update(), hubPoolClient.update()]);
     await relayerInstance.checkForUnfilledDepositsAndFill();
     expect(multiCallerClient.transactionCount()).to.equal(0); // no Transactions to send.
-    expect(lastSpyLogIncludes(spy, "No unfilled deposits")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "0 unfilled deposits")).to.be.true;
   });
 
   it("Selects the correct message in an updated deposit", async function () {

--- a/test/Relayer.TokenShortfall.ts
+++ b/test/Relayer.TokenShortfall.ts
@@ -166,14 +166,14 @@ describe("Relayer: Token balance shortfall", async function () {
     expect(lastSpyLogIncludes(spy, "Insufficient balance to fill all deposits")).to.be.true;
     expect(lastSpyLogIncludes(spy, "Shortfall on Hardhat2:")).to.be.true;
     expect(lastSpyLogIncludes(spy, `${await l1Token.symbol()} cumulative shortfall of 150.00`)).to.be.true;
-    expect(lastSpyLogIncludes(spy, "blocking deposits: 1,0")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "blocking deposits: 0,1")).to.be.true;
 
     // Submitting another relay should increment the shortfall and log accordingly. Total shortfall of 250 now.
     await depositV2(spokePool_1, erc20_1, depositor, depositor, destinationChainId);
     await updateAllClients();
     await relayerInstance.checkForUnfilledDepositsAndFill();
     expect(lastSpyLogIncludes(spy, `${await l1Token.symbol()} cumulative shortfall of 250.00`)).to.be.true;
-    expect(lastSpyLogIncludes(spy, "blocking deposits: 2,1,0")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "blocking deposits: 0,1,2")).to.be.true;
 
     // Mint more tokens to the relayer to fill the shortfall. Mint enough to just cover the most recent relay. The
     // Other relays should not be filled.
@@ -181,7 +181,7 @@ describe("Relayer: Token balance shortfall", async function () {
     await updateAllClients();
     await relayerInstance.checkForUnfilledDepositsAndFill();
     expect(lastSpyLogIncludes(spy, `${await l1Token.symbol()} cumulative shortfall of 190.00`)).to.be.true;
-    expect(lastSpyLogIncludes(spy, "blocking deposits: 1,0")).to.be.true;
+    expect(lastSpyLogIncludes(spy, "blocking deposits: 1,2")).to.be.true;
 
     const tx = await multiCallerClient.executeTransactionQueue();
     expect(lastSpyLogIncludes(spy, "Relayed depositId 2")).to.be.true;


### PR DESCRIPTION
The comment attached to this ordering says that it's done to prioritise the most profitable deposits first. This is only a very coarse way of sorting because it ignores the amount being bridged. In practice it will probably tend to prioritise low-value transactions (which indirectly _may_ be the most profitable due to gas padding).

Sorting this early isn't compatible with v3 deposits because their profitability is determined later in the relayer run. In any case, ordering deposits by profitability doesn't seem to have much benefit in practice because it should only take effect at the absolute margins where the relayer can fill each deposit individually, but not the sum of them. So...remove it for now.