### PR TITLE
chore: Drop Dataworker v2 deposit-related events

### DIFF
--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -86,7 +86,6 @@ export async function constructSpokePoolClientsForFastDataworker(
     "RelayedRootBundle",
     "ExecutedRelayerRefundRoot",
     "V3FundsDeposited",
-    "RequestedSpeedUpV3Deposit",
     "RequestedV3SlowFill",
     "FilledV3Relay",
   ]);

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -81,8 +81,6 @@ export async function constructSpokePoolClientsForFastDataworker(
     endBlocks
   );
   await updateSpokePoolClients(spokePoolClients, [
-    "FundsDeposited",
-    "RequestedSpeedUpDeposit",
     "FilledRelay",
     "EnabledDepositRoute",
     "RelayedRootBundle",

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -86,6 +86,7 @@ export async function constructSpokePoolClientsForFastDataworker(
     "RelayedRootBundle",
     "ExecutedRelayerRefundRoot",
     "V3FundsDeposited",
+    "RequestedSpeedUpV3Deposit",
     "RequestedV3SlowFill",
     "FilledV3Relay",
   ]);


### PR DESCRIPTION
The Dataworker lookbacks are now short enough that they won't see any FundsDeposited events. RequestedSpeedUpEvents actually seem irrelevant here as well. We can technically still see these, but they're not used for validating fills.