### PR TITLE
improve(ProfitClient): Permit applying gas multipler on message fills

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -278,7 +278,7 @@ export class ProfitClient {
     // @todo Consider phasing this out and relying solely on the minimum profitability config.
     if (isMessageEmpty(resolveDepositMessage(deposit))) {
       tokenGasCost = tokenGasCost.mul(this.gasMultiplier).div(fixedPoint);
-    } else if (isDefined(process.env.RELAYER_GAS_MULTIPLIER_MESSAGES)) {
+    } else if (isDefined(process.env.RELAYER_MESSAGE_GAS_MULTIPLIER)) {
       // @todo: Parse this in RelayerConfig and pass it in via the constructor.
       tokenGasCost = tokenGasCost.mul(process.env.RELAYER_MESSAGE_GAS_MULTIPLIER).div(fixedPoint);
     }

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -278,6 +278,9 @@ export class ProfitClient {
     // @todo Consider phasing this out and relying solely on the minimum profitability config.
     if (isMessageEmpty(resolveDepositMessage(deposit))) {
       tokenGasCost = tokenGasCost.mul(this.gasMultiplier).div(fixedPoint);
+    } else if (isDefined(process.env.RELAYER_GAS_MULTIPLIER_MESSAGES)) {
+      // @todo: Parse this in RelayerConfig and pass it in via the constructor.
+      tokenGasCost = tokenGasCost.mul(process.env.RELAYER_MESSAGE_GAS_MULTIPLIER).div(fixedPoint);
     }
 
     const gasCostUsd = tokenGasCost.mul(gasTokenPriceUsd).div(bn10.pow(gasToken.decimals));

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -52,6 +52,7 @@ export type FillProfitCommon = {
   tokenGasCost: BigNumber; // Cost of completing the fill in the relevant gas token.
   gasPadding: BigNumber; // Positive padding applied to nativeGasCost and tokenGasCost before profitability.
   gasMultiplier: BigNumber; // Multiplier applied to token-only fill cost estimates before profitability.
+  gasMessageMultiplier: BigNumber; // Multiplier applied to message fill cost estimates before profitability.
   gasTokenPriceUsd: BigNumber; // Price paid per unit of gas the gas token in USD.
   gasCostUsd: BigNumber; // Estimated cost of completing the fill in USD.
   netRelayerFeePct: BigNumber; // Relayer fee after gas costs as a portion of relayerCapitalUsd.
@@ -387,6 +388,7 @@ export class ProfitClient {
       tokenGasCost,
       gasPadding: this.gasPadding,
       gasMultiplier: this.gasMultiplier,
+      gasMessageMultiplier: this.gasMessageMultiplier,
       gasTokenPriceUsd,
       gasCostUsd,
       refundFeeUsd,
@@ -469,6 +471,7 @@ export class ProfitClient {
       tokenGasCost,
       gasPadding: this.gasPadding,
       gasMultiplier: this.gasMultiplier,
+      gasMessageMultiplier: this.gasMessageMultiplier,
       gasTokenPriceUsd,
       gasCostUsd,
       netRelayerFeePct,
@@ -548,6 +551,7 @@ export class ProfitClient {
           tokenGasCost: formatEther(fill.tokenGasCost),
           gasPadding: this.gasPadding,
           gasMultiplier: this.gasMultiplier,
+          gasMessageMultiplier: this.gasMessageMultiplier,
           gasTokenPriceUsd: formatEther(fill.gasTokenPriceUsd),
           grossRelayerFeeUsd: formatEther(fill.grossRelayerFeeUsd),
           gasCostUsd: formatEther(fill.gasCostUsd),

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -145,6 +145,7 @@ export class ProfitClient {
     readonly defaultMinRelayerFeePct = toBNWei(constants.RELAYER_MIN_FEE_PCT),
     readonly debugProfitability = false,
     protected gasMultiplier = toBNWei(constants.DEFAULT_RELAYER_GAS_MULTIPLIER),
+    protected gasMessageMultiplier = toBNWei(constants.DEFAULT_RELAYER_GAS_MESSAGE_MULTIPLIER),
     protected gasPadding = toBNWei(constants.DEFAULT_RELAYER_GAS_PADDING)
   ) {
     // Require 0% <= gasPadding <= 200%
@@ -159,6 +160,11 @@ export class ProfitClient {
       this.gasMultiplier.gte(bnZero) && this.gasMultiplier.lte(toBNWei(4)),
       `Gas multiplier out of range (${this.gasMultiplier})`
     );
+    assert(
+      this.gasMessageMultiplier.gte(bnZero) && this.gasMessageMultiplier.lte(toBNWei(4)),
+      `Gas message multiplier out of range (${this.gasMessageMultiplier})`
+    );
+
     this.priceClient = new PriceClient(logger, [
       new acrossApi.PriceFeed(),
       new coingecko.PriceFeed({ apiKey: process.env.COINGECKO_PRO_API_KEY }),
@@ -276,12 +282,10 @@ export class ProfitClient {
     // Gas estimates for token-only fills are stable and reliable. Allow these to be scaled up or down via the
     // configured gasMultiplier. Do not scale the nativeGasCost, since it might be used to set the transaction gasLimit.
     // @todo Consider phasing this out and relying solely on the minimum profitability config.
-    if (isMessageEmpty(resolveDepositMessage(deposit))) {
-      tokenGasCost = tokenGasCost.mul(this.gasMultiplier).div(fixedPoint);
-    } else if (isDefined(process.env.RELAYER_MESSAGE_GAS_MULTIPLIER)) {
-      // @todo: Parse this in RelayerConfig and pass it in via the constructor.
-      tokenGasCost = tokenGasCost.mul(process.env.RELAYER_MESSAGE_GAS_MULTIPLIER).div(fixedPoint);
-    }
+    const gasMultiplier = isMessageEmpty(resolveDepositMessage(deposit))
+      ? this.gasMultiplier
+      : this.gasMessageMultiplier;
+    tokenGasCost = tokenGasCost.mul(gasMultiplier).div(fixedPoint);
 
     const gasCostUsd = tokenGasCost.mul(gasTokenPriceUsd).div(bn10.pow(gasToken.decimals));
 

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -152,6 +152,7 @@ export const BUNDLE_END_BLOCK_BUFFERS = {
 
 export const DEFAULT_RELAYER_GAS_PADDING = ".15"; // Padding on token- and message-based relayer fill gas estimates.
 export const DEFAULT_RELAYER_GAS_MULTIPLIER = "1.0"; // Multiplier on pre-profitability token-only gas estimates.
+export const DEFAULT_RELAYER_GAS_MESSAGE_MULTIPLIER = "1.0"; // Multiplier on pre-profitability message fill gas estimates.
 
 export const DEFAULT_MULTICALL_CHUNK_SIZE = 100;
 export const DEFAULT_CHAIN_MULTICALL_CHUNK_SIZE: { [chainId: number]: number } = {

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -79,6 +79,7 @@ export async function constructRelayerClients(
     config.minRelayerFeePct,
     config.debugProfitability,
     config.relayerGasMultiplier,
+    config.relayerMessageGasMultiplier,
     config.relayerGasPadding
   );
   await profitClient.update();

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -19,6 +19,7 @@ export class RelayerConfig extends CommonConfig {
   readonly relayerDestinationChains: number[] = [];
   readonly relayerGasPadding: BigNumber;
   readonly relayerGasMultiplier: BigNumber;
+  readonly relayerMessageGasMultiplier: BigNumber;
   readonly minRelayerFeePct: BigNumber;
   readonly acceptInvalidFills: boolean;
   // List of depositors we only want to send slow fills for.
@@ -37,6 +38,7 @@ export class RelayerConfig extends CommonConfig {
       RELAYER_DESTINATION_CHAINS,
       SLOW_DEPOSITORS,
       DEBUG_PROFITABILITY,
+      RELAYER_GAS_MESSAGE_MULTIPLIER,
       RELAYER_GAS_MULTIPLIER,
       RELAYER_GAS_PADDING,
       RELAYER_INVENTORY_CONFIG,
@@ -132,6 +134,9 @@ export class RelayerConfig extends CommonConfig {
     this.debugProfitability = DEBUG_PROFITABILITY === "true";
     this.relayerGasPadding = toBNWei(RELAYER_GAS_PADDING || Constants.DEFAULT_RELAYER_GAS_PADDING);
     this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
+    this.relayerMessageGasMultiplier = toBNWei(
+      RELAYER_GAS_MESSAGE_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MESSAGE_MULTIPLIER
+    );
     this.sendingRelaysEnabled = SEND_RELAYS === "true";
     this.sendingRebalancesEnabled = SEND_REBALANCES === "true";
     this.sendingMessageRelaysEnabled = SEND_MESSAGE_RELAYS === "true";

--- a/test/mocks/MockProfitClient.ts
+++ b/test/mocks/MockProfitClient.ts
@@ -20,6 +20,7 @@ export class MockProfitClient extends ProfitClient {
     defaultMinRelayerFeePct?: BigNumber,
     debugProfitability?: boolean,
     gasMultiplier = toBNWei("1"),
+    gasMessageMultiplier = toBNWei("1"),
     gasPadding = toBNWei("0")
   ) {
     super(
@@ -31,6 +32,7 @@ export class MockProfitClient extends ProfitClient {
       defaultMinRelayerFeePct,
       debugProfitability,
       gasMultiplier,
+      gasMessageMultiplier,
       gasPadding
     );
 


### PR DESCRIPTION
This change permits the relayer to have a separate gas multiplier for fills. This is desirable since fills with messages will typically have much higher gas consumption, so heavily discounting them is quite risky. However, ethers seems to over-estimate quite a bit, so it can be helpful to wind some of that back in some cases.