### PR TITLE
improve(relayer): Add execution time logging

### DIFF
--- a/src/relayer/index.ts
+++ b/src/relayer/index.ts
@@ -1,17 +1,30 @@
-import { processEndPollingLoop, winston, config, startupLogLevel, Signer, disconnectRedisClients } from "../utils";
+import {
+  getCurrentTime,
+  processEndPollingLoop,
+  winston,
+  config,
+  startupLogLevel,
+  Signer,
+  disconnectRedisClients,
+} from "../utils";
 import { Relayer } from "./Relayer";
 import { RelayerConfig } from "./RelayerConfig";
 import { constructRelayerClients, RelayerClients, updateRelayerClients } from "./RelayerClientHelper";
 config();
 let logger: winston.Logger;
 
+const randomNumber = () => Math.floor(Math.random() * 1_000_000);
+
 export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
+  const relayerRun = randomNumber();
+  const startTime = getCurrentTime();
+
   logger = _logger;
   const config = new RelayerConfig(process.env);
   let relayerClients: RelayerClients;
 
   try {
-    logger[startupLogLevel(config)]({ at: "Relayer#index", message: "Relayer started 🏃‍♂️", config });
+    logger[startupLogLevel(config)]({ at: "Relayer#index", message: "Relayer started 🏃‍♂️", config, relayerRun });
     relayerClients = await constructRelayerClients(logger, config, baseSigner);
     const relayer = new Relayer(await baseSigner.getAddress(), logger, relayerClients, config);
 
@@ -44,4 +57,7 @@ export async function runRelayer(_logger: winston.Logger, baseSigner: Signer): P
   } finally {
     await disconnectRedisClients(logger);
   }
+
+  const runtime = getCurrentTime() - startTime;
+  logger.debug({ at: "Relayer#index", message: `Completed relayer run ${relayerRun}.`, runtime });
 }


### PR DESCRIPTION
Use a random number to identify the start and end points for each relayer run, and record the time required to complete the run.