### PR TITLE
improve(FillUtils): Optimise block range lookups

### DIFF
--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -227,13 +227,15 @@ export function getFillsInRange(
   blockRangesForChains: number[][],
   chainIdListForBundleEvaluationBlockNumbers: number[]
 ): FillWithBlock[] {
+  const blockRanges = Object.fromEntries(
+    chainIdListForBundleEvaluationBlockNumbers.map((chainId) => [
+      chainId,
+      getBlockRangeForChain(blockRangesForChains, chainId, chainIdListForBundleEvaluationBlockNumbers),
+    ])
+  );
   return fills.filter((fill) => {
-    const blockRangeForChain = getBlockRangeForChain(
-      blockRangesForChains,
-      fill.destinationChainId,
-      chainIdListForBundleEvaluationBlockNumbers
-    );
-    return fill.blockNumber <= blockRangeForChain[1] && fill.blockNumber >= blockRangeForChain[0];
+    const [startBlock, endBlock] = blockRanges[fill.destinationChainId];
+    return fill.blockNumber >= startBlock && fill.blockNumber <= endBlock;
   });
 }
 


### PR DESCRIPTION
Rather than resolving the target block range once per fill, just the target block range for each destination chain and look it up on demand. This makes sense as long as there are more fills than the number of chains supported.