### PR TITLE
improve(dataworker): allow linea to execute relay leaves

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.12",
     "@across-protocol/contracts-v2": "2.5.0-beta.7",
-    "@across-protocol/sdk-v2": "0.22.6",
+    "@across-protocol/sdk-v2": "0.22.9",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=16.18.0"
   },
   "dependencies": {
-    "@across-protocol/constants-v2": "1.0.11",
+    "@across-protocol/constants-v2": "1.0.12",
     "@across-protocol/contracts-v2": "2.5.0-beta.7",
     "@across-protocol/sdk-v2": "0.22.6",
     "@arbitrum/sdk": "^3.1.3",

--- a/src/common/ContractAddresses.ts
+++ b/src/common/ContractAddresses.ts
@@ -39,6 +39,22 @@ const CCTP_MESSAGE_TRANSMITTER_CONTRACT_ABI = [
   },
 ];
 
+export const LINEA_L2_MESSAGE_SERVICE_CONTRACT_ABI = [
+  {
+    inputs: [],
+    name: "minimumFeeInWei",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
 // Constants file exporting hardcoded contract addresses per chain.
 export const CONTRACT_ADDRESSES: {
   [chainId: number]: {
@@ -848,7 +864,12 @@ export const CONTRACT_ADDRESSES: {
       abi: CCTP_MESSAGE_TRANSMITTER_CONTRACT_ABI,
     },
   },
-
+  59144: {
+    l2MessageService: {
+      address: "0x508Ca82Df566dCD1B0DE8296e70a96332cD644ec",
+      abi: LINEA_L2_MESSAGE_SERVICE_CONTRACT_ABI,
+    },
+  },
   // Testnets
   11155111: {
     cctpMessageTransmitter: {
@@ -860,6 +881,12 @@ export const CONTRACT_ADDRESSES: {
     cctpMessageTransmitter: {
       address: "0x7865fAfC2db2093669d92c0F33AeEF291086BEFD",
       abi: CCTP_MESSAGE_TRANSMITTER_CONTRACT_ABI,
+    },
+  },
+  59140: {
+    l2MessageService: {
+      address: "0xC499a572640B64eA1C8c194c43Bc3E19940719dC",
+      abi: LINEA_L2_MESSAGE_SERVICE_CONTRACT_ABI,
     },
   },
 };

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2101,16 +2101,17 @@ export class Dataworker {
    * relay fee from the L2Linea Messenger contract.
    * @param leaf The relay leaf to execute. Used in this function to prevent non-Linea chains from calling this method.
    * @returns The amount of ETH required to execute the relay leaf.
+   * @throws If the method is called using a non-linea spoke pool client.
    */
-  _getRequiredEthForLineaRelayLeafExecution(client: SpokePoolClient): Promise<BigNumber | undefined> {
+  _getRequiredEthForLineaRelayLeafExecution(client: SpokePoolClient): Promise<BigNumber> {
+    // You should *only* call this method on Linea chains.
     if (![CHAIN_IDs.LINEA, CHAIN_IDs.LINEA_GOERLI].includes(client.chainId)) {
-      this.logger.warn({
+      this.logger.error({
         at: "Dataworker#_getRequiredEthForLineaRelayLeafExecution",
         message: "Tried to get required ETH for Linea relay leaf execution on a non-Linea chain!",
         chainId: client.chainId,
       });
-      // There is no fee for non-Linea chains w/r/t Linea so we can return undefined.
-      return undefined;
+      throw new Error("Tried to get required ETH for Linea relay leaf execution on a non-Linea chain!");
     }
     // Resolve the contract entry for the L2Linea Messenger contract.
     const { abi: l2MessageABI, address: l2MessageAddress } = CONTRACT_ADDRESSES[client.chainId].l2MessageService;

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2113,8 +2113,17 @@ export class Dataworker {
       });
       throw new Error("Tried to get required ETH for Linea relay leaf execution on a non-Linea chain!");
     }
-    // Resolve the contract entry for the L2Linea Messenger contract.
-    const { abi: l2MessageABI, address: l2MessageAddress } = CONTRACT_ADDRESSES[client.chainId].l2MessageService;
+    // Resolve and sanitize the L2MessageService contract ABI and address.
+    const l2MessageABI = CONTRACT_ADDRESSES[client.chainId].l2MessageService?.abi;
+    const l2MessageAddress = CONTRACT_ADDRESSES[client.chainId].l2MessageService?.address;
+    if (!isDefined(l2MessageABI) || !isDefined(l2MessageAddress)) {
+      this.logger.error({
+        at: "Dataworker#_getRequiredEthForLineaRelayLeafExecution",
+        message: "L2MessageService contract ABI or address is not defined for Linea chain!",
+        chainId: client.chainId,
+      });
+      throw new Error("L2MessageService contract ABI or address is not defined for Linea chain!");
+    }
     // For Linea, the bot needs enough ETH to pay for each L2 -> L1 message.
     const l2MessagerContract = new Contract(l2MessageAddress, l2MessageABI, client.spokePool.provider);
     // Get the latest relay fee from the L2Linea Messenger contract.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -2112,8 +2112,8 @@ export class Dataworker {
       throw new Error("Tried to get required ETH for Linea relay leaf execution on a non-Linea chain!");
     }
     // Resolve and sanitize the L2MessageService contract ABI and address.
-    const l2MessageABI = CONTRACT_ADDRESSES[client.chainId].l2MessageService?.abi;
-    const l2MessageAddress = CONTRACT_ADDRESSES[client.chainId].l2MessageService?.address;
+    const l2MessageABI = CONTRACT_ADDRESSES[client.chainId]?.l2MessageService?.abi;
+    const l2MessageAddress = CONTRACT_ADDRESSES[client.chainId]?.l2MessageService?.address;
     if (!isDefined(l2MessageABI) || !isDefined(l2MessageAddress)) {
       this.logger.error({
         at: "Dataworker#_getRequiredEthForLineaRelayLeafExecution",

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -15,7 +15,6 @@ import {
   toBNWei,
   getFillsInRange,
   ZERO_ADDRESS,
-  CHAIN_IDs,
 } from "../utils";
 import {
   FillsToRefund,
@@ -1877,7 +1876,7 @@ export class Dataworker {
     // If the chain is Linea, then we need to allocate ETH in the call to executeRelayerRefundLeaf. This is currently
     // unique to the L2 -> L1 relay direction for Linea. We will make this variable generic defaulting to undefined
     // for other chains.
-    const valueToPassViaPayable = [CHAIN_IDs.LINEA, CHAIN_IDs.LINEA_GOERLI].includes(chainId)
+    const valueToPassViaPayable = sdkUtils.chainIsLinea(chainId)
       ? await this._getRequiredEthForLineaRelayLeafExecution(client)
       : undefined;
 
@@ -2104,7 +2103,7 @@ export class Dataworker {
    */
   _getRequiredEthForLineaRelayLeafExecution(client: SpokePoolClient): Promise<BigNumber> {
     // You should *only* call this method on Linea chains.
-    if (![CHAIN_IDs.LINEA, CHAIN_IDs.LINEA_GOERLI].includes(client.chainId)) {
+    if (!sdkUtils.chainIsLinea(client.chainId)) {
       this.logger.error({
         at: "Dataworker#_getRequiredEthForLineaRelayLeafExecution",
         message: "Tried to get required ETH for Linea relay leaf execution on a non-Linea chain!",

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1908,14 +1908,14 @@ export class Dataworker {
               amount: totalSent,
             },
           ];
-          // If we have to pass ETH via the payable function, then we need to add a balance request for the SpokePool
+          // If we have to pass ETH via the payable function, then we need to add a balance request for the signer
           // to ensure that it has enough ETH to send.
           // NOTE: this is ETH required separately from the amount required to send the tokens
           if (isDefined(valueToPassViaPayable)) {
             balanceRequestsToQuery.push({
               chainId: leaf.chainId,
               tokens: [ZERO_ADDRESS], // ZERO_ADDRESS is used to represent ETH.
-              holder: client.spokePool.address,
+              holder: await client.spokePool.signer.getAddress(), // The signer's address is what will be sending the ETH.
               amount: valueToPassViaPayable,
             });
           }

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1877,10 +1877,9 @@ export class Dataworker {
     // If the chain is Linea, then we need to allocate ETH in the call to executeRelayerRefundLeaf. This is currently
     // unique to the L2 -> L1 relay direction for Linea. We will make this variable generic defaulting to undefined
     // for other chains.
-    const valueToPassViaPayable =
-      chainId === CHAIN_IDs.LINEA || CHAIN_IDs.LINEA_GOERLI
-        ? await this._getRequiredEthForLineaRelayLeafExecution(client)
-        : undefined;
+    const valueToPassViaPayable = [CHAIN_IDs.LINEA, CHAIN_IDs.LINEA_GOERLI].includes(chainId)
+      ? await this._getRequiredEthForLineaRelayLeafExecution(client)
+      : undefined;
 
     // Filter for leaves where the contract has the funding to send the required tokens.
     const fundedLeaves = (

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,7 +11,7 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants-v2@1.0.12":
+"@across-protocol/constants-v2@1.0.12", "@across-protocol/constants-v2@^1.0.12":
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.12.tgz#a85e8d39efa9c5294a368e229eab65357f00645e"
   integrity sha512-UrrPOxV/+FjCHmlMnezviAMXDiGDzUNCwKC2ifQ0U8PGa+lNulb7KCGNIEIFAFLHNn+/CMFST5Vwf+aAqbumvQ==
@@ -50,13 +50,13 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.22.6":
-  version "0.22.6"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.6.tgz#ec9b6b05a6b52667b8399b4d4ea570f5ece1ef8d"
-  integrity sha512-o4Cpjz7rF7V+3ch1AFbKMrfPXPkdcc4ToIz9mci8r3HVAhNf0918UGcNyzS1RfZuUyW6vyCIncfvQQfkGiud1A==
+"@across-protocol/sdk-v2@0.22.9":
+  version "0.22.9"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.9.tgz#ce6c1fd7a2fa94e341089f1df799dc86c9d39278"
+  integrity sha512-ejHayFWh7JI1LVpwuRkEho6Y0UWE3Fs+cg1TkF/Mbp36bmJ2/tb6QDbs9hX9YoTP762MrEXl64IBEHSqvx9DLA==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
-    "@across-protocol/constants-v2" "^1.0.11"
+    "@across-protocol/constants-v2" "^1.0.12"
     "@across-protocol/contracts-v2" "2.5.0-beta.7"
     "@eth-optimism/sdk" "^3.1.8"
     "@pinata/sdk" "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11,7 +11,12 @@
     "@uma/common" "^2.17.0"
     hardhat "^2.9.3"
 
-"@across-protocol/constants-v2@1.0.11", "@across-protocol/constants-v2@^1.0.11":
+"@across-protocol/constants-v2@1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.12.tgz#a85e8d39efa9c5294a368e229eab65357f00645e"
+  integrity sha512-UrrPOxV/+FjCHmlMnezviAMXDiGDzUNCwKC2ifQ0U8PGa+lNulb7KCGNIEIFAFLHNn+/CMFST5Vwf+aAqbumvQ==
+
+"@across-protocol/constants-v2@^1.0.11":
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.11.tgz#58d34b5cb50351d097f2ca43c5a30b5908faed7c"
   integrity sha512-RpseYB2QxGyfyrfXtUeFxUSCUW1zqu442QFzsdD1LBZtymuzdHuL2MwtTdmRRnJSvzRTFTtlRh4bYDoExSb5zQ==


### PR DESCRIPTION
Linea adds a constraint in the L2->L1 direction where we need to pass a payable `minimumWeiFee` to the `executeRelayerRefundLeaf`. 

We need to query this fee & pass it accordingly to the multicaller client.