### PR TITLE
refactor(ProfitClient): Update tests for v3

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -437,7 +437,7 @@ export class ProfitClient {
 
     // Determine profitability.
     const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd);
-    const netRelayerFeePct = inputAmountUsd.gt(bnZero) ? netRelayerFeeUsd.mul(fixedPoint).div(inputAmountUsd) : bnZero;
+    const netRelayerFeePct = outputAmountUsd.gt(bnZero) ? netRelayerFeeUsd.mul(fixedPoint).div(outputAmountUsd) : bnZero;
 
     // If either token prices are unknown, assume the relay is unprofitable. Force non-equivalent tokens
     // to be unprofitable for now. The relayer may be updated in future to support in-protocol swaps.

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -437,7 +437,9 @@ export class ProfitClient {
 
     // Determine profitability.
     const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd);
-    const netRelayerFeePct = outputAmountUsd.gt(bnZero) ? netRelayerFeeUsd.mul(fixedPoint).div(outputAmountUsd) : bnZero;
+    const netRelayerFeePct = outputAmountUsd.gt(bnZero)
+      ? netRelayerFeeUsd.mul(fixedPoint).div(outputAmountUsd)
+      : bnZero;
 
     // If either token prices are unknown, assume the relay is unprofitable. Force non-equivalent tokens
     // to be unprofitable for now. The relayer may be updated in future to support in-protocol swaps.

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -435,7 +435,8 @@ export class ProfitClient {
       deposit.outputAmount
     );
 
-    // Determine profitability.
+    // Determine profitability. netRelayerFeePct effectively represents the capital cost to the relayer;
+    // i.e. how much it pays out to the recipient vs. the net fee that it receives for doing so.
     const netRelayerFeeUsd = grossRelayerFeeUsd.sub(gasCostUsd);
     const netRelayerFeePct = outputAmountUsd.gt(bnZero)
       ? netRelayerFeeUsd.mul(fixedPoint).div(outputAmountUsd)

--- a/test/ProfitClient.ConsiderProfitability.ts
+++ b/test/ProfitClient.ConsiderProfitability.ts
@@ -71,7 +71,7 @@ describe("ProfitClient: Consider relay profit", () => {
   const randomiseGasCost = (chainId: number): TransactionCostEstimate & { gasTokenPriceUsd: BigNumber } => {
     // Randomise the gas token price (usd)
     const gasToken = profitClient.resolveGasToken(chainId);
-    const gasTokenPriceUsd = profitClient.getPriceOfToken(gasToken.symbol);
+    const gasTokenPriceUsd = toBNWei(Math.random().toFixed(18));
 
     // Randomise the fillRelay cost in units of gas.
     const nativeGasCost = toBN(random(80_000, 100_000));
@@ -428,7 +428,12 @@ describe("ProfitClient: Consider relay profit", () => {
               netRelayerFeeUsd: formatEther(expected.netRelayerFeeUsd),
             });
 
-            const { profitable } = await profitClient.isFillProfitable(deposit, deposit.outputAmount, effectiveLpFeePct, token);
+            const { profitable } = await profitClient.isFillProfitable(
+              deposit,
+              deposit.outputAmount,
+              effectiveLpFeePct,
+              token
+            );
             expect(profitable).to.equal(expected.profitable);
           }
         }


### PR DESCRIPTION
This change upgrades all ProfitClient tests to v3. It's submitted in advance of a subsequent PR to remove all v2 support from the ProfitClient.