### PR TITLE
improve: Add InvalidSlowFillRequest known reason to MultiCallerClient

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -24,7 +24,13 @@ import lodash from "lodash";
 // .includes() to partially match reason string in order to not ignore errors thrown by non-contract reverts.
 // For example, a NodeJS error might result in a reason string that includes more than just the contract r
 // evert reason.
-export const knownRevertReasons = new Set(["relay filled", "Already claimed", "RelayFilled", "ClaimedMerkleLeaf"]);
+export const knownRevertReasons = new Set([
+  "relay filled",
+  "Already claimed",
+  "RelayFilled",
+  "ClaimedMerkleLeaf",
+  "InvalidSlowFillRequest",
+]);
 
 // The following reason potentially includes false positives of reverts that we should be alerted on, however
 // there is something likely broken in how the provider is interpreting contract reverts. Currently, there are
@@ -445,11 +451,14 @@ export class MultiCallerClient {
   // string that includes more than just the contract revert reason.
   protected canIgnoreRevertReason(txn: TransactionSimulationResult): boolean {
     const { transaction: _txn, reason } = txn;
-    const knownReason = [...knownRevertReasons].some((knownReason) => reason.includes(knownReason));
+    const lowerCaseReason = reason.toLowerCase();
+    const knownReason = [...knownRevertReasons].some((knownReason) =>
+      lowerCaseReason.includes(knownReason.toLowerCase())
+    );
     return (
       knownReason ||
       (unknownRevertReasonMethodsToIgnore.has(_txn.method) &&
-        unknownRevertReasons.some((_reason) => reason.includes(_reason)))
+        unknownRevertReasons.some((_reason) => lowerCaseReason.includes(_reason.toLowerCase())))
     );
   }
 


### PR DESCRIPTION
This gets emitted when a slow fill request has already been sent for a relay hash.

Also adds case insensitivity to multicaller client
