### PR TITLE
refactor: Simplify FillUtils getUnfilledDeposits()

### DIFF
--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -1,4 +1,3 @@
-import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { BalanceAllocator } from "../clients";
 import { spokePoolClientsToProviders } from "../common";
 import {
@@ -186,15 +185,15 @@ export class Monitor {
 
     // Group unfilled amounts by chain id and token id.
     const unfilledAmountByChainAndToken: { [chainId: number]: { [tokenAddress: string]: BigNumber } } = {};
-    for (const deposit of unfilledDeposits) {
-      const chainId = deposit.deposit.destinationChainId;
-      const outputToken = sdkUtils.getDepositOutputToken(deposit.deposit);
+    Object.entries(unfilledDeposits).forEach(([_destinationChainId, deposits]) => {
+      const chainId = Number(_destinationChainId);
       unfilledAmountByChainAndToken[chainId] ??= {};
-      unfilledAmountByChainAndToken[chainId][outputToken] ??= bnZero;
-      unfilledAmountByChainAndToken[chainId][outputToken] = unfilledAmountByChainAndToken[chainId][outputToken].add(
-        deposit.unfilledAmount
-      );
-    }
+
+      deposits.forEach(({ deposit: { outputToken, outputAmount } }) => {
+        const unfilledAmount = unfilledAmountByChainAndToken[chainId][outputToken] ?? bnZero;
+        unfilledAmountByChainAndToken[chainId][outputToken] = unfilledAmount.add(outputAmount);
+      });
+    });
 
     let mrkdwn = "";
     for (const [chainIdStr, amountByToken] of Object.entries(unfilledAmountByChainAndToken)) {

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -48,7 +48,10 @@ export class Relayer {
     const { configStoreClient, hubPoolClient, spokePoolClients, acrossApiClient } = this.clients;
     const { relayerTokens, ignoredAddresses, acceptInvalidFills } = this.config;
 
-    const unfilledDeposits = await getUnfilledDeposits(spokePoolClients, hubPoolClient, this.config.maxRelayerLookBack);
+    // Flatten unfilledDeposits for now. @todo: Process deposits in parallel by destination chain.
+    const unfilledDeposits = Object.values(
+      await getUnfilledDeposits(spokePoolClients, hubPoolClient, this.config.maxRelayerLookBack)
+    ).flat();
 
     const maxVersion = configStoreClient.configStoreVersion;
     return sdkUtils.filterAsync(unfilledDeposits, async ({ deposit, version, invalidFills }) => {

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -153,9 +153,8 @@ describe("Relayer: Unfilled Deposits", async function () {
     await Promise.all([spokePool_1, spokePool_2].map((spokePool) => spokePool.setCurrentTime(currentTime)));
     await updateAllClients();
 
-    _getUnfilledDeposits = async (): Promise<RelayerUnfilledDeposit[]> => {
-      return await getUnfilledDeposits(relayerInstance.clients.spokePoolClients, hubPoolClient);
-    };
+    _getUnfilledDeposits = async (): Promise<RelayerUnfilledDeposit[]> =>
+      Object.values(await getUnfilledDeposits(relayerInstance.clients.spokePoolClients, hubPoolClient)).flat();
     unfilledDeposits = [];
 
     const tokenBalance = await erc20_1.balanceOf(depositor.address);
@@ -181,13 +180,15 @@ describe("Relayer: Unfilled Deposits", async function () {
     expect(unfilledDeposits)
       .excludingEvery(["realizedLpFeePct", "quoteBlockNumber"])
       .to.deep.equal(
-        deposits.map((deposit) => ({
-          unfilledAmount: deposit.outputAmount,
-          deposit,
-          fillCount: 0,
-          invalidFills: [],
-          version: configStoreClient.configStoreVersion,
-        }))
+        [...deposits]
+          .sort((a, b) => (a.destinationChainId > b.destinationChainId ? 1 : -1))
+          .map((deposit) => ({
+            unfilledAmount: deposit.outputAmount,
+            deposit,
+            fillCount: 0,
+            invalidFills: [],
+            version: configStoreClient.configStoreVersion,
+          }))
       );
   });
 


### PR DESCRIPTION
This is an incremental change to drop some unneeded members from the return type, and to return an Object of destination chain => unfilled deposits array. This permits the caller to keep the unfilled deposits segregated, which fits future use cases pretty well.

This is take #2 at this change, since the original commit incorrectly handled the deposit filtering based on the block lookback by applying the wrong "low block" for each chain Id.