### PR TITLE
fix(MulticallerClient): Remove error reason that is produces false positives

### DIFF
--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -38,7 +38,7 @@ export const knownRevertReasons = new Set([
 // to execute a relayer refund leaf takes a while to execute and ends up reverting because a duplicate transaction
 // mines before it. This situation leads to this revert reason which is spamming the Logger currently.
 export const unknownRevertReasons = [
-  "missing revert data in call exception; Transaction reverted without a reason string"
+  "missing revert data in call exception; Transaction reverted without a reason string",
 ];
 export const unknownRevertReasonMethodsToIgnore = new Set([
   "multicall",

--- a/src/clients/MultiCallerClient.ts
+++ b/src/clients/MultiCallerClient.ts
@@ -38,9 +38,7 @@ export const knownRevertReasons = new Set([
 // to execute a relayer refund leaf takes a while to execute and ends up reverting because a duplicate transaction
 // mines before it. This situation leads to this revert reason which is spamming the Logger currently.
 export const unknownRevertReasons = [
-  "missing revert data in call exception; Transaction reverted without a reason string",
-  // execution reverted is the error reason when a require statement with a custom error is thrown.
-  "execution reverted",
+  "missing revert data in call exception; Transaction reverted without a reason string"
 ];
 export const unknownRevertReasonMethodsToIgnore = new Set([
   "multicall",


### PR DESCRIPTION
Ignoring "execution reverted" is supressing some legitimate warnings like SpokePool being out of funds to execute a leaf