### PR TITLE
fix(BundleDataClient): When historical deposit is found, save into v3RelayHash

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -734,7 +734,7 @@ export class BundleDataClient {
                   ...fill,
                   quoteTimestamp: matchedDeposit.quoteTimestamp,
                 });
-
+                v3RelayHashes[relayDataHash].deposit = matchedDeposit;
                 if (fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill) {
                   fastFillsReplacingSlowFills.push(relayDataHash);
                 }
@@ -821,6 +821,7 @@ export class BundleDataClient {
               // sanity check it here by comparing the full relay hashes. If there's an error here then the
               // historical deposit query is not working as expected.
               assert(utils.getV3RelayHashFromEvent(matchedDeposit) === relayDataHash);
+              v3RelayHashes[relayDataHash].deposit = matchedDeposit;
 
               // Note: we don't need to query for a historical fill at this point because a fill
               // cannot precede a slow fill request and if the fill came after the slow fill request,

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -231,7 +231,6 @@ export class InventoryClient {
       // Consider any refunds from executed and to-be executed bundles.
       totalRefundsPerChain = await this.getBundleRefunds(l1Token);
     } catch (e) {
-      console.error(e)
       this.log("Failed to get bundle refunds, defaulting refund chain to hub chain");
       // Fallback to getting refunds on Mainnet if calculating bundle refunds goes wrong.
       // Inventory management can always rebalance from Mainnet to other chains easily if needed.

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -231,6 +231,7 @@ export class InventoryClient {
       // Consider any refunds from executed and to-be executed bundles.
       totalRefundsPerChain = await this.getBundleRefunds(l1Token);
     } catch (e) {
+      console.error(e)
       this.log("Failed to get bundle refunds, defaulting refund chain to hub chain");
       // Fallback to getting refunds on Mainnet if calculating bundle refunds goes wrong.
       // Inventory management can always rebalance from Mainnet to other chains easily if needed.


### PR DESCRIPTION
We should save matched deposits into the dictionary, otherwise we violate an assumption that fiulls/slow fill requests that matched deposits have those deposits stored in memory