### PR TITLE
fix: Early exit when searching for unexecutable V2 slow fills

### DIFF
--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -152,7 +152,7 @@ export async function getFillDataForSlowFillFromPreviousRootBundle(
 
   // Find the first fill chronologically for matched deposit for the input fill.
   const allMatchingFills = sortEventsAscending(
-    allValidFills.filter((_fill) => sdkUtils.filledSameDeposit(_fill, fill) && versionFilter(fill, _fill))
+    allValidFills.filter((_fill) => _fill.depositId === fill.depositId && sdkUtils.filledSameDeposit(_fill, fill) && versionFilter(fill, _fill))
   );
   let firstFillForSameDeposit = allMatchingFills.find((_fill) => isFirstFillForDeposit(_fill));
 

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -152,7 +152,10 @@ export async function getFillDataForSlowFillFromPreviousRootBundle(
 
   // Find the first fill chronologically for matched deposit for the input fill.
   const allMatchingFills = sortEventsAscending(
-    allValidFills.filter((_fill) => _fill.depositId === fill.depositId && sdkUtils.filledSameDeposit(_fill, fill) && versionFilter(fill, _fill))
+    allValidFills.filter(
+      (_fill) =>
+        _fill.depositId === fill.depositId && sdkUtils.filledSameDeposit(_fill, fill) && versionFilter(fill, _fill)
+    )
   );
   let firstFillForSameDeposit = allMatchingFills.find((_fill) => isFirstFillForDeposit(_fill));
 


### PR DESCRIPTION
This linear search is extremely slow if there are a lot of partial fills (i.e. we created 400+ slow fills in a recent bundle) in a bundle that we have to evaluate as a possible unexecutable slow fill that was replaced by a fast fill.

With this many slow fills, it was taking 50 seconds to find the first partial fill for each slow fill, which would effectively make this function never able to complete with 400+ slow fills.

Early exiting means each search goes down to 5 ms, a massive speedup
