### PR TITLE
[WIP] feat: Update LP fee computation

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.8",
     "@across-protocol/contracts-v2": "2.5.0-beta.5",
-    "@across-protocol/sdk-v2": "0.21.1",
+    "@across-protocol/sdk-v2": "0.22.0",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.1.0",

--- a/src/clients/HubPoolClient.ts
+++ b/src/clients/HubPoolClient.ts
@@ -4,6 +4,8 @@ import winston from "winston";
 import { MakeOptional, EventSearchConfig } from "../utils";
 import { IGNORED_HUB_EXECUTED_BUNDLES, IGNORED_HUB_PROPOSED_BUNDLES } from "../common";
 
+export type LpFeeRequest = clients.LpFeeRequest;
+
 export class HubPoolClient extends clients.HubPoolClient {
   constructor(
     logger: winston.Logger,
@@ -31,9 +33,7 @@ export class HubPoolClient extends clients.HubPoolClient {
     );
   }
 
-  async computeRealizedLpFeePct(
-    deposit: clients.V2PartialDepositWithBlock | clients.V3PartialDepositWithBlock
-  ): Promise<interfaces.RealizedLpFee> {
+  async computeRealizedLpFeePct(deposit: clients.LpFeeRequest): Promise<interfaces.RealizedLpFee> {
     if (deposit.quoteTimestamp > this.currentTime) {
       throw new Error(
         `Cannot compute lp fee percent for quote timestamp ${deposit.quoteTimestamp} in the future. Current time: ${this.currentTime}.`

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -21,6 +21,7 @@ import {
   getCurrentTime,
   isDefined,
   max,
+  min,
   winston,
   toBNWei,
   toBN,
@@ -28,7 +29,7 @@ import {
   CHAIN_IDs,
   TOKEN_SYMBOLS_MAP,
 } from "../utils";
-import { Deposit, DepositWithBlock, L1Token, SpokePoolClientsByChain, V2Deposit } from "../interfaces";
+import { Deposit, DepositWithBlock, L1Token, SpokePoolClientsByChain, V2Deposit, V3Deposit } from "../interfaces";
 import { HubPoolClient } from ".";
 
 type TransactionCostEstimate = sdkUtils.TransactionCostEstimate;
@@ -45,10 +46,8 @@ const { getNativeTokenSymbol, isMessageEmpty, resolveDepositMessage } = sdkUtils
 const bn10 = toBN(10);
 
 // @note All FillProfit BigNumbers are scaled to 18 decimals unless specified otherwise.
-export type FillProfit = {
+export type FillProfitCommon = {
   grossRelayerFeePct: BigNumber; // Max of relayerFeePct and newRelayerFeePct from Deposit.
-  tokenPriceUsd: BigNumber; // Resolved USD price of the bridged token.
-  fillAmountUsd: BigNumber; // Amount of the bridged token being filled.
   grossRelayerFeeUsd: BigNumber; // USD value of the relay fee paid by the user.
   nativeGasCost: BigNumber; // Cost of completing the fill in the units of gas.
   tokenGasCost: BigNumber; // Cost of completing the fill in the relevant gas token.
@@ -56,12 +55,26 @@ export type FillProfit = {
   gasMultiplier: BigNumber; // Multiplier applied to token-only fill cost estimates before profitability.
   gasTokenPriceUsd: BigNumber; // Price paid per unit of gas the gas token in USD.
   gasCostUsd: BigNumber; // Estimated cost of completing the fill in USD.
-  refundFeeUsd: BigNumber; // Estimated relayer refund fee on the refund chain.
-  relayerCapitalUsd: BigNumber; // Amount to be sent by the relayer in USD.
   netRelayerFeePct: BigNumber; // Relayer fee after gas costs as a portion of relayerCapitalUsd.
   netRelayerFeeUsd: BigNumber; // Relayer fee in USD after paying for gas costs.
   profitable: boolean; // Fill profitability indicator.
 };
+
+export type V2FillProfit = FillProfitCommon & {
+  tokenPriceUsd: BigNumber; // Resolved USD price of the bridged token.
+  fillAmountUsd: BigNumber; // Amount of the bridged token being filled.
+  relayerCapitalUsd: BigNumber; // Amount to be sent by the relayer in USD.
+  refundFeeUsd: BigNumber; // Estimated relayer refund fee on the refund chain.
+};
+
+export type V3FillProfit = FillProfitCommon & {
+  inputTokenPriceUsd: BigNumber;
+  inputAmountUsd: BigNumber;
+  outputTokenPriceUsd: BigNumber;
+  outputAmountUsd: BigNumber;
+};
+
+export type FillProfit = V2FillProfit | V3FillProfit;
 
 type UnprofitableFill = {
   deposit: DepositWithBlock;
@@ -298,21 +311,30 @@ export class ProfitClient {
     return minRelayerFeePct as BigNumber;
   }
 
-  appliedRelayerFeePct(deposit: V2Deposit): BigNumber {
-    // Return the maximum available relayerFeePct (max of Deposit and any SpeedUp).
-    return max(deposit.relayerFeePct, deposit.newRelayerFeePct ?? bnZero);
+  async calculateFillProfitability(
+    deposit: Deposit,
+    fillAmount: BigNumber,
+    lpFeePct: BigNumber,
+    l1Token: L1Token,
+    minRelayerFeePct: BigNumber
+  ): Promise<FillProfit> {
+    const refundFee = bnZero;
+    return sdkUtils.isV2Deposit(deposit)
+      ? this.calculateV2FillProfitability(deposit, fillAmount, refundFee, l1Token, minRelayerFeePct)
+      : this.calculateV3FillProfitability(deposit, lpFeePct, minRelayerFeePct);
   }
 
-  async calculateFillProfitability(
+  async calculateV2FillProfitability(
     deposit: V2Deposit,
     fillAmount: BigNumber,
     refundFee: BigNumber,
     l1Token: L1Token,
     minRelayerFeePct: BigNumber
-  ): Promise<FillProfit> {
-    assert(fillAmount.gt(0), `Unexpected fillAmount: ${fillAmount}`);
+  ): Promise<V2FillProfit> {
+    assert(fillAmount.gt(bnZero), `Unexpected fillAmount: ${fillAmount}`);
+
     const tokenPriceUsd = this.getPriceOfToken(l1Token.symbol);
-    if (tokenPriceUsd.lte(0)) {
+    if (tokenPriceUsd.lte(bnZero)) {
       throw new Error(`Unable to determine ${l1Token.symbol} L1 token price`);
     }
 
@@ -321,7 +343,7 @@ export class ProfitClient {
     const scaledRefundFeeAmount =
       l1Token.decimals === 18 ? refundFee : refundFee.mul(toBNWei(1, 18 - l1Token.decimals));
 
-    const grossRelayerFeePct = this.appliedRelayerFeePct(deposit);
+    const grossRelayerFeePct = max(deposit.relayerFeePct, deposit.newRelayerFeePct ?? bnZero);
 
     // Calculate relayer fee and capital outlay in relay token terms.
     const grossRelayerFee = grossRelayerFeePct.mul(scaledFillAmount).div(fixedPoint);
@@ -344,7 +366,8 @@ export class ProfitClient {
     const netRelayerFeePct = netRelayerFeeUsd.mul(fixedPoint).div(relayerCapitalUsd);
 
     // If token price or gas price is unknown, assume the relay is unprofitable.
-    const profitable = tokenPriceUsd.gt(0) && gasTokenPriceUsd.gt(0) && netRelayerFeePct.gte(minRelayerFeePct);
+    const profitable =
+      tokenPriceUsd.gt(bnZero) && gasTokenPriceUsd.gt(bnZero) && netRelayerFeePct.gte(minRelayerFeePct);
 
     return {
       grossRelayerFeePct,
@@ -365,13 +388,88 @@ export class ProfitClient {
     };
   }
 
+  /**
+   * @param deposit V3Deposit object.
+   * @param lpFeePct Predetermined LP fee as a multiplier of the deposit inputAmount.
+   * @param minRelayerFeePct Relayer minimum fee requirements.
+   * @returns FillProfit object detailing the profitability breakdown.
+   */
+  async calculateV3FillProfitability(
+    deposit: V3Deposit,
+    lpFeePct: BigNumber,
+    minRelayerFeePct: BigNumber
+  ): Promise<V3FillProfit> {
+    const { hubPoolClient } = this;
+
+    const inputTokenInfo = hubPoolClient.getL1TokenInfoForL2Token(deposit.inputToken, deposit.originChainId);
+    const inputTokenPriceUsd = this.getPriceOfToken(inputTokenInfo.symbol);
+    const inputTokenScalar = toBNWei(1, 18 - inputTokenInfo.decimals);
+    const scaledInputAmount = deposit.inputAmount.mul(inputTokenScalar);
+    const inputAmountUsd = scaledInputAmount.mul(inputTokenPriceUsd).div(fixedPoint);
+
+    const outputTokenInfo = hubPoolClient.getL1TokenInfoForL2Token(deposit.outputToken, deposit.destinationChainId);
+    const outputTokenPriceUsd = this.getPriceOfToken(outputTokenInfo.symbol);
+    const outputTokenScalar = toBNWei(1, 18 - outputTokenInfo.decimals);
+    const effectiveOutputAmount = min(deposit.outputAmount, deposit.updatedOutputAmount ?? deposit.outputAmount);
+    const scaledOutputAmount = effectiveOutputAmount.mul(outputTokenScalar);
+    const outputAmountUsd = scaledOutputAmount.mul(outputTokenPriceUsd).div(fixedPoint);
+
+    // Normalise token amounts to USD terms.
+    const scaledLpFeeAmount = scaledInputAmount.mul(lpFeePct).div(fixedPoint);
+    const lpFeeUsd = scaledLpFeeAmount.mul(inputTokenPriceUsd).div(fixedPoint);
+
+    // Infer gross relayer fee (excluding gas cost of fill).
+    const grossRelayerFeeUsd = inputAmountUsd.sub(outputAmountUsd).sub(lpFeeUsd);
+    const grossRelayerFeePct = grossRelayerFeeUsd.gt(bnZero)
+      ? grossRelayerFeeUsd.mul(fixedPoint).div(inputAmountUsd)
+      : bnZero;
+
+    // Estimate the gas cost of filling this relay.
+    const { nativeGasCost, tokenGasCost, gasTokenPriceUsd, gasCostUsd } = await this.estimateFillCost(
+      deposit,
+      deposit.outputAmount
+    );
+
+    // Determine profitability.
+    const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd);
+    const netRelayerFeePct = inputAmountUsd.gt(bnZero) ? netRelayerFeeUsd.mul(fixedPoint).div(inputAmountUsd) : bnZero;
+
+    // If token price or gas price is unknown, assume the relay is unprofitable. Force non-equivalent tokens
+    // to be unprofitable for now. The relayer may be updated in future to support in-protocol swaps.
+    const equivalentTokens = outputTokenInfo.address === inputTokenInfo.address;
+    const profitable =
+      equivalentTokens &&
+      inputTokenPriceUsd.gt(bnZero) &&
+      outputTokenPriceUsd.gt(bnZero) &&
+      gasTokenPriceUsd.gt(bnZero) &&
+      netRelayerFeePct.gte(minRelayerFeePct);
+
+    return {
+      inputTokenPriceUsd,
+      inputAmountUsd,
+      outputTokenPriceUsd,
+      outputAmountUsd,
+      grossRelayerFeePct,
+      grossRelayerFeeUsd,
+      nativeGasCost,
+      tokenGasCost,
+      gasPadding: this.gasPadding,
+      gasMultiplier: this.gasMultiplier,
+      gasTokenPriceUsd,
+      gasCostUsd,
+      netRelayerFeePct,
+      netRelayerFeeUsd,
+      profitable,
+    };
+  }
+
   // Return USD amount of fill amount for deposited token, should always return in wei as the units.
   getFillAmountInUsd(deposit: Deposit, fillAmount: BigNumber): BigNumber {
     const l1TokenInfo = this.hubPoolClient.getTokenInfoForDeposit(deposit);
     if (!l1TokenInfo) {
       const inputToken = sdkUtils.getDepositInputToken(deposit);
       throw new Error(
-        `ProfitClient::isFillProfitable missing l1TokenInfo for deposit with origin token: ${inputToken}`
+        `ProfitClient::getFillAmountInUsd missing l1TokenInfo for deposit with origin token: ${inputToken}`
       );
     }
     const tokenPriceInUsd = this.getPriceOfToken(l1TokenInfo.symbol);
@@ -379,67 +477,106 @@ export class ProfitClient {
   }
 
   async getFillProfitability(
-    deposit: V2Deposit,
+    deposit: Deposit,
     fillAmount: BigNumber,
-    refundFee: BigNumber,
+    lpFeePct: BigNumber,
     l1Token: L1Token
   ): Promise<FillProfit> {
     const minRelayerFeePct = this.minRelayerFeePct(l1Token.symbol, deposit.originChainId, deposit.destinationChainId);
 
-    const fill = await this.calculateFillProfitability(deposit, fillAmount, refundFee, l1Token, minRelayerFeePct);
+    const fill = await this.calculateFillProfitability(deposit, fillAmount, lpFeePct, l1Token, minRelayerFeePct);
     if (!fill.profitable || this.debugProfitability) {
       const { depositId, originChainId } = deposit;
       const profitable = fill.profitable ? "profitable" : "unprofitable";
 
-      this.logger.debug({
-        at: "ProfitClient#isFillProfitable",
-        message: `${l1Token.symbol} deposit ${depositId} on chain ${originChainId} is ${profitable}`,
-        deposit,
-        l1Token,
-        fillAmount: formatEther(fillAmount),
-        fillAmountUsd: formatEther(fill.fillAmountUsd),
-        grossRelayerFeePct: `${formatFeePct(fill.grossRelayerFeePct)}%`,
-        nativeGasCost: fill.nativeGasCost,
-        tokenGasCost: formatEther(fill.tokenGasCost),
-        gasPadding: this.gasPadding,
-        gasMultiplier: this.gasMultiplier,
-        gasTokenPriceUsd: formatEther(fill.gasTokenPriceUsd),
-        refundFeeUsd: formatEther(fill.refundFeeUsd),
-        relayerCapitalUsd: formatEther(fill.relayerCapitalUsd),
-        grossRelayerFeeUsd: formatEther(fill.grossRelayerFeeUsd),
-        gasCostUsd: formatEther(fill.gasCostUsd),
-        netRelayerFeeUsd: formatEther(fill.netRelayerFeeUsd),
-        netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)}%`,
-        minRelayerFeePct: `${formatFeePct(minRelayerFeePct)}%`,
-        profitable: fill.profitable,
-      });
+      const isV2FillProfit = (fillProfit: FillProfit, deposit: Deposit): fillProfit is V2FillProfit => {
+        fillProfit; // tsc
+        return sdkUtils.isV2Deposit(deposit);
+      };
+
+      if (isV2FillProfit(fill, deposit)) {
+        this.logger.debug({
+          at: "ProfitClient#getFillProfitability",
+          message: `${l1Token.symbol} deposit ${depositId} on chain ${originChainId} is ${profitable}`,
+          deposit,
+          l1Token,
+          fillAmount: formatEther(fillAmount),
+          fillAmountUsd: formatEther(fill.fillAmountUsd),
+          lpFeePct: `${formatFeePct(lpFeePct)}%`,
+          grossRelayerFeePct: `${formatFeePct(fill.grossRelayerFeePct)}%`,
+          nativeGasCost: fill.nativeGasCost,
+          tokenGasCost: formatEther(fill.tokenGasCost),
+          gasPadding: this.gasPadding,
+          gasMultiplier: this.gasMultiplier,
+          gasTokenPriceUsd: formatEther(fill.gasTokenPriceUsd),
+          refundFeeUsd: formatEther(fill.refundFeeUsd),
+          relayerCapitalUsd: formatEther(fill.relayerCapitalUsd),
+          grossRelayerFeeUsd: formatEther(fill.grossRelayerFeeUsd),
+          gasCostUsd: formatEther(fill.gasCostUsd),
+          netRelayerFeeUsd: formatEther(fill.netRelayerFeeUsd),
+          netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)}%`,
+          minRelayerFeePct: `${formatFeePct(minRelayerFeePct)}%`,
+          profitable: fill.profitable,
+        });
+      } else {
+        this.logger.debug({
+          at: "ProfitClient#getFillProfitability",
+          message: `${l1Token.symbol} v3 deposit ${depositId} on chain ${originChainId} is ${profitable}`,
+          deposit,
+          inputTokenPriceUsd: formatEther(fill.inputTokenPriceUsd),
+          inputTokenAmountUsd: formatEther(fill.inputAmountUsd),
+          outputTokenPriceUsd: formatEther(fill.inputTokenPriceUsd),
+          outputTokenAmountUsd: formatEther(fill.outputAmountUsd),
+          lpFeePct: `${formatFeePct(lpFeePct)}%`,
+          grossRelayerFeePct: `${formatFeePct(fill.grossRelayerFeePct)}%`,
+          nativeGasCost: fill.nativeGasCost,
+          tokenGasCost: formatEther(fill.tokenGasCost),
+          gasPadding: this.gasPadding,
+          gasMultiplier: this.gasMultiplier,
+          gasTokenPriceUsd: formatEther(fill.gasTokenPriceUsd),
+          grossRelayerFeeUsd: formatEther(fill.grossRelayerFeeUsd),
+          gasCostUsd: formatEther(fill.gasCostUsd),
+          netRelayerFeeUsd: formatEther(fill.netRelayerFeeUsd),
+          netRelayerFeePct: `${formatFeePct(fill.netRelayerFeePct)}%`,
+          minRelayerFeePct: `${formatFeePct(minRelayerFeePct)}%`,
+          profitable: fill.profitable,
+        });
+      }
     }
 
     return fill;
   }
 
   async isFillProfitable(
-    deposit: V2Deposit,
+    deposit: Deposit,
     fillAmount: BigNumber,
-    refundFee: BigNumber,
+    lpFeePct: BigNumber,
     l1Token: L1Token
-  ): Promise<Pick<FillProfit, "profitable" | "nativeGasCost">> {
+  ): Promise<Pick<FillProfit, "profitable" | "nativeGasCost" | "grossRelayerFeePct">> {
     let profitable = false;
+    let grossRelayerFeePct = bnZero;
     let nativeGasCost = uint256Max;
     try {
-      ({ profitable, nativeGasCost } = await this.getFillProfitability(deposit, fillAmount, refundFee, l1Token));
+      ({ profitable, grossRelayerFeePct, nativeGasCost } = await this.getFillProfitability(
+        deposit,
+        fillAmount,
+        lpFeePct,
+        l1Token
+      ));
     } catch (err) {
       this.logger.debug({
         at: "ProfitClient#isFillProfitable",
         message: `Unable to determine fill profitability (${err}).`,
         deposit,
         fillAmount,
+        lpFeePct,
       });
     }
 
     return {
       profitable: profitable || this.isTestnet,
       nativeGasCost,
+      grossRelayerFeePct,
     };
   }
 
@@ -459,7 +596,7 @@ export class ProfitClient {
   protected async updateTokenPrices(): Promise<void> {
     // Generate list of tokens to retrieve. Map by symbol because tokens like
     // ETH/WETH refer to the same mainnet contract address.
-    const tokens: { [_symbol: string]: string } = Object.fromEntries(
+    const tokens: { [symbol: string]: string } = Object.fromEntries(
       this.hubPoolClient.getL1Tokens().map(({ symbol }) => {
         const { addresses } = TOKEN_SYMBOLS_MAP[symbol];
         const address = addresses[1];

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { utils as ethersUtils } from "ethers";
-import { Deposit, DepositWithBlock, L1Token, V2Deposit } from "../interfaces";
+import { Deposit, DepositWithBlock, L1Token, V2Deposit, V3Deposit } from "../interfaces";
 import {
   BigNumber,
   bnZero,
@@ -22,21 +22,26 @@ import {
 import { RelayerClients } from "./RelayerClientHelper";
 import { RelayerConfig } from "./RelayerConfig";
 
-const { bnUint256Max, isDepositSpedUp, isMessageEmpty, resolveDepositMessage } = sdkUtils;
+const { getAddress } = ethersUtils;
+const { isDepositSpedUp, isMessageEmpty, resolveDepositMessage } = sdkUtils;
 const UNPROFITABLE_DEPOSIT_NOTICE_PERIOD = 60 * 60; // 1 hour
 const zeroFillAmount = bnOne;
 
 export class Relayer {
+  public readonly relayerAddress: string;
+
   // Track by originChainId since depositId is issued on the origin chain.
   // Key is in the form of "chainId-depositId".
   private fullyFilledDeposits: { [key: string]: boolean } = {};
 
   constructor(
-    readonly relayerAddress: string,
+    relayerAddress: string,
     readonly logger: winston.Logger,
     readonly clients: RelayerClients,
     readonly config: RelayerConfig
-  ) {}
+  ) {
+    this.relayerAddress = getAddress(relayerAddress);
+  }
 
   /**
    * @description Retrieve the complete array of unfilled deposits and filter out deposits we can't or choose
@@ -66,19 +71,6 @@ export class Relayer {
         return false;
       }
 
-      if (
-        ignoredAddresses?.includes(ethersUtils.getAddress(depositor)) ||
-        ignoredAddresses?.includes(ethersUtils.getAddress(recipient))
-      ) {
-        this.logger.debug({
-          at: "Relayer::getUnfilledDeposits",
-          message: "Ignoring deposit",
-          depositor,
-          recipient,
-        });
-        return false;
-      }
-
       if (!this.routeEnabled(originChainId, destinationChainId)) {
         this.logger.debug({
           at: "Relayer::getUnfilledDeposits",
@@ -93,6 +85,29 @@ export class Relayer {
       // Skip deposits with quoteTimestamp in the future (impossible to know HubPool utilization => LP fee cannot be computed).
       if (quoteTimestamp > hubPoolClient.currentTime) {
         return false;
+      }
+
+      if (ignoredAddresses?.includes(getAddress(depositor)) || ignoredAddresses?.includes(getAddress(recipient))) {
+        this.logger.debug({
+          at: "Relayer::getUnfilledDeposits",
+          message: "Ignoring deposit",
+          depositor,
+          recipient,
+        });
+        return false;
+      }
+
+      // Filters specific to v3.
+      if (sdkUtils.isV3Deposit(deposit)) {
+        // It would be preferable to use host time since it's more reliably up-to-date, but this creates issues in test.
+        const currentTime = this.clients.spokePoolClients[destinationChainId].getCurrentTime();
+        if (deposit.fillDeadline <= currentTime) {
+          return false;
+        }
+
+        if (deposit.exclusivityDeadline > currentTime && getAddress(deposit.exclusiveRelayer) !== this.relayerAddress) {
+          return false;
+        }
       }
 
       // Skip deposit with message if sending fills with messages is not supported.
@@ -232,7 +247,7 @@ export class Relayer {
       })
     );
     this.logger.debug({
-      at: "Relayer",
+      at: "Relayer::checkForUnfilledDepositsAndFill",
       message: "Setting minimum deposit confirmation based on origin chain aggregate deposit amount",
       unfilledDepositAmountsPerChain,
       mdcPerChain,
@@ -254,7 +269,7 @@ export class Relayer {
     // If not enough ballance add the shortfall to the shortfall tracker to produce an appropriate log. If the deposit
     // is has no other fills then send a 0 sized fill to initiate a slow relay. If unprofitable then add the
     // unprofitable tx to the unprofitable tx tracker to produce an appropriate log.
-    for (const { deposit, version, unfilledAmount, fillCount } of confirmedUnfilledDeposits) {
+    for (const { deposit, unfilledAmount, fillCount } of confirmedUnfilledDeposits) {
       const { slowDepositors } = config;
 
       const { depositor, recipient, destinationChainId, originChainId } = deposit;
@@ -278,16 +293,14 @@ export class Relayer {
       const l1Token = hubPoolClient.getL1TokenInfoForL2Token(inputToken, originChainId);
       const selfRelay = [depositor, recipient].every((address) => address === this.relayerAddress);
       if (tokenClient.hasBalanceForFill(deposit, unfilledAmount) && !selfRelay) {
-        assert(isDefined(deposit.realizedLpFeePct)); // Sanity check.
         const { repaymentChainId, gasLimit: gasCost } = await this.resolveRepaymentChain(
-          version,
           deposit,
           unfilledAmount,
           l1Token
         );
         if (isDefined(repaymentChainId)) {
           const gasLimit = isMessageEmpty(resolveDepositMessage(deposit)) ? undefined : gasCost;
-          this.fillRelay(deposit, unfilledAmount, repaymentChainId, gasLimit);
+          this.fillRelay(deposit, repaymentChainId, gasLimit);
         } else {
           profitClient.captureUnprofitableFill(deposit, unfilledAmount, gasCost);
         }
@@ -295,7 +308,7 @@ export class Relayer {
         // A relayer can fill its own deposit without an ERC20 transfer. Only bypass profitability requirements if the
         // relayer is both the depositor and the recipient, because a deposit on a cheap SpokePool chain could cause
         // expensive fills on (for example) mainnet.
-        this.fillRelay(deposit, unfilledAmount, destinationChainId);
+        this.fillRelay(deposit, destinationChainId);
       } else {
         // TokenClient.getBalance returns that we don't have enough balance to submit the fast fill.
         // At this point, capture the shortfall so that the inventory manager can rebalance the token inventory.
@@ -432,20 +445,57 @@ export class Relayer {
     });
   }
 
-  fillRelay(deposit: Deposit, fillAmount: BigNumber, repaymentChainId: number, gasLimit?: BigNumber): void {
+  fillRelay(deposit: Deposit, repaymentChainId: number, gasLimit?: BigNumber): void {
     // Skip deposits that this relayer has already filled completely before to prevent double filling (which is a waste
     // of gas as the second fill would fail).
-    // TODO: Handle the edge case scenario where the first fill failed due to transient errors and needs to be retried
+    // TODO: Handle the edge case scenario where the first fill failed due to transient errors and needs to be retried.
     const fillKey = `${deposit.originChainId}-${deposit.depositId}`;
     if (this.fullyFilledDeposits[fillKey]) {
       this.logger.debug({
         at: "Relayer",
-        message: "Skipping deposit already filled by this relayer",
+        message: "Skipping deposit already filled by this relayer.",
         originChainId: deposit.originChainId,
         depositId: deposit.depositId,
       });
       return;
     }
+
+    sdkUtils.isV2Deposit(deposit)
+      ? this.fillV2Relay(deposit, sdkUtils.getDepositOutputAmount(deposit), repaymentChainId, gasLimit)
+      : this.fillV3Relay(deposit, repaymentChainId, gasLimit);
+
+    // All fills routed through `fillRelay()` will complete the relay.
+    this.fullyFilledDeposits[fillKey] = true;
+  }
+
+  fillV3Relay(deposit: V3Deposit, repaymentChainId: number, gasLimit?: BigNumber): void {
+    assert(sdkUtils.isV3Deposit(deposit));
+    const { spokePoolClients, multiCallerClient } = this.clients;
+    this.logger.debug({ at: "Relayer", message: "Filling v3 deposit.", deposit, repaymentChainId });
+
+    const [method, messageModifier, args] = !isDepositSpedUp(deposit)
+      ? ["fillV3Relay", "", [deposit, repaymentChainId]]
+      : [
+          "fillV3RelayWithUpdatedDeposit",
+          " with updated parameters ",
+          [
+            deposit,
+            repaymentChainId,
+            deposit.updatedOutputAmount,
+            deposit.updatedRecipient,
+            deposit.updatedMessage,
+            deposit.speedUpSignature,
+          ],
+        ];
+
+    const message = `Filled v3 deposit ${messageModifier}🚀`;
+    const mrkdwn = this.constructRelayFilledMrkdwn(deposit, repaymentChainId, deposit.outputAmount);
+    const contract = spokePoolClients[deposit.destinationChainId].spokePool;
+    const chainId = deposit.destinationChainId;
+    multiCallerClient.enqueueTransaction({ contract, chainId, method, args, gasLimit, message, mrkdwn });
+  }
+
+  fillV2Relay(deposit: V2Deposit, fillAmount: BigNumber, repaymentChainId: number, gasLimit?: BigNumber): void {
     const zeroFill = fillAmount.eq(zeroFillAmount);
     this.logger.debug({
       at: "Relayer",
@@ -479,10 +529,6 @@ export class Relayer {
       mrkdwn: this.constructRelayFilledMrkdwn(deposit, repaymentChainId, fillAmount),
     });
 
-    // @dev: Only zero fills _or_ fills that complete the transfer are attempted, so zeroFill indicates whether the
-    // deposit was filled to completion. @todo: Revisit in the future when we implement partial fills.
-    this.fullyFilledDeposits[fillKey] = !zeroFill;
-
     // Decrement tokens in token client used in the fill. This ensures that we dont try and fill more than we have.
     const outputToken = sdkUtils.getDepositOutputToken(deposit);
     this.clients.tokenClient.decrementLocalBalance(deposit.destinationChainId, outputToken, fillAmount);
@@ -493,18 +539,20 @@ export class Relayer {
    * @param deposit Deposit object to zero-fill.
    */
   zeroFillDeposit(deposit: V2Deposit): void {
-    this.fillRelay(deposit, zeroFillAmount, deposit.destinationChainId);
+    this.fillV2Relay(deposit, zeroFillAmount, deposit.destinationChainId);
   }
 
   protected async resolveRepaymentChain(
-    version: number,
     deposit: DepositWithBlock,
     fillAmount: BigNumber,
     hubPoolToken: L1Token
-  ): Promise<{ repaymentChainId?: number; gasLimit: BigNumber }> {
-    assert(sdkUtils.isV2Deposit(deposit)); // temporary
-
-    const { inventoryClient, profitClient } = this.clients;
+  ): Promise<{
+    gasLimit: BigNumber;
+    repaymentChainId?: number;
+    realizedLpFeePct: BigNumber;
+    relayerFeePct: BigNumber;
+  }> {
+    const { hubPoolClient, inventoryClient, profitClient } = this.clients;
     const { depositId, originChainId, destinationChainId, transactionHash: depositHash } = deposit;
     const outputAmount = sdkUtils.getDepositOutputAmount(deposit);
 
@@ -522,21 +570,21 @@ export class Relayer {
       ? await inventoryClient.determineRefundChainId(deposit, hubPoolToken.address)
       : destinationChainId;
 
-    if (sdkUtils.isV3Deposit(deposit)) {
-      return { repaymentChainId: undefined, gasLimit: bnUint256Max };
-    }
+    const { realizedLpFeePct } = sdkUtils.isV3Deposit(deposit)
+      ? await hubPoolClient.computeRealizedLpFeePct(deposit)
+      : deposit;
 
-    const refundFee = bnZero;
-    const { profitable, nativeGasCost: gasLimit } = await profitClient.isFillProfitable(
-      deposit,
-      fillAmount,
-      refundFee,
-      hubPoolToken
-    );
+    const {
+      profitable,
+      nativeGasCost: gasLimit,
+      grossRelayerFeePct: relayerFeePct,
+    } = await profitClient.isFillProfitable(deposit, fillAmount, realizedLpFeePct, hubPoolToken);
 
     return {
-      repaymentChainId: profitable ? preferredChainId : undefined,
       gasLimit,
+      repaymentChainId: profitable ? preferredChainId : undefined,
+      realizedLpFeePct,
+      relayerFeePct,
     };
   }
 
@@ -592,11 +640,12 @@ export class Relayer {
         const formatFunction = createFormatFunction(2, 4, false, decimals);
         const gasFormatFunction = createFormatFunction(2, 10, false, 18);
         const depositblockExplorerLink = blockExplorerLink(deposit.transactionHash, deposit.originChainId);
+
+        const inputAmount = formatFunction(sdkUtils.getDepositInputAmount(deposit).toString());
+        const relayerFeePct = formatFeePct(sdkUtils.isV2Deposit(deposit) ? deposit.relayerFeePct : bnZero); // @todo
         depositMrkdwn +=
-          `- DepositId ${deposit.depositId} (tx: ${depositblockExplorerLink}) of amount ${formatFunction(
-            deposit.amount.toString()
-          )} ${symbol}` +
-          ` with a relayerFeePct ${formatFeePct(deposit.relayerFeePct)}% and gas cost ${gasFormatFunction(gasCost)}` +
+          `- DepositId ${deposit.depositId} (tx: ${depositblockExplorerLink}) of amount ${inputAmount} ${symbol}` +
+          ` with a relayerFeePct ${relayerFeePct}% and gas cost ${gasFormatFunction(gasCost)}` +
           ` from ${getNetworkName(deposit.originChainId)} to ${getNetworkName(deposit.destinationChainId)}` +
           ` and an unfilled amount of ${formatFunction(fillAmount.toString())} ${symbol} is unprofitable!\n`;
       });
@@ -636,19 +685,28 @@ export class Relayer {
     const { symbol, decimals } = this.clients.hubPoolClient.getTokenInfoForDeposit(deposit);
     const srcChain = getNetworkName(deposit.originChainId);
     const dstChain = getNetworkName(deposit.destinationChainId);
-    const inputAmount = sdkUtils.getDepositInputAmount(deposit);
-    const amount = createFormatFunction(2, 4, false, decimals)(inputAmount.toString());
     const depositor = blockExplorerLink(deposit.depositor, deposit.originChainId);
-    const _fillAmount = createFormatFunction(2, 4, false, decimals)(fillAmount.toString());
-    const relayerFeePct = formatFeePct(deposit.relayerFeePct);
-    const realizedLpFeePct = formatFeePct(deposit.realizedLpFeePct);
+    const inputAmount = sdkUtils.getDepositInputAmount(deposit);
+    const _inputAmount = createFormatFunction(2, 4, false, decimals)(inputAmount.toString());
 
-    let msg =
-      `Relayed depositId ${deposit.depositId} from ${srcChain} to ${dstChain} of ${amount} ${symbol},` +
-      ` with depositor ${depositor}. Fill amount of ${_fillAmount} ${symbol} with` +
-      ` relayerFee ${relayerFeePct}% & realizedLpFee ${realizedLpFeePct}%.`;
-    if (fillAmount.eq(zeroFillAmount)) {
-      msg += " Has been zero filled due to a token shortfall! This will initiate a slow relay for this deposit.";
+    let msg = `Relayed depositId ${deposit.depositId} from ${srcChain} to ${dstChain} of ${_inputAmount} ${symbol}`;
+    if (sdkUtils.isV2Deposit(deposit)) {
+      const _fillAmount = createFormatFunction(2, 4, false, decimals)(fillAmount.toString());
+      const _relayerFeePct = formatFeePct(deposit.relayerFeePct);
+      const realizedLpFeePct = formatFeePct(deposit.realizedLpFeePct);
+      msg +=
+        ` with depositor ${depositor}. Fill amount of ${_fillAmount} ${symbol}` +
+        ` with relayerFee ${_relayerFeePct}% & realizedLpFee ${realizedLpFeePct}%.`;
+
+      if (fillAmount.eq(zeroFillAmount)) {
+        msg += " Has been zero filled due to a token shortfall! This will initiate a slow relay for this deposit.";
+      }
+    } else {
+      const { symbol: outputTokenSymbol, decimals: outputTokenDecimals } =
+        this.clients.hubPoolClient.getTokenInfoForDeposit(deposit);
+      const outputAmount = deposit.outputAmount;
+      const _outputAmount = createFormatFunction(2, 4, false, outputTokenDecimals)(outputAmount.toString());
+      msg += ` and output ${_outputAmount} ${outputTokenSymbol}, with depositor ${depositor}.`;
     }
 
     return msg;

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -571,7 +571,7 @@ export class Relayer {
       : destinationChainId;
 
     const { realizedLpFeePct } = sdkUtils.isV3Deposit(deposit)
-      ? await hubPoolClient.computeRealizedLpFeePct(deposit)
+      ? await hubPoolClient.computeRealizedLpFeePct({ ...deposit, paymentChainId: preferredChainId })
       : deposit;
 
     const {

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -48,6 +48,7 @@ export const {
   depositV2,
   enableRoutes,
   getContractFactory,
+  getUpdatedV3DepositSignature,
   hubPoolFixture,
   modifyRelayHelper,
   randomAddress,


### PR DESCRIPTION
Permit realizedLpFeePct computation to occur between originChainId and
any arbitrary chain, rather than destinationChainId. This supports more
dynamic fee behaviour.