### PR TITLE
improve(relayer): Drop unused SpokePool events

### DIFF
--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -134,8 +134,6 @@ export async function updateRelayerClients(clients: RelayerClients, config: Rela
     "RequestedV3SlowFill",
     "FilledV3Relay",
     "EnabledDepositRoute",
-    "RelayedRootBundle",
-    "ExecutedRelayerRefundRoot",
   ]);
 
   // Update the token client first so that inventory client has latest balances.


### PR DESCRIPTION
These events are not required by the relayer, so there's no need to query them.