### PR TITLE
feat: add a block distance after which we set no TTL in redis

### DIFF
--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -194,6 +194,20 @@ export const CHAIN_CACHE_FOLLOW_DISTANCE: { [chainId: number]: number } = {
   11155420: 0,
 };
 
+// This is the block distance at which the bot, by default, stores in redis with no TTL.
+// These are all intended to be roughly 2 days of blocks for each chain.
+// blocks = 172800 / avg_block_time
+export const DEFAULT_NO_TTL_DISTANCE: { [chainId: number]: number } = {
+  1: 14400,
+  10: 86400,
+  137: 86400,
+  288: 86400,
+  324: 172800,
+  8453: 86400,
+  42161: 691200,
+  534352: 57600,
+};
+
 // Reasonable default maxFeePerGas and maxPriorityFeePerGas scalers for each chain.
 export const DEFAULT_GAS_FEE_SCALERS: {
   [chainId: number]: { maxFeePerGasScaler: number; maxPriorityFeePerGasScaler: number };

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -564,9 +564,7 @@ export async function getProvider(chainId: number, logger?: winston.Logger, useC
 
   const disableNoTtl = process.env["DISABLE_NO_TTL"] === "true";
 
-  const noTtlBlockDistance = process.env[`NO_TTL_BLOCK_DISTANCE_${chainId}`]
-    ? Number(process.env[`NO_TTL_BLOCK_DISTANCE_${chainId}`])
-    : DEFAULT_NO_TTL_DISTANCE[chainId];
+  const noTtlBlockDistance = Number(process.env[`NO_TTL_BLOCK_DISTANCE_${chainId}`] ?? DEFAULT_NO_TTL_DISTANCE[chainId]);
 
   // Provider caching defaults to being enabled if a redis instance exists. It can be manually disabled by setting
   // NODE_DISABLE_PROVIDER_CACHING=true.

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -564,7 +564,12 @@ export async function getProvider(chainId: number, logger?: winston.Logger, useC
 
   const disableNoTtl = process.env["DISABLE_NO_TTL"] === "true";
 
-  const noTtlBlockDistance = Number(process.env[`NO_TTL_BLOCK_DISTANCE_${chainId}`] ?? DEFAULT_NO_TTL_DISTANCE[chainId]);
+  // Note: if there is no env var override _and_ no default, this will remain undefined and
+  // effectively disable indefinite caching of old blocks/keys.
+  const noTtlBlockDistanceKey = `NO_TTL_BLOCK_DISTANCE_${chainId}`;
+  const noTtlBlockDistance: number | undefined = process.env[noTtlBlockDistanceKey]
+    ? Number(process.env[noTtlBlockDistanceKey])
+    : DEFAULT_NO_TTL_DISTANCE[chainId];
 
   // Provider caching defaults to being enabled if a redis instance exists. It can be manually disabled by setting
   // NODE_DISABLE_PROVIDER_CACHING=true.

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -124,7 +124,7 @@ class CacheProvider extends RateLimitedProvider {
     providerCacheNamespace: string,
     readonly redisClient?: RedisClient,
     // Note: if not provided, this is set to POSITIVE_INFINITY, meaning the TTL is infinite (i.e. no TTL).
-    readonly noTtlBlockDistance: number = Number.POSITIVE_INFINITY,
+    readonly noTtlBlockDistance = Number.POSITIVE_INFINITY,
     ...jsonRpcConstructorParams: ConstructorParameters<typeof RateLimitedProvider>
   ) {
     super(...jsonRpcConstructorParams);

--- a/src/utils/RedisUtils.ts
+++ b/src/utils/RedisUtils.ts
@@ -41,7 +41,10 @@ export class RedisClient {
   async set(key: string, val: string, expirySeconds = constants.DEFAULT_CACHING_TTL): Promise<void> {
     // Apply namespace to key.
     key = this.getNamespacedKey(key);
-    if (expirySeconds > 0) {
+    if (expirySeconds === Number.POSITIVE_INFINITY) {
+      // No TTL
+      await this.client.set(key, val);
+    } else if (expirySeconds > 0) {
       // EX: Expire key after expirySeconds.
       await this.client.set(key, val, { EX: expirySeconds });
     } else {


### PR DESCRIPTION
This changes the behavior of the provider caching system s.t. after a certain per-chain block distance in the past, we add no TTL so the cache stores it forever until it is forcibly evicted by redis's max mem eviction policy.