### PR TITLE
improve(Relayer): Fallback to destination chain when resolving repayment chain ID

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -68,6 +68,7 @@ export type V2FillProfit = FillProfitCommon & {
 };
 
 export type V3FillProfit = FillProfitCommon & {
+  totalFeePct: BigNumber; // Total fee as a portion of the fill amount.
   inputTokenPriceUsd: BigNumber;
   inputAmountUsd: BigNumber;
   outputTokenPriceUsd: BigNumber;
@@ -411,6 +412,8 @@ export class ProfitClient {
     const scaledOutputAmount = effectiveOutputAmount.mul(outputTokenScalar);
     const outputAmountUsd = scaledOutputAmount.mul(outputTokenPriceUsd).div(fixedPoint);
 
+    const totalFeePct = inputAmountUsd.sub(outputAmountUsd).mul(fixedPoint).div(inputAmountUsd);
+
     // Normalise token amounts to USD terms.
     const scaledLpFeeAmount = scaledInputAmount.mul(lpFeePct).div(fixedPoint);
     const lpFeeUsd = scaledLpFeeAmount.mul(inputTokenPriceUsd).div(fixedPoint);
@@ -441,6 +444,7 @@ export class ProfitClient {
       netRelayerFeePct.gte(minRelayerFeePct);
 
     return {
+      totalFeePct,
       inputTokenPriceUsd,
       inputAmountUsd,
       outputTokenPriceUsd,
@@ -523,6 +527,7 @@ export class ProfitClient {
           inputTokenAmountUsd: formatEther(fill.inputAmountUsd),
           outputTokenPriceUsd: formatEther(fill.inputTokenPriceUsd),
           outputTokenAmountUsd: formatEther(fill.outputAmountUsd),
+          totalFeePct: `${formatFeePct(fill.totalFeePct)}%`,
           lpFeePct: `${formatFeePct(lpFeePct)}%`,
           grossRelayerFeePct: `${formatFeePct(fill.grossRelayerFeePct)}%`,
           nativeGasCost: fill.nativeGasCost,

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -601,20 +601,20 @@ export class Relayer {
       grossRelayerFeePct: relayerFeePct,
     } = await profitClient.isFillProfitable(deposit, fillAmount, realizedLpFeePct, hubPoolToken);
 
-    // If preferred chain is mainnet and that is different from the destination chain and the preferred chain
+    // If preferred chain is different from the destination chain and the preferred chain
     // is not profitable, then check if the destination chain is profitable.
     // This assumes that the depositor is getting quotes from the /suggested-fees endpoint
     // in the frontend-v2 repo which assumes that repayment is the destination chain. If this is profitable, then
     // go ahead and use the preferred chain as repayment and log the lp fee loss. This is a temporary solution
     // so that depositors can continue to quote lp fees assuming repayment is on the destination chain until
     // we come up with a smarter profitability check.
-    if (!profitable && preferredChainId === hubPoolClient.chainId && preferredChainId !== destinationChainId) {
+    if (!profitable && preferredChainId !== destinationChainId && sdkUtils.isV3Deposit(deposit)) {
       this.logger.debug({
         at: "Relayer",
         message: `Preferred chain ${preferredChainId} is not profitable. Checking destination chain ${destinationChainId} profitability.`,
         deposit: { originChain, depositId, destinationChain, depositHash },
       });
-      const { realizedLpFeePct: destinationChainLpFeePct } = sdkUtils.isV3Deposit(deposit)
+      const { realizedLpFeePct: destinationChainLpFeePct } = deposit
         ? await hubPoolClient.computeRealizedLpFeePct({ ...deposit, paymentChainId: destinationChainId })
         : deposit;
       const fallbackProfitability = await profitClient.isFillProfitable(

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -574,6 +574,7 @@ export class Relayer {
     const { hubPoolClient, inventoryClient, profitClient } = this.clients;
     const { depositId, originChainId, destinationChainId, transactionHash: depositHash } = deposit;
     const outputAmount = sdkUtils.getDepositOutputAmount(deposit);
+    const inputAmount = sdkUtils.getDepositInputAmount(deposit);
     const originChain = getNetworkName(originChainId);
     const destinationChain = getNetworkName(destinationChainId);
 
@@ -624,6 +625,11 @@ export class Relayer {
           at: "Relayer",
           message: `Alternative repayment chain ${destinationChainId} is profitable.`,
           deposit: { originChain, depositId, destinationChain, depositHash },
+          realizedLpFeePct: fallbackRealizedLpFeePct,
+          relayerFeePct: fallbackProfitability.grossRelayerFeePct,
+          inputAmount,
+          outputAmount,
+          hubPoolToken: hubPoolToken.symbol,
         });
         return {
           gasLimit: fallbackProfitability.nativeGasCost,
@@ -637,9 +643,25 @@ export class Relayer {
           at: "Relayer",
           message: `Alternative repayment chain ${destinationChainId} is also not profitable.`,
           deposit: { originChain, depositId, destinationChain, depositHash },
+          realizedLpFeePct: fallbackRealizedLpFeePct,
+          relayerFeePct: fallbackProfitability.grossRelayerFeePct,
+          inputAmount,
+          outputAmount,
+          hubPoolToken: hubPoolToken.symbol,
         });
       }
     }
+
+    this.logger.debug({
+      at: "Relayer",
+      message: `Preferred chain ${preferredChainId} is${profitable ? "" : " not"} profitable.`,
+      deposit: { originChain, depositId, destinationChain, depositHash },
+      realizedLpFeePct,
+      relayerFeePct,
+      inputAmount,
+      outputAmount,
+      hubPoolToken: hubPoolToken.symbol,
+    });
 
     return {
       gasLimit,


### PR DESCRIPTION
If preferred chain is not destination chain and destination chain is not 1 and preferred chain is not profitable, then try checking profitability of destination chain. If destination chain is profitable, still use preferred chain as repayment, and log the loss. This avoids penalizing honest depositors who set lp fee according to quote API which assumes payment chain is dest. chain.

This should allow the suggested-fees API to go back to quoting just the destination chain for quotes, which is usually the case for relays unless we're overallocated on a chain