### PR TITLE
improve(relayer): Limit HubPoolClient lookback

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.11",
     "@across-protocol/contracts-v2": "2.5.0-beta.7",
-    "@across-protocol/sdk-v2": "0.22.10",
+    "@across-protocol/sdk-v2": "0.22.11",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
     "@eth-optimism/sdk": "^3.2.1",

--- a/src/common/ClientHelper.ts
+++ b/src/common/ClientHelper.ts
@@ -287,8 +287,8 @@ export async function constructClients(
   const hubPoolDeploymentBlock = Number(getDeploymentBlockNumber("HubPool", config.hubPoolChainId));
   const { average: avgMainnetBlockTime } = await sdkUtils.averageBlockTime(hubPoolProvider);
   const fromBlock = isDefined(hubPoolLookback)
-    ? Math.max(latestMainnetBlock - (hubPoolLookback / avgMainnetBlockTime), hubPoolDeploymentBlock)
-    : hubPoolDeploymentBlock
+    ? Math.max(latestMainnetBlock - hubPoolLookback / avgMainnetBlockTime, hubPoolDeploymentBlock)
+    : hubPoolDeploymentBlock;
   const hubPoolClientSearchSettings = { ...rateModelClientSearchSettings, fromBlock };
 
   // Create contract instances for each chain for each required contract.

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -28,7 +28,8 @@ export async function constructRelayerClients(
   baseSigner: Signer
 ): Promise<RelayerClients> {
   const signerAddr = await baseSigner.getAddress();
-  const commonClients = await constructClients(logger, config, baseSigner);
+  const hubPoolLookBack = 3600 * 12;
+  const commonClients = await constructClients(logger, config, baseSigner, hubPoolLookBack);
   const { configStoreClient, hubPoolClient } = commonClients;
   await updateClients(commonClients, config);
   await hubPoolClient.update();

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -28,6 +28,8 @@ export async function constructRelayerClients(
   baseSigner: Signer
 ): Promise<RelayerClients> {
   const signerAddr = await baseSigner.getAddress();
+  // The relayer only uses the HubPoolClient to query repayments refunds for the latest validated
+  // bundle and the pending bundle. 12 hours should cover these bundles in almost all cases.
   const hubPoolLookBack = 3600 * 12;
   const commonClients = await constructClients(logger, config, baseSigner, hubPoolLookBack);
   const { configStoreClient, hubPoolClient } = commonClients;

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,10 +50,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.22.10":
-  version "0.22.10"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.10.tgz#3cba4df6b0c29faf50b68b683f60ce9ed0f3ce92"
-  integrity sha512-UlGEQrIGXUe0qRz3Cdtl+d2eyMu7sKlTrYUTRME+Ctv6ASo7P277oUPs9QQzpPaUViIWeO4Qh/dJi1wC+y06Rw==
+"@across-protocol/sdk-v2@0.22.11":
+  version "0.22.11"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.11.tgz#a6a83e6e0f232d22e37acfaa7a7d59a2c6639b2f"
+  integrity sha512-e+L52wL81PYnjsK5UvAPzi8SSuI1BJpNL3rYSQ7TWgbr3ds0Iqefy8A6q+ZkjqeqEd6VFdmPU0IUdGtkycUz7A==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.12"


### PR DESCRIPTION
The HubPoolClient now has logic to override the requested lookback for specific events if it has not previously been updated. This is the same logic that is implemented for the SpokePoolClients. As a result, it's now possible to be much more restrictive on the lookback for the HubPoolClient. The relayer can benefit from this be only querying RootBundle events for the past ~12 hours, which should be sufficient for the InventoryManager to determine repayment chains.