### PR TITLE
fix: reinstate logic for testnets

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=16.18.0"
   },
   "dependencies": {
-    "@across-protocol/constants-v2": "1.0.8",
+    "@across-protocol/constants-v2": "1.0.11",
     "@across-protocol/contracts-v2": "2.5.0-beta.7",
     "@across-protocol/sdk-v2": "0.22.6",
     "@arbitrum/sdk": "^3.1.3",

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -20,6 +20,7 @@ export type ERC20 = {
 const fallbackProviders: { [chainId: number]: string } = {
   [CHAIN_IDs.MAINNET]: "https://eth.llamarpc.com",
   [CHAIN_IDs.GOERLI]: "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
+  [CHAIN_IDs.SEPOLIA]: "https://sepolia.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161",
 };
 
 async function askQuestion(query: string) {
@@ -105,7 +106,7 @@ export function resolveHubChainId(spokeChainId: number): number {
   }
 
   assert(sdkUtils.chainIsTestnet(spokeChainId), `Unsupported testnet SpokePool chain ID: ${spokeChainId}`);
-  return CHAIN_IDs.GOERLI;
+  return CHAIN_IDs.SEPOLIA;
 }
 
 /**

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -111,7 +111,11 @@ const QUERY_HANDLERS: {
   420: relayFeeCalculator.OptimismGoerliQueries,
   80001: relayFeeCalculator.PolygonMumbaiQueries,
   84531: relayFeeCalculator.BaseGoerliQueries,
+  84532: relayFeeCalculator.BaseSepoliaQueries,
   421613: relayFeeCalculator.ArbitrumGoerliQueries,
+  421614: relayFeeCalculator.ArbitrumSepoliaQueries,
+  11155111: relayFeeCalculator.EthereumSepoliaQueries,
+  11155420: relayFeeCalculator.OptimismSepoliaQueries,
 };
 
 const { PriceClient } = priceClient;
@@ -618,13 +622,31 @@ export class ProfitClient {
   protected async updateTokenPrices(): Promise<void> {
     // Generate list of tokens to retrieve. Map by symbol because tokens like
     // ETH/WETH refer to the same mainnet contract address.
-    const tokens: { [symbol: string]: string } = Object.fromEntries(
-      this.hubPoolClient.getL1Tokens().map(({ symbol }) => {
-        const { addresses } = TOKEN_SYMBOLS_MAP[symbol];
-        const address = addresses[1];
-        return [symbol, address];
-      })
+    const tokens: { [_symbol: string]: string } = Object.fromEntries(
+      this.hubPoolClient
+        .getL1Tokens()
+        .filter(({ symbol }) => isDefined(TOKEN_SYMBOLS_MAP[symbol]))
+        .map(({ symbol }) => {
+          const { addresses } = TOKEN_SYMBOLS_MAP[symbol];
+          const address = addresses[1];
+          return [symbol, address];
+        })
     );
+
+    // Log any tokens that are in the L1Tokens list but are not in the tokenSymbolsMap.
+    // Note: we should batch these up and log them all at once to avoid spamming the logs.
+    const unknownTokens = this.hubPoolClient
+      .getL1Tokens()
+      .filter(({ symbol }) => !isDefined(TOKEN_SYMBOLS_MAP[symbol]));
+    if (unknownTokens.length > 0) {
+      this.logger.warn({
+        at: "ProfitClient#updateTokenPrices",
+        message: "Filtered out unknown token(s) that don't have a corresponding entry in TOKEN_SYMBOLS_MAP.",
+        unknownTokens,
+        resolvedTokens: Object.keys(tokens),
+        availableTokens: Object.keys(TOKEN_SYMBOLS_MAP),
+      });
+    }
 
     // Also ensure all gas tokens are included in the lookup.
     this.enabledChainIds.forEach((chainId) => {

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -60,7 +60,11 @@ export const DEFAULT_MIN_DEPOSIT_CONFIRMATIONS = {
   420: 0,
   80001: 0,
   84531: 0,
+  84532: 0,
   421613: 0,
+  421614: 0,
+  11155111: 0,
+  11155420: 0,
 };
 export const MIN_DEPOSIT_CONFIRMATIONS: { [threshold: number | string]: { [chainId: number]: number } } = {
   1000: {
@@ -118,7 +122,11 @@ export const CHAIN_MAX_BLOCK_LOOKBACK = {
   420: 10000,
   80001: 10000,
   84531: 10000,
+  84532: 10000,
   421613: 10000,
+  421614: 10000,
+  11155111: 10000,
+  11155420: 10000,
 };
 
 export const BUNDLE_END_BLOCK_BUFFERS = {
@@ -135,7 +143,11 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
   420: 0,
   80001: 0,
   84531: 0,
+  84532: 0,
   421613: 0,
+  421614: 0,
+  11155111: 0,
+  11155420: 0,
 };
 
 export const DEFAULT_RELAYER_GAS_PADDING = ".15"; // Padding on token- and message-based relayer fill gas estimates.
@@ -170,14 +182,16 @@ export const CHAIN_CACHE_FOLLOW_DISTANCE: { [chainId: number]: number } = {
   534352: 0,
   // Testnets:
   5: 0,
-  11155111: 0,
   280: 0,
   420: 0,
   80001: 0,
   84531: 0,
   84532: 0,
   421613: 0,
+  421614: 0,
   534351: 0,
+  11155111: 0,
+  11155420: 0,
 };
 
 // Reasonable default maxFeePerGas and maxPriorityFeePerGas scalers for each chain.

--- a/src/dataworker/DataworkerConfig.ts
+++ b/src/dataworker/DataworkerConfig.ts
@@ -108,10 +108,16 @@ export class DataworkerConfig extends CommonConfig {
         assert(Array.isArray(bundleRange), `forceProposalBundleRange[${index}] is not an array`);
         assert(bundleRange.length === 2, `forceProposalBundleRange[${index}] does not have length 2`);
         const [start, end] = bundleRange;
-        assert(typeof start === "number", `forceProposalBundleRange[${index}][start] is not a number`);
-        assert(typeof end === "number", `forceProposalBundleRange[${index}][end] is not a number`);
-        assert(start > 0, `forceProposalBundleRange[${index}][start] is not positive`);
-        assert(end > 0, `forceProposalBundleRange[${index}][end] is not positive`);
+        assert(
+          typeof start === "number" && Number.isInteger(start),
+          `forceProposalBundleRange[${index}][start] is not a number`
+        );
+        assert(
+          typeof end === "number" && Number.isInteger(end),
+          `forceProposalBundleRange[${index}][end] is not a number`
+        );
+        assert(start >= 0, `forceProposalBundleRange[${index}][start] is not non-negative`);
+        assert(end >= 0, `forceProposalBundleRange[${index}][end] is not non-negative`);
         assert(start <= end, `forceProposalBundleRange[${index}][start] >= forceProposalBundleRange[${index}][end]`);
       });
     } else {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -250,7 +250,10 @@ export class Relayer {
     const mdcPerChain = Object.fromEntries(
       Object.entries(unfilledDepositAmountsPerChain).map(([chainId, unfilledAmount]) => {
         const usdThreshold = minimumDepositConfirmationThresholds.find((_usdThreshold) => {
-          return toBNWei(_usdThreshold).gte(unfilledAmount);
+          return (
+            toBNWei(_usdThreshold).gte(unfilledAmount) &&
+            isDefined(config.minDepositConfirmations[_usdThreshold][chainId])
+          );
         });
         // If no thresholds are greater than unfilled amount, then use fallback which should have largest MDCs.
         return [chainId, config.minDepositConfirmations[usdThreshold ?? "default"][chainId]];

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,12 +11,7 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants-v2@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.8.tgz#0f4dc9fbcf7b99dd895a06bb6070b5d3c8e1188d"
-  integrity sha512-7rygtlYseWNI/5ocIT9SXYu6L86oQbKTtFNAOw5MqD53bbsREzRy5dU0wkUHJzvHiNIQ+iawKnzprqshHHeRKw==
-
-"@across-protocol/constants-v2@^1.0.11":
+"@across-protocol/constants-v2@1.0.11", "@across-protocol/constants-v2@^1.0.11":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.11.tgz#58d34b5cb50351d097f2ca43c5a30b5908faed7c"
   integrity sha512-RpseYB2QxGyfyrfXtUeFxUSCUW1zqu442QFzsdD1LBZtymuzdHuL2MwtTdmRRnJSvzRTFTtlRh4bYDoExSb5zQ==


### PR DESCRIPTION
This PR (https://github.com/across-protocol/relayer-v2/pull/1185) was merged into `npai/v3Dataworker`. It was not automatically rebased like GitHub does when `npai/v3Dataworker` was merged.

This current PR aims to reinstate the logic that should've been added to master.

Note: please refer to these comments as the code should be the same https://github.com/across-protocol/relayer-v2/pull/1185