### PR TITLE
fix(ProfitClient): Don't attempt to fill reverting testnet txns

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -581,7 +581,7 @@ export class ProfitClient {
     }
 
     return {
-      profitable: profitable || this.isTestnet,
+      profitable: profitable || (this.isTestnet && nativeGasCost.lt(uint256Max)),
       nativeGasCost,
       tokenGasCost,
       grossRelayerFeePct,


### PR DESCRIPTION
Identified during the hackathon - a reverting deposit was incorrectly being bundled into a multicall and forcing the entire multicall to fail.