### PR TITLE
improve: query fillStatuses as of bundle end block

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -712,11 +712,7 @@ export class BundleDataClient {
               fill.blockNumber >= destinationChainBlockRange[0]
             ) {
               const historicalDeposit = await queryHistoricalDepositForFill(originClient, fill);
-              if (
-                !historicalDeposit.found ||
-                !utils.isV3Deposit(historicalDeposit.deposit) ||
-                historicalDeposit.deposit.blockNumber > originChainBlockRange[1]
-              ) {
+              if (!historicalDeposit.found || !utils.isV3Deposit(historicalDeposit.deposit)) {
                 bundleInvalidFillsV3.push(fill);
               } else {
                 const matchedDeposit: V3DepositWithBlock = historicalDeposit.deposit;
@@ -806,11 +802,7 @@ export class BundleDataClient {
               slowFillRequest.blockNumber >= destinationChainBlockRange[0]
             ) {
               const historicalDeposit = await queryHistoricalDepositForFill(originClient, slowFillRequest);
-              if (
-                !historicalDeposit.found ||
-                !utils.isV3Deposit(historicalDeposit.deposit) ||
-                historicalDeposit.deposit.blockNumber > originChainBlockRange[1]
-              ) {
+              if (!historicalDeposit.found || !utils.isV3Deposit(historicalDeposit.deposit)) {
                 // TODO: Invalid slow fill request. Maybe worth logging.
                 return;
               }

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -909,7 +909,8 @@ export class BundleDataClient {
         // If we haven't seen a fill matching this deposit, then we need to rule out that it was filled a long time ago
         // by checkings its on-chain fill status.
         const fillStatus: BigNumber = await spokePoolClients[deposit.destinationChainId].spokePool.fillStatuses(
-          relayDataHash
+          relayDataHash,
+          { blockTag: destinationChainId[1] }
         );
         // If there is no matching fill and the deposit expired in this bundle and the fill status on-chain is not
         // Filled, then we can to refund it as an expired deposit.

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -640,11 +640,6 @@ export class BundleDataClient {
     const validatedBundleUnexecutableSlowFills: V3DepositWithBlock[] = [];
     for (const originChainId of allChainIds) {
       const originClient = spokePoolClients[originChainId];
-      const originChainBlockRange = getBlockRangeForChain(
-        blockRangesForChains,
-        originChainId,
-        this.chainIdListForBundleEvaluationBlockNumbers
-      );
       for (const destinationChainId of allChainIds) {
         if (originChainId === destinationChainId) {
           continue;


### PR DESCRIPTION
This way the bundle contents shouldn't change depending on the fill status changing of an expired deposit