### PR TITLE
fix: Dataworker shouldn't call fillDeadlineBuffer for bundles whose start block is before V3 upgrade block

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -736,13 +736,13 @@ export class BundleDataClient {
               if (!v3RelayHashes[relayDataHash].slowFillRequest) {
                 // At this point, the v3RelayHashes entry already existed meaning that there is either a matching
                 // fill or deposit.
+                v3RelayHashes[relayDataHash].slowFillRequest = slowFillRequest;
                 if (v3RelayHashes[relayDataHash].fill) {
                   // If there is a fill matching the relay hash, then this slow fill request can't be used
                   // to create a slow fill for a filled deposit.
                   return;
                 }
                 assert(v3RelayHashes[relayDataHash].deposit, "Deposit should exist in relay hash dictionary.");
-                v3RelayHashes[relayDataHash].slowFillRequest = slowFillRequest;
                 const matchedDeposit = v3RelayHashes[relayDataHash].deposit;
 
                 // Input and Output tokens must be equivalent on the deposit for this to be slow filled.

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -129,12 +129,18 @@ export async function blockRangesAreInvalidForSpokeClients(
       return true;
     }
 
-    // if (endBlockTimestamps !== undefined) {
-    // const maxFillDeadlineBufferInBlockRange = await spokePoolClient.getMaxFillDeadlineInRange(start, end);
-    // if (endBlockTimestamps[chainId] - spokePoolClient.getOldestTime() < maxFillDeadlineBufferInBlockRange) {
-    //   return true;
-    // }
-    // }
+    if (endBlockTimestamps !== undefined) {
+      // TODO: Change this to query the max fill deadline between the values at the start and the end block after
+      // we've fully migrated to V3. This is set to only query at the end block right now to deal with the
+      // V2 to V3 migration bundle that contains a start block prior to the V3 upgrade. At this block, the
+      // fill deadline buffer will not be in the SpokePool Proxy's ABI so it will fail. We could handle this dynamically
+      // but because its a one-time change and I think the fill deadline buffer is unlikely to change during this
+      // bundle, that this is a safe temporary fix.
+      const maxFillDeadlineBufferInBlockRange = await spokePoolClient.getMaxFillDeadlineInRange(/* start*/ end, end);
+      if (endBlockTimestamps[chainId] - spokePoolClient.getOldestTime() < maxFillDeadlineBufferInBlockRange) {
+        return true;
+      }
+    }
     // We must now assume that all newly expired deposits at the time of the bundle end blocks are contained within
     // the spoke pool client's memory.
 

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -130,13 +130,7 @@ export async function blockRangesAreInvalidForSpokeClients(
     }
 
     if (endBlockTimestamps !== undefined) {
-      // TODO: Change this to query the max fill deadline between the values at the start and the end block after
-      // we've fully migrated to V3. This is set to only query at the end block right now to deal with the
-      // V2 to V3 migration bundle that contains a start block prior to the V3 upgrade. At this block, the
-      // fill deadline buffer will not be in the SpokePool Proxy's ABI so it will fail. We could handle this dynamically
-      // but because its a one-time change and I think the fill deadline buffer is unlikely to change during this
-      // bundle, that this is a safe temporary fix.
-      const maxFillDeadlineBufferInBlockRange = await spokePoolClient.getMaxFillDeadlineInRange(/* start*/ end, end);
+      const maxFillDeadlineBufferInBlockRange = await spokePoolClient.getMaxFillDeadlineInRange(start, end);
       if (endBlockTimestamps[chainId] - spokePoolClient.getOldestTime() < maxFillDeadlineBufferInBlockRange) {
         return true;
       }

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -128,7 +128,7 @@ export class Relayer {
         // @todo: This is only relevant if inputToken and outputToken are equivalent.
         const outputToken = sdkUtils.getDepositOutputToken(deposit);
         if (!hubPoolClient.areTokensEquivalent(inputToken, originChainId, outputToken, destinationChainId)) {
-          this.logger.debug({
+          this.logger.warn({
             at: "Relayer::getUnfilledDeposits",
             message: "Skipping deposit including in-protocol token swap.",
             deposit,

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -1,4 +1,4 @@
-import { ethers, expect } from "./utils";
+import { ethers, expect, smock } from "./utils";
 import { setupDataworker } from "./fixtures/Dataworker.Fixture";
 
 // Tested
@@ -8,7 +8,9 @@ import { getWidestPossibleExpectedBlockRange } from "../src/dataworker/PoolRebal
 import { originChainId } from "./constants";
 import { blockRangesAreInvalidForSpokeClients, getEndBlockBuffers } from "../src/dataworker/DataworkerUtils";
 import { getDeployedBlockNumber } from "@across-protocol/contracts-v2";
-import { MockHubPoolClient } from "./mocks";
+import { MockHubPoolClient, MockSpokePoolClient } from "./mocks";
+import { getTimestampsForBundleEndBlocks } from "../src/utils/BlockUtils";
+import { assert } from "../src/utils";
 
 let dataworkerClients: DataworkerClients;
 let spokePoolClients: { [chainId: number]: SpokePoolClient };
@@ -152,7 +154,7 @@ describe("Dataworker block range-related utility methods", async function () {
     // Only use public chain IDs because getDeploymentBlockNumber will only work for real chain ID's. This is a hack
     // and getDeploymentBlockNumber should be changed to work in test environments.
     const _spokePoolClients = { [chainId]: spokePoolClients[chainId] };
-    const chainIds = [chainId];
+    let chainIds = [chainId];
 
     // Look if bundle range from block is before the latest invalid
     // bundle start block. If so, then the range is invalid.
@@ -252,96 +254,96 @@ describe("Dataworker block range-related utility methods", async function () {
       )
     ).to.equal(false);
 
-    // // Override spoke pool client fill deadline buffer and oldest time searched and check that it returns false
-    // // buffer if not great enough to cover the time between the end block and the oldest time searched by
-    // // the client.
-    // const originSpokePoolClient = spokePoolClients[originChainId];
-    // chainIds = [originChainId];
+    // Override spoke pool client fill deadline buffer and oldest time searched and check that it returns false
+    // buffer if not great enough to cover the time between the end block and the oldest time searched by
+    // the client.
+    const originSpokePoolClient = spokePoolClients[originChainId];
+    chainIds = [originChainId];
 
-    // // Create a fake spoke pool so we can manipulate the fill deadline buffer. Make sure it returns a realistic
-    // // current time so that computing bundle end block timestamps gives us realistic numbers.
-    // const fakeSpokePool = await smock.fake(originSpokePoolClient.spokePool.interface);
-    // fakeSpokePool.getCurrentTime.returns(originSpokePoolClient.currentTime);
-    // const mockSpokePoolClient = new MockSpokePoolClient(
-    //   originSpokePoolClient.logger,
-    //   fakeSpokePool,
-    //   originSpokePoolClient.chainId,
-    //   originSpokePoolClient.deploymentBlock
-    // );
-    // const blockRanges = [[mainnetDeploymentBlock + 1, mockSpokePoolClient.latestBlockSearched]];
-    // const endBlockTimestamps = await getTimestampsForBundleEndBlocks(
-    //   { [originChainId]: mockSpokePoolClient as SpokePoolClient },
-    //   blockRanges,
-    //   chainIds
-    // );
-    // // override oldest spoke pool client's oldest time searched to be realistic (i.e. not zero)
-    // mockSpokePoolClient.setOldestBlockTimestampOverride(originSpokePoolClient.getOldestTime());
-    // const expectedTimeBetweenOldestAndEndBlockTimestamp =
-    //   endBlockTimestamps[originChainId] - mockSpokePoolClient.getOldestTime();
-    // assert(
-    //   expectedTimeBetweenOldestAndEndBlockTimestamp > 0,
-    //   "unrealistic time between oldest and end block timestamp"
-    // );
-    // const fillDeadlineOverride = expectedTimeBetweenOldestAndEndBlockTimestamp + 1;
-    // mockSpokePoolClient.setMaxFillDeadlineOverride(fillDeadlineOverride);
-    // expect(
-    //   await blockRangesAreInvalidForSpokeClients(
-    //     { [originChainId]: mockSpokePoolClient as SpokePoolClient },
-    //     blockRanges,
-    //     chainIds,
-    //     {
-    //       [originChainId]: mainnetDeploymentBlock,
-    //     },
-    //     true // isV3
-    //   )
-    // ).to.equal(true);
+    // Create a fake spoke pool so we can manipulate the fill deadline buffer. Make sure it returns a realistic
+    // current time so that computing bundle end block timestamps gives us realistic numbers.
+    const fakeSpokePool = await smock.fake(originSpokePoolClient.spokePool.interface);
+    fakeSpokePool.getCurrentTime.returns(originSpokePoolClient.currentTime);
+    const mockSpokePoolClient = new MockSpokePoolClient(
+      originSpokePoolClient.logger,
+      fakeSpokePool,
+      originSpokePoolClient.chainId,
+      originSpokePoolClient.deploymentBlock
+    );
+    const blockRanges = [[mainnetDeploymentBlock + 1, mockSpokePoolClient.latestBlockSearched]];
+    const endBlockTimestamps = await getTimestampsForBundleEndBlocks(
+      { [originChainId]: mockSpokePoolClient as SpokePoolClient },
+      blockRanges,
+      chainIds
+    );
+    // override oldest spoke pool client's oldest time searched to be realistic (i.e. not zero)
+    mockSpokePoolClient.setOldestBlockTimestampOverride(originSpokePoolClient.getOldestTime());
+    const expectedTimeBetweenOldestAndEndBlockTimestamp =
+      endBlockTimestamps[originChainId] - mockSpokePoolClient.getOldestTime();
+    assert(
+      expectedTimeBetweenOldestAndEndBlockTimestamp > 0,
+      "unrealistic time between oldest and end block timestamp"
+    );
+    const fillDeadlineOverride = expectedTimeBetweenOldestAndEndBlockTimestamp + 1;
+    mockSpokePoolClient.setMaxFillDeadlineOverride(fillDeadlineOverride);
+    expect(
+      await blockRangesAreInvalidForSpokeClients(
+        { [originChainId]: mockSpokePoolClient as SpokePoolClient },
+        blockRanges,
+        chainIds,
+        {
+          [originChainId]: mainnetDeploymentBlock,
+        },
+        true // isV3
+      )
+    ).to.equal(true);
 
-    // // Should be valid if not V3
-    // expect(
-    //   await blockRangesAreInvalidForSpokeClients(
-    //     { [originChainId]: mockSpokePoolClient as SpokePoolClient },
-    //     blockRanges,
-    //     chainIds,
-    //     {
-    //       [originChainId]: mainnetDeploymentBlock,
-    //     },
-    //     false // isV3
-    //   )
-    // ).to.equal(false);
+    // Should be valid if not V3
+    expect(
+      await blockRangesAreInvalidForSpokeClients(
+        { [originChainId]: mockSpokePoolClient as SpokePoolClient },
+        blockRanges,
+        chainIds,
+        {
+          [originChainId]: mainnetDeploymentBlock,
+        },
+        false // isV3
+      )
+    ).to.equal(false);
 
-    // // Set oldest time older such that fill deadline buffer now exceeds the time between the end block and the oldest
-    // // time. Block ranges should now be valid.
-    // const oldestBlockTimestampOverride = endBlockTimestamps[originChainId] - fillDeadlineOverride - 1;
-    // assert(oldestBlockTimestampOverride > 0, "unrealistic oldest block timestamp");
-    // mockSpokePoolClient.setOldestBlockTimestampOverride(oldestBlockTimestampOverride);
-    // expect(
-    //   await blockRangesAreInvalidForSpokeClients(
-    //     { [originChainId]: mockSpokePoolClient as SpokePoolClient },
-    //     blockRanges,
-    //     chainIds,
-    //     {
-    //       [originChainId]: mainnetDeploymentBlock,
-    //     },
-    //     true // isV3
-    //   )
-    // ).to.equal(false);
+    // Set oldest time older such that fill deadline buffer now exceeds the time between the end block and the oldest
+    // time. Block ranges should now be valid.
+    const oldestBlockTimestampOverride = endBlockTimestamps[originChainId] - fillDeadlineOverride - 1;
+    assert(oldestBlockTimestampOverride > 0, "unrealistic oldest block timestamp");
+    mockSpokePoolClient.setOldestBlockTimestampOverride(oldestBlockTimestampOverride);
+    expect(
+      await blockRangesAreInvalidForSpokeClients(
+        { [originChainId]: mockSpokePoolClient as SpokePoolClient },
+        blockRanges,
+        chainIds,
+        {
+          [originChainId]: mainnetDeploymentBlock,
+        },
+        true // isV3
+      )
+    ).to.equal(false);
 
-    // // Finally, reset fill deadline buffer in contracts and reset the override in the mock to test that
-    // // the client calls from the contracts.
-    // mockSpokePoolClient.setOldestBlockTimestampOverride(undefined);
-    // mockSpokePoolClient.setMaxFillDeadlineOverride(undefined);
-    // fakeSpokePool.fillDeadlineBuffer.returns(expectedTimeBetweenOldestAndEndBlockTimestamp); // This should be same
-    // // length as time between oldest time and end block timestamp so it should be a valid block range.
-    // expect(
-    //   await blockRangesAreInvalidForSpokeClients(
-    //     { [originChainId]: mockSpokePoolClient as SpokePoolClient },
-    //     blockRanges,
-    //     chainIds,
-    //     {
-    //       [originChainId]: mainnetDeploymentBlock,
-    //     },
-    //     true // isV3
-    //   )
-    // ).to.equal(false);
+    // Finally, reset fill deadline buffer in contracts and reset the override in the mock to test that
+    // the client calls from the contracts.
+    mockSpokePoolClient.setOldestBlockTimestampOverride(undefined);
+    mockSpokePoolClient.setMaxFillDeadlineOverride(undefined);
+    fakeSpokePool.fillDeadlineBuffer.returns(expectedTimeBetweenOldestAndEndBlockTimestamp); // This should be same
+    // length as time between oldest time and end block timestamp so it should be a valid block range.
+    expect(
+      await blockRangesAreInvalidForSpokeClients(
+        { [originChainId]: mockSpokePoolClient as SpokePoolClient },
+        blockRanges,
+        chainIds,
+        {
+          [originChainId]: mainnetDeploymentBlock,
+        },
+        true // isV3
+      )
+    ).to.equal(false);
   });
 });

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -1301,6 +1301,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       expect(data1.bundleFillsV3[repaymentChainId][l1Token_1.address].fills.length).to.equal(1);
       expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address].length).to.equal(1);
       expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address][0].depositId).to.equal(deposits[1].depositId);
+      expect(data1.unexecutableSlowFills).to.deep.equal({});
     });
     it("Handles slow fill requests out of block range", async function () {
       generateV3Deposit({ outputToken: erc20_2.address });


### PR DESCRIPTION
Reverts across-protocol/relayer-v2#1214