### PR TITLE
improve(SpokePoolClient): Fix re-export

### DIFF
--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,4 +1,0 @@
-import { clients } from "@across-protocol/sdk-v2";
-
-export type SpokePoolClient = clients.SpokePoolClient;
-export const { SpokePoolClient } = clients;

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,13 +1,4 @@
 import { clients } from "@across-protocol/sdk-v2";
-import { FundsDepositedEvent } from "../interfaces";
-import { isDefined } from "../utils/TypeGuards";
 
-export class SpokePoolClient extends clients.SpokePoolClient {
-  _isEarlyDeposit(depositEvent: FundsDepositedEvent, currentTime: number): boolean {
-    const hubCurrentTime = this.hubPoolClient?.currentTime;
-    if (!isDefined(hubCurrentTime)) {
-      throw new Error("HubPoolClient's currentTime is not defined");
-    }
-    return depositEvent.args.quoteTimestamp > currentTime || depositEvent.args.quoteTimestamp > hubCurrentTime;
-  }
-}
+export type SpokePoolClient = clients.SpokePoolClient;
+export const { SpokePoolClient } = clients;

--- a/src/clients/SpokePoolClient.ts
+++ b/src/clients/SpokePoolClient.ts
@@ -1,0 +1,4 @@
+import { clients } from "@across-protocol/sdk-v2";
+
+export type SpokePoolClient = clients.SpokePoolClient;
+export const { SpokePoolClient } = clients;

--- a/src/clients/bridges/ZKSyncAdapter.ts
+++ b/src/clients/bridges/ZKSyncAdapter.ts
@@ -12,7 +12,7 @@ import {
   getTokenAddress,
   TOKEN_SYMBOLS_MAP,
 } from "../../utils";
-import { SpokePoolClient } from "../SpokePoolClient";
+import { SpokePoolClient } from "../.";
 import assert from "assert";
 import * as zksync from "zksync-web3";
 import { CONTRACT_ADDRESSES } from "../../common";

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,11 +1,7 @@
-import { clients } from "@across-protocol/sdk-v2";
-
-export type SpokePoolClient = clients.SpokePoolClient;
-export const { SpokePoolClient } = clients;
-
 export * from "./BalanceAllocator";
 export * from "./BundleDataClient";
 export * from "./HubPoolClient";
+export * from "./SpokePoolClient";
 export * from "./ConfigStoreClient";
 export * from "./MultiCallerClient";
 export * from "./ProfitClient";

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -1,7 +1,11 @@
+import { clients } from "@across-protocol/sdk-v2";
+
+export type SpokePoolClient = clients.SpokePoolClient;
+export const { SpokePoolClient } = clients;
+
 export * from "./BalanceAllocator";
 export * from "./BundleDataClient";
 export * from "./HubPoolClient";
-export * from "./SpokePoolClient";
 export * from "./ConfigStoreClient";
 export * from "./MultiCallerClient";
 export * from "./ProfitClient";


### PR DESCRIPTION
Extending and exporting a the SpokePoolClient class frequently causes tsc warnings to be flagged when running with a locally linked sdk-v2. The errors seem to be anchored in tsc not resolving the inherited parts of the SpokePoolClient correctly - it seems to view the SpokePoolClient as an opaque class that only contains the locally-overridden methods.

Now that it's physically impossible for an early v2 deposit event to occur, remove the override and revert to simply exporting directly.