### PR TITLE
feat(proposer): store bundle to arweave

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -255,7 +255,7 @@ ARWEAVE_WALLET_JWK=$({"kty":"", "e":"", "n":"", "d":"", "p":"", "q":"", "dp":"",
 # The Arweave gateway to use for storing bundle data. This is used to connect to the
 # Arweave network and store bundle data. The default gateway is the official Arweave
 # gateway. This can be changed to a custom gateway if desired.
-ARWEAVE_GATEWAY=$({"host":"", "port": 443, "protocol":"https"})
+ARWEAVE_GATEWAY=$({"url":"", "port": 443, "protocol":"https"})
 
 ################################################################################
 ########################### Testing Configuration ##############################

--- a/.env.example
+++ b/.env.example
@@ -248,6 +248,15 @@ RELAYER_TOKENS='["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "0xA0b86991c6218b
 #  },
 #}'
 
+# This wallet JWK is used to sign transactions intended for permenant storage of bundle
+# data on Arweave. Ensure that the wallet has enough AR to cover the cost of storage.
+ARWEAVE_WALLET_JWK=$({"kty":"", "e":"", "n":"", "d":"", "p":"", "q":"", "dp":"", "dq":"", "qi":""})
+
+# The Arweave gateway to use for storing bundle data. This is used to connect to the
+# Arweave network and store bundle data. The default gateway is the official Arweave
+# gateway. This can be changed to a custom gateway if desired.
+ARWEAVE_GATEWAY=$({"host":"", "port": 443, "protocol":"https"})
+
 ################################################################################
 ########################### Testing Configuration ##############################
 ################################################################################

--- a/.env.example
+++ b/.env.example
@@ -248,6 +248,13 @@ RELAYER_TOKENS='["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "0xA0b86991c6218b
 #  },
 #}'
 
+# The dataworker can be configured to store tertiary bundle data on Arweave 
+# for debugging and auditing purposes. This is disabled by default and must be
+# explicitly enabled for the dataworker to store bundle data on Arweave. When
+# PERSIST_BUNDLES_TO_ARWEAVE is set to "true", the variables ARWEAVE_WALLET_JWK
+# and ARWEAVE_GATEWAY must be set to valid values.
+PERSIST_BUNDLES_TO_ARWEAVE=false
+
 # This wallet JWK is used to sign transactions intended for permenant storage of bundle
 # data on Arweave. Ensure that the wallet has enough AR to cover the cost of storage.
 ARWEAVE_WALLET_JWK=$({"kty":"", "e":"", "n":"", "d":"", "p":"", "q":"", "dp":"", "dq":"", "qi":""})

--- a/.env.example
+++ b/.env.example
@@ -251,9 +251,9 @@ RELAYER_TOKENS='["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", "0xA0b86991c6218b
 # The dataworker can be configured to store tertiary bundle data on Arweave 
 # for debugging and auditing purposes. This is disabled by default and must be
 # explicitly enabled for the dataworker to store bundle data on Arweave. When
-# PERSIST_BUNDLES_TO_ARWEAVE is set to "true", the variables ARWEAVE_WALLET_JWK
+# PERSIST_DATA_TO_ARWEAVE is set to "true", the variables ARWEAVE_WALLET_JWK
 # and ARWEAVE_GATEWAY must be set to valid values.
-PERSIST_BUNDLES_TO_ARWEAVE=false
+PERSIST_DATA_TO_ARWEAVE=false
 
 # This wallet JWK is used to sign transactions intended for permenant storage of bundle
 # data on Arweave. Ensure that the wallet has enough AR to cover the cost of storage.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.8",
     "@across-protocol/contracts-v2": "2.5.0-beta.5",
-    "@across-protocol/sdk-v2": "0.21.1",
+    "@across-protocol/sdk-v2": "0.21.2",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.8",
     "@across-protocol/contracts-v2": "2.5.0-beta.5",
-    "@across-protocol/sdk-v2": "0.21.2",
+    "@across-protocol/sdk-v2": "0.21.4",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lodash.get": "^4.4.2",
     "minimist": "^1.2.8",
     "redis4": "npm:redis@^4.1.0",
+    "superstruct": "^1.0.3",
     "ts-node": "^10.9.1",
     "winston": "^3.10.0",
     "zksync-web3": "^0.14.3"

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -503,6 +503,20 @@ export class Dataworker {
       unexecutableSlowFills,
       expiredDepositsToRefundV3,
     } = await this.clients.bundleDataClient.loadData(blockRangesForProposal, spokePoolClients, logData);
+
+    const arweaveBundleStorageHash = await this.clients.arweaveClient.set(
+      {
+        bundleStorageVersion: "1",
+        bundleBlockRanges: blockRangesForProposal,
+        bundleDepositsV3,
+        expiredDepositsToRefundV3,
+        bundleFillsV3,
+        unexecutableSlowFills,
+        bundleSlowFillsV3,
+      },
+      "bundle"
+    );
+
     const allValidFillsInRange = getFillsInRange(
       allValidFills,
       blockRangesForProposal,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -492,7 +492,7 @@ export class Dataworker {
         rootBundleData.slowFillTree.getHexRoot()
       );
     }
-    return rootBundleData.dataToPersistToDALayer;
+    return submitProposals ? rootBundleData.dataToPersistToDALayer : undefined;
   }
 
   async _proposeRootBundle(

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -492,7 +492,7 @@ export class Dataworker {
         rootBundleData.slowFillTree.getHexRoot()
       );
     }
-    return submitProposals ? rootBundleData.dataToPersistToDALayer : undefined;
+    return rootBundleData.dataToPersistToDALayer;
   }
 
   async _proposeRootBundle(

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -71,7 +71,7 @@ type RootBundle = {
   tree: MerkleTree<SlowFillLeaf>;
 };
 
-type DataToPersistToDALayerType = {
+export type BundleDataToPersistToDALayerType = {
   bundleBlockRanges: number[][];
   bundleDepositsV3: BundleDepositsV3;
   expiredDepositsToRefundV3: ExpiredDepositsToRefundV3;
@@ -87,7 +87,7 @@ type ProposeRootBundleReturnType = {
   relayerRefundTree: MerkleTree<RelayerRefundLeaf>;
   slowFillLeaves: SlowFillLeaf[];
   slowFillTree: MerkleTree<SlowFillLeaf>;
-  dataToPersistToDALayer: DataToPersistToDALayerType;
+  dataToPersistToDALayer: BundleDataToPersistToDALayerType;
 };
 
 export type PoolRebalanceRoot = {
@@ -380,7 +380,7 @@ export class Dataworker {
     usdThresholdToSubmitNewBundle?: BigNumber,
     submitProposals = true,
     earliestBlocksInSpokePoolClients: { [chainId: number]: number } = {}
-  ): Promise<DataToPersistToDALayerType> {
+  ): Promise<BundleDataToPersistToDALayerType> {
     // TODO: Handle the case where we can't get event data or even blockchain data from any chain. This will require
     // some changes to override the bundle block range here, and loadData to skip chains with zero block ranges.
     // For now, we assume that if one blockchain fails to return data, then this entire function will fail. This is a

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -59,9 +59,9 @@ export async function constructDataworkerClients(
   const arweaveClient = new caching.ArweaveClient(
     config.arweaveWalletJWK,
     logger,
-    config.arweaveGateway.url,
-    config.arweaveGateway.protocol,
-    config.arweaveGateway.port
+    config.arweaveGateway?.url,
+    config.arweaveGateway?.protocol,
+    config.arweaveGateway?.port
   );
 
   return {

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -12,10 +12,12 @@ import { BundleDataClient, HubPoolClient, TokenClient } from "../clients";
 import { getBlockForChain } from "./DataworkerUtils";
 import { Dataworker } from "./Dataworker";
 import { ProposedRootBundle, SpokePoolClientsByChain } from "../interfaces";
+import { caching } from "@across-protocol/sdk-v2";
 
 export interface DataworkerClients extends Clients {
   tokenClient: TokenClient;
   bundleDataClient: BundleDataClient;
+  arweaveClient: caching.ArweaveClient;
   priceClient?: PriceClient;
 }
 
@@ -53,11 +55,21 @@ export async function constructDataworkerClients(
     new defiLlama.PriceFeed(),
   ]);
 
+  // Define the Arweave client.
+  const arweaveClient = new caching.ArweaveClient(
+    config.arweaveWalletJWK,
+    logger,
+    config.arweaveGateway.url,
+    config.arweaveGateway.protocol,
+    config.arweaveGateway.port
+  );
+
   return {
     ...commonClients,
     bundleDataClient,
     tokenClient,
     priceClient,
+    arweaveClient,
   };
 }
 

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -38,8 +38,8 @@ export class DataworkerConfig extends CommonConfig {
   readonly sendingExecutionsEnabled: boolean;
   readonly sendingFinalizationsEnabled: boolean;
 
-  // This variable should be set if the user wants to persist data to Arweave.
-  readonly persistingDataEnabled: boolean;
+  // This variable should be set if the user wants to persist bundle data to Arweave.
+  readonly persistingBundleData: boolean;
 
   // These variables allow the user to optimize dataworker run-time, which can slow down drastically because of all the
   // historical events it needs to fetch and parse.
@@ -70,7 +70,7 @@ export class DataworkerConfig extends CommonConfig {
       DATAWORKER_FAST_START_BUNDLE,
       FORCE_PROPOSAL,
       FORCE_PROPOSAL_BUNDLE_RANGE,
-      PERSIST_DATA_TO_ARWEAVE,
+      PERSIST_BUNDLES_TO_ARWEAVE,
       ARWEAVE_WALLET_JWK,
       ARWEAVE_GATEWAY,
     } = env;
@@ -166,8 +166,10 @@ export class DataworkerConfig extends CommonConfig {
       );
     }
 
-    this.persistingDataEnabled = PERSIST_DATA_TO_ARWEAVE === "true";
-    if (this.persistingDataEnabled) {
+    this.persistingBundleData = PERSIST_BUNDLES_TO_ARWEAVE === "true";
+    assert(!this.persistingBundleData || this.proposerEnabled, "Cannot persist bundle data if proposer is disabled");
+
+    if (this.persistingBundleData) {
       // Load the Arweave wallet JWK from the environment.
       const _arweaveWalletJWK = JSON.parse(ARWEAVE_WALLET_JWK ?? "{}");
       assert(ArweaveWalletJWKInterfaceSS.is(_arweaveWalletJWK), "Invalid Arweave wallet JWK");

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -39,7 +39,6 @@ export class DataworkerConfig extends CommonConfig {
   readonly sendingFinalizationsEnabled: boolean;
 
   // This variable should be set if the user wants to persist bundles to Arweave.
-  // Note: sendingProposalsEnabled must be true for this to work.
   readonly persistingBundlesEnabled: boolean;
 
   // These variables allow the user to optimize dataworker run-time, which can slow down drastically because of all the
@@ -168,11 +167,6 @@ export class DataworkerConfig extends CommonConfig {
     }
 
     this.persistingBundlesEnabled = PERSIST_BUNDLES_TO_ARWEAVE === "true";
-    assert(
-      !this.persistingBundlesEnabled || this.sendingProposalsEnabled,
-      "persistingBundlesEnabled requires sendingProposalsEnabled"
-    );
-
     if (this.persistingBundlesEnabled) {
       // Load the Arweave wallet JWK from the environment.
       const _arweaveWalletJWK = JSON.parse(ARWEAVE_WALLET_JWK ?? "{}");

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -38,8 +38,8 @@ export class DataworkerConfig extends CommonConfig {
   readonly sendingExecutionsEnabled: boolean;
   readonly sendingFinalizationsEnabled: boolean;
 
-  // This variable should be set if the user wants to persist bundles to Arweave.
-  readonly persistingBundlesEnabled: boolean;
+  // This variable should be set if the user wants to persist data to Arweave.
+  readonly persistingDataEnabled: boolean;
 
   // These variables allow the user to optimize dataworker run-time, which can slow down drastically because of all the
   // historical events it needs to fetch and parse.
@@ -70,7 +70,7 @@ export class DataworkerConfig extends CommonConfig {
       DATAWORKER_FAST_START_BUNDLE,
       FORCE_PROPOSAL,
       FORCE_PROPOSAL_BUNDLE_RANGE,
-      PERSIST_BUNDLES_TO_ARWEAVE,
+      PERSIST_DATA_TO_ARWEAVE,
       ARWEAVE_WALLET_JWK,
       ARWEAVE_GATEWAY,
     } = env;
@@ -166,8 +166,8 @@ export class DataworkerConfig extends CommonConfig {
       );
     }
 
-    this.persistingBundlesEnabled = PERSIST_BUNDLES_TO_ARWEAVE === "true";
-    if (this.persistingBundlesEnabled) {
+    this.persistingDataEnabled = PERSIST_DATA_TO_ARWEAVE === "true";
+    if (this.persistingDataEnabled) {
       // Load the Arweave wallet JWK from the environment.
       const _arweaveWalletJWK = JSON.parse(ARWEAVE_WALLET_JWK ?? "{}");
       assert(ArweaveWalletJWKInterfaceSS.is(_arweaveWalletJWK), "Invalid Arweave wallet JWK");

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -1,4 +1,10 @@
 import { CommonConfig, ProcessEnv } from "../common";
+import {
+  ArweaveGatewayInterface,
+  ArweaveGatewayInterfaceSS,
+  ArweaveWalletJWKInterface,
+  ArweaveWalletJWKInterfaceSS,
+} from "../interfaces";
 import { BigNumber, assert, toBNWei } from "../utils";
 
 export class DataworkerConfig extends CommonConfig {
@@ -39,6 +45,9 @@ export class DataworkerConfig extends CommonConfig {
 
   readonly bufferToPropose: number;
 
+  readonly arweaveWalletJWK: ArweaveWalletJWKInterface;
+  readonly arweaveGateway: ArweaveGatewayInterface;
+
   constructor(env: ProcessEnv) {
     const {
       ROOT_BUNDLE_EXECUTION_THRESHOLD,
@@ -58,6 +67,8 @@ export class DataworkerConfig extends CommonConfig {
       DATAWORKER_FAST_START_BUNDLE,
       FORCE_PROPOSAL,
       FORCE_PROPOSAL_BUNDLE_RANGE,
+      ARWEAVE_WALLET_JWK,
+      ARWEAVE_GATEWAY,
     } = env;
     super(env);
 
@@ -150,5 +161,13 @@ export class DataworkerConfig extends CommonConfig {
         `dataworkerFastStartBundle=${this.dataworkerFastStartBundle} should be >= dataworkerFastLookbackCount=${this.dataworkerFastLookbackCount}`
       );
     }
+    // Load the Arweave wallet JWK from the environment.
+    const _arweaveWalletJWK = JSON.parse(ARWEAVE_WALLET_JWK);
+    assert(ArweaveWalletJWKInterfaceSS.is(_arweaveWalletJWK), "Invalid Arweave wallet JWK");
+    this.arweaveWalletJWK = _arweaveWalletJWK;
+    // Load the Arweave gateway from the environment.
+    const _arweaveGateway = JSON.parse(ARWEAVE_GATEWAY);
+    assert(ArweaveGatewayInterfaceSS.is(_arweaveGateway), "Invalid Arweave gateway");
+    this.arweaveGateway = _arweaveGateway;
   }
 }

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { utils, typechain, interfaces } from "@across-protocol/sdk-v2";
+import { utils, typechain, interfaces, caching } from "@across-protocol/sdk-v2";
 import { SpokePoolClient } from "../clients";
 import { spokesThatHoldEthAndWeth } from "../common/Constants";
 import { CONTRACT_ADDRESSES } from "../common/ContractAddresses";
@@ -60,6 +60,7 @@ import {
   BundleSlowFills,
   ExpiredDepositsToRefundV3,
 } from "../interfaces/BundleData";
+import { any } from "superstruct";
 export const { getImpliedBundleBlockRanges, getBlockRangeForChain, getBlockForChain } = utils;
 
 export function getEndBlockBuffers(
@@ -706,4 +707,40 @@ export function l2TokensToCountTowardsSpokePoolLeafExecutionCapital(
   // If we get to here, ETH and WETH addresses should be defined, or we'll throw an error.
   const ethAndWeth = getWethAndEth(l2ChainId);
   return ethAndWeth.includes(l2TokenAddress) ? ethAndWeth : [l2TokenAddress];
+}
+
+/**
+ * Persists data to Arweave with a given tag, given that the data doesn't
+ * already exist on Arweave with the tag.
+ * @param client The Arweave client to use for persistence.
+ * @param data The data to persist to Arweave.
+ * @param logger A winston logger
+ * @param tag The tag to use for the data.
+ */
+export async function persistDataToArweave(
+  client: caching.ArweaveClient,
+  data: Record<string, unknown>,
+  logger: winston.Logger,
+  tag?: string
+): Promise<void> {
+  // Check if data already exists on Arweave with the given tag.
+  // If so, we don't need to persist it again.
+  const matchingTxns = await client.getByTopic(tag, any());
+  if (matchingTxns.length > 0) {
+    logger.info({
+      at: "Dataworker#index",
+      message: `Data already exists on Arweave with tag: ${tag}`,
+      hash: matchingTxns.map((txn) => txn.hash),
+    });
+  } else {
+    const hashTxn = await client.set(data, tag);
+    const [address, balance] = await Promise.all([client.getAddress(), client.getBalance()]);
+    logger.info({
+      at: "Dataworker#index",
+      message: `Persisted data to Arweave with transaction hash: ${hashTxn}`,
+      hash: hashTxn,
+      address,
+      balance,
+    });
+  }
 }

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -122,7 +122,11 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
           config.sendingProposalsEnabled,
           fromBlocks
         );
-        if (isDefined(persistedProposerData) && Object.keys(persistedProposerData).length > 0) {
+        if (
+          config.sendingProposalsEnabled &&
+          isDefined(persistedProposerData) &&
+          Object.keys(persistedProposerData).length > 0
+        ) {
           dataToPersist = { ...(dataToPersist ?? {}), proposer: persistedProposerData };
         }
       } else {

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -122,7 +122,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
           config.sendingProposalsEnabled,
           fromBlocks
         );
-        if (persistedProposerData && Object.keys(persistedProposerData).length > 0) {
+        if (isDefined(persistedProposerData) && Object.keys(persistedProposerData).length > 0) {
           dataToPersist = { ...(dataToPersist ?? {}), proposer: persistedProposerData };
         }
       } else {
@@ -163,7 +163,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         const hashTxn = await clients.arweaveClient.set(dataToPersist, "proposal");
         logger.info({
           at: "Dataworker#index",
-          message: `Persisted proposal data to Arweave with transaction hash: ${hashTxn}`,
+          message: `Persisted data to Arweave with transaction hash: ${hashTxn}`,
           hash: hashTxn,
           address: await clients.arweaveClient.getAddress(),
           balance: await clients.arweaveClient.getBalance(),

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -146,10 +146,7 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
         logger[startupLogLevel(config)]({ at: "Dataworker#index", message: "Executor disabled" });
       }
 
-      await clients.multiCallerClient.executeTransactionQueue();
-
-      // If we have data and persisting is enabled, post it to Arweave.
-      if (config.persistingDataEnabled && Object.keys(dataToPersist).length > 0) {
+      if (config.persistingDataEnabled) {
         const hashTxn = await clients.arweaveClient.set(dataToPersist, "proposal");
         logger.info({
           at: "Dataworker#index",
@@ -159,6 +156,8 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
           balance: await clients.arweaveClient.getBalance(),
         });
       }
+
+      await clients.multiCallerClient.executeTransactionQueue();
 
       logger.debug({
         at: "Dataworker#index",

--- a/src/interfaces/Arweave.ts
+++ b/src/interfaces/Arweave.ts
@@ -1,0 +1,37 @@
+import { number, object, optional, string } from "superstruct";
+
+export type ArweaveWalletJWKInterface = {
+  kty: string;
+  e: string;
+  n: string;
+  d?: string;
+  p?: string;
+  q?: string;
+  dp?: string;
+  dq?: string;
+  qi?: string;
+};
+
+export type ArweaveGatewayInterface = {
+  url: string;
+  protocol: string;
+  port: number;
+};
+
+export const ArweaveWalletJWKInterfaceSS = object({
+  kty: string(),
+  e: string(),
+  n: string(),
+  d: optional(string()),
+  p: optional(string()),
+  q: optional(string()),
+  dp: optional(string()),
+  dq: optional(string()),
+  qi: optional(string()),
+});
+
+export const ArweaveGatewayInterfaceSS = object({
+  url: string(),
+  protocol: string(),
+  port: number(),
+});

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,6 +5,7 @@ export * from "./SpokePool";
 export * from "./Token";
 export * from "./Error";
 export * from "./Report";
+export * from "./Arweave";
 
 // Bridge interfaces
 export type OutstandingTransfers = interfaces.OutstandingTransfers;

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.21.1":
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.21.1.tgz#b3cbac5132cd669caadd0cc6f66edc04cd24791b"
-  integrity sha512-lVVHSs36eEO1HnvBShRH5sFElrrb6M2HybCZwd4b8qohIWUajXqfQEjzZPKBJXyW0n8XPpDcBCcJtoG3ZYd/3A==
+"@across-protocol/sdk-v2@0.21.2":
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.21.2.tgz#48ff7d9f4c43df4a188a1ee9617d2c0339111ca9"
+  integrity sha512-FWthY8pSOj6t8XByKh72v8CUeZMDBuuX+wvykb4DHyEQBccQuaPlpu2rgjARkUGCI+X5yL7XlwSgaR0UnE2DqQ==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.11"
@@ -62,6 +62,7 @@
     "@pinata/sdk" "^2.1.0"
     "@types/mocha" "^10.0.1"
     "@uma/sdk" "^0.34.1"
+    arweave "^1.14.4"
     axios "^0.27.2"
     big-number "^2.0.0"
     decimal.js "^10.3.1"
@@ -3698,6 +3699,13 @@ archy@~1.0.0:
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
+arconnect@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/arconnect/-/arconnect-0.4.2.tgz#83de7638fb46183e82d7ec7efb5594c5f7cdc806"
+  integrity sha512-Jkpd4QL3TVqnd3U683gzXmZUVqBUy17DdJDuL/3D9rkysLgX6ymJ2e+sR+xyZF5Rh42CBqDXWNMmCjBXeP7Gbw==
+  dependencies:
+    arweave "^1.10.13"
+
 are-we-there-yet@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz#372e0e7bd279d8e94c653aaa1f67200884bf3e1c"
@@ -3805,12 +3813,22 @@ arrify@^2.0.0, arrify@^2.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
 
+arweave@^1.10.13, arweave@^1.14.4:
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/arweave/-/arweave-1.14.4.tgz#5ba22136aa0e7fd9495258a3931fb770c9d6bf21"
+  integrity sha512-tmqU9fug8XAmFETYwgUhLaD3WKav5DaM4p1vgJpEj/Px2ORPPMikwnSySlFymmL2qgRh2ZBcZsg11+RXPPGLsA==
+  dependencies:
+    arconnect "^0.4.2"
+    asn1.js "^5.4.1"
+    base64-js "^1.5.1"
+    bignumber.js "^9.0.2"
+
 asap@^2.0.0, asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
-asn1.js@^5.0.1, asn1.js@^5.2.0:
+asn1.js@^5.0.1, asn1.js@^5.2.0, asn1.js@^5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
   integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
@@ -4004,7 +4022,7 @@ base-x@^3.0.2, base-x@^3.0.8:
   dependencies:
     safe-buffer "^5.0.1"
 
-base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.3.0, base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -4072,6 +4090,11 @@ bignumber.js@^8.0.1:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
   integrity sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==
+
+bignumber.js@^9.0.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
+  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
 
 bin-links@^2.2.1:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.21.2":
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.21.2.tgz#48ff7d9f4c43df4a188a1ee9617d2c0339111ca9"
-  integrity sha512-FWthY8pSOj6t8XByKh72v8CUeZMDBuuX+wvykb4DHyEQBccQuaPlpu2rgjARkUGCI+X5yL7XlwSgaR0UnE2DqQ==
+"@across-protocol/sdk-v2@0.21.4":
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.21.4.tgz#d108bd7ed5a305a7ecee8b54be20f528ca9118db"
+  integrity sha512-FPoR+FZtpo99rKJpxsf3S3ZPZs8txF/4TYivFcVmYwJ7BAzcJzy0nlziAHigs5asG1Fle14EGxFZhyB52YW6aw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,7 +53,7 @@
 "@across-protocol/sdk-v2@0.22.0":
   version "0.22.0"
   resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.0.tgz#71ac068a2d397ed0201d7f1427c70746e570c5a0"
-  integrity sha512-pQESKjDzNghpKYrvC1SnBX4FX5f4TW4hE9gwehqt4ag4a8bc4YWT3wIr49akHoD8sCJdgDf9u7CoyqEL4OHLLw=
+  integrity sha512-pQESKjDzNghpKYrvC1SnBX4FX5f4TW4hE9gwehqt4ag4a8bc4YWT3wIr49akHoD8sCJdgDf9u7CoyqEL4OHLLw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.11"


### PR DESCRIPTION
This PR adds a persisted state to Arweave based on configurations in the data worker.

Three new environment variables have been added to the dataworker, these include:
1. PERSIST_BUNDLES_TO_ARWEAVE
2. ARWEAVE_WALLET_JWK
3. ARWEAVE_GATEWAY

New JWK wallets can be generated with the following snippet:
```
node -e "require('arweave').init({}).wallets.generate().then(JSON.stringify).then(console.log.bind(console))" > wallet.json
```

For testing, it is recommended to set
```
ARWEAVE_GATEWAY='{ "url": "localhost", "port": 1984, "protocol": "http" }'
```
and use `npx arlocal` to simulate an arweave-like server.

The wallet generated can be funded for use with `arlocal` via the following GET calls:
```
curl http://localhost:1984/mint/{arweave address}/{amountToMint}
curl http://localhost:1984/mine
```