### PR TITLE
improve(relayer): Don't query irrelevant HubPool events

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.11",
     "@across-protocol/contracts-v2": "2.5.0-beta.7",
-    "@across-protocol/sdk-v2": "0.22.6",
+    "@across-protocol/sdk-v2": "0.22.10",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.2.1",

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -311,7 +311,6 @@ export async function constructClients(
 export async function updateClients(clients: Clients, config: CommonConfig): Promise<void> {
   await clients.configStoreClient.update();
   config.loadAndValidateConfigForChains(clients.configStoreClient.getChainIdIndicesForBlock());
-  await clients.hubPoolClient.update();
 }
 
 export function spokePoolClientsToProviders(spokePoolClients: { [chainId: number]: SpokePoolClient }): {

--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -26,10 +26,13 @@ export async function constructDataworkerClients(
 ): Promise<DataworkerClients> {
   const signerAddr = await baseSigner.getAddress();
   const commonClients = await constructClients(logger, config, baseSigner);
+  const { hubPoolClient, configStoreClient } = commonClients;
+
   await updateClients(commonClients, config);
+  await hubPoolClient.update();
 
   // We don't pass any spoke pool clients to token client since data worker doesn't need to set approvals for L2 tokens.
-  const tokenClient = new TokenClient(logger, signerAddr, {}, commonClients.hubPoolClient);
+  const tokenClient = new TokenClient(logger, signerAddr, {}, hubPoolClient);
   await tokenClient.update();
   // Run approval on hub pool.
   if (config.sendingTransactionsEnabled) {
@@ -42,7 +45,7 @@ export async function constructDataworkerClients(
     logger,
     commonClients,
     {},
-    commonClients.configStoreClient.getChainIdIndicesForBlock(),
+    configStoreClient.getChainIdIndicesForBlock(),
     config.blockRangeEndBlockBuffer
   );
 

--- a/src/monitor/MonitorClientHelper.ts
+++ b/src/monitor/MonitorClientHelper.ts
@@ -26,14 +26,17 @@ export async function constructMonitorClients(
 ): Promise<MonitorClients> {
   const signerAddr = await baseSigner.getAddress();
   const commonClients = await constructClients(logger, config, baseSigner);
+  const { hubPoolClient, configStoreClient } = commonClients;
+
   await updateClients(commonClients, config);
+  await hubPoolClient.update();
 
   // Construct spoke pool clients for all chains that are not *currently* disabled. Caller can override
   // the disabled chain list by setting the DISABLED_CHAINS_OVERRIDE environment variable.
   const spokePoolClients = await constructSpokePoolClientsWithLookback(
     logger,
-    commonClients.hubPoolClient,
-    commonClients.configStoreClient,
+    hubPoolClient,
+    configStoreClient,
     config,
     baseSigner,
     config.maxRelayerLookBack
@@ -42,7 +45,7 @@ export async function constructMonitorClients(
     logger,
     commonClients,
     spokePoolClients,
-    commonClients.configStoreClient.getChainIdIndicesForBlock(),
+    configStoreClient.getChainIdIndicesForBlock(),
     config.blockRangeEndBlockBuffer
   );
 
@@ -51,9 +54,9 @@ export async function constructMonitorClients(
 
   // Cross-chain transfers will originate from the HubPool's address and target SpokePool addresses, so
   // track both.
-  const adapterManager = new AdapterManager(logger, spokePoolClients, commonClients.hubPoolClient, [
+  const adapterManager = new AdapterManager(logger, spokePoolClients, hubPoolClient, [
     signerAddr,
-    commonClients.hubPoolClient.hubPool.address,
+    hubPoolClient.hubPool.address,
     ...spokePoolAddresses,
   ]);
   const spokePoolChains = Object.keys(spokePoolClients).map((chainId) => Number(chainId));

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -31,6 +31,11 @@ export async function constructRelayerClients(
   const commonClients = await constructClients(logger, config, baseSigner);
   const { configStoreClient, hubPoolClient } = commonClients;
   await updateClients(commonClients, config);
+  await hubPoolClient.update([
+    "CrossChainContractsSet",
+    "L1TokenEnabledForLiquidityProvision",
+    "SetPoolRebalanceRoute",
+  ]);
 
   // If both origin and destination chains are configured, then limit the SpokePoolClients instantiated to the
   // sum of them. Otherwise, do not specify the chains to be instantiated to inherit one SpokePoolClient per

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,11 @@
   resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.11.tgz#58d34b5cb50351d097f2ca43c5a30b5908faed7c"
   integrity sha512-RpseYB2QxGyfyrfXtUeFxUSCUW1zqu442QFzsdD1LBZtymuzdHuL2MwtTdmRRnJSvzRTFTtlRh4bYDoExSb5zQ==
 
+"@across-protocol/constants-v2@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@across-protocol/constants-v2/-/constants-v2-1.0.12.tgz#a85e8d39efa9c5294a368e229eab65357f00645e"
+  integrity sha512-UrrPOxV/+FjCHmlMnezviAMXDiGDzUNCwKC2ifQ0U8PGa+lNulb7KCGNIEIFAFLHNn+/CMFST5Vwf+aAqbumvQ==
+
 "@across-protocol/contracts-v2@2.5.0-beta.7":
   version "2.5.0-beta.7"
   resolved "https://registry.yarnpkg.com/@across-protocol/contracts-v2/-/contracts-v2-2.5.0-beta.7.tgz#9410efc9e39b8b1b6e814dcd416e6017f7d40abd"
@@ -45,13 +50,13 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.22.6":
-  version "0.22.6"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.6.tgz#ec9b6b05a6b52667b8399b4d4ea570f5ece1ef8d"
-  integrity sha512-o4Cpjz7rF7V+3ch1AFbKMrfPXPkdcc4ToIz9mci8r3HVAhNf0918UGcNyzS1RfZuUyW6vyCIncfvQQfkGiud1A==
+"@across-protocol/sdk-v2@0.22.10":
+  version "0.22.10"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.10.tgz#3cba4df6b0c29faf50b68b683f60ce9ed0f3ce92"
+  integrity sha512-UlGEQrIGXUe0qRz3Cdtl+d2eyMu7sKlTrYUTRME+Ctv6ASo7P277oUPs9QQzpPaUViIWeO4Qh/dJi1wC+y06Rw==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
-    "@across-protocol/constants-v2" "^1.0.11"
+    "@across-protocol/constants-v2" "^1.0.12"
     "@across-protocol/contracts-v2" "2.5.0-beta.7"
     "@eth-optimism/sdk" "^3.1.8"
     "@pinata/sdk" "^2.1.0"


### PR DESCRIPTION
The relayer has no obvious need to query root bundle events, so skip them.

Note: Tests all pass, and I've also tested this on mainnet. It just needs the corresponding SDK-v2 PR to be merged, and a new package to be built (https://github.com/across-protocol/sdk-v2/pull/581).