### PR TITLE
improve: Hardcode bundle refund lookback for relayer and monitor

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -175,7 +175,7 @@ export class BundleDataClient {
     this.bundleTimestampCache[key] = timestamps;
   }
 
-  async getPendingRefundsFromValidBundles(bundleLookback: number): Promise<CombinedRefunds[]> {
+  async getPendingRefundsFromValidBundles(bundleLookback = 1): Promise<CombinedRefunds[]> {
     const refunds = [];
     if (!this.clients.hubPoolClient.isUpdated) {
       throw new Error("BundleDataClient::getPendingRefundsFromValidBundles HubPoolClient not updated.");

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -226,6 +226,7 @@ export class InventoryClient {
     const outputAmount = sdkUtils.getDepositOutputAmount(deposit);
     let chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfall.sub(outputAmount);
 
+    const startTime = Date.now();
     let totalRefundsPerChain: { [chainId: string]: BigNumber } = {};
     try {
       // Consider any refunds from executed and to-be executed bundles.
@@ -236,6 +237,7 @@ export class InventoryClient {
       // This would create issues if there are relatively a lot of upcoming relayer refunds that would affect
       // the relayer's repayment chain of choice.
     }
+    this.log(`Time taken to get bundle refunds: ${Math.floor(Date.now() - startTime)/1000}s`);
 
     // Add upcoming refunds going to this destination chain.
     chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfallPostRelay.add(

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -42,7 +42,6 @@ export class InventoryClient {
   private logDisabledManagement = false;
   private readonly scalar: BigNumber;
   private readonly formatWei: ReturnType<typeof createFormatFunction>;
-  private readonly bundleRefundLookback = 1;
 
   constructor(
     readonly relayer: string,

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -237,7 +237,7 @@ export class InventoryClient {
       // This would create issues if there are relatively a lot of upcoming relayer refunds that would affect
       // the relayer's repayment chain of choice.
     }
-    this.log(`Time taken to get bundle refunds: ${Math.floor(Date.now() - startTime)/1000}s`);
+    this.log(`Time taken to get bundle refunds: ${Math.floor(Date.now() - startTime) / 1000}s`);
 
     // Add upcoming refunds going to this destination chain.
     chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfallPostRelay.add(

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -42,7 +42,7 @@ export class InventoryClient {
   private logDisabledManagement = false;
   private readonly scalar: BigNumber;
   private readonly formatWei: ReturnType<typeof createFormatFunction>;
-  private bundleRefundLookback = 1;
+  private readonly bundleRefundLookback = 1;
 
   constructor(
     readonly relayer: string,

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -160,9 +160,7 @@ export class InventoryClient {
     // Increase virtual balance by pending relayer refunds from the latest valid bundle and the
     // upcoming bundle. We can assume that all refunds from the second latest valid bundle have already
     // been executed.
-    const refundsToConsider: CombinedRefunds[] = await this.bundleDataClient.getPendingRefundsFromValidBundles(
-      this.bundleRefundLookback
-    );
+    const refundsToConsider: CombinedRefunds[] = await this.bundleDataClient.getPendingRefundsFromValidBundles();
 
     // Consider refunds from next bundle to be proposed:
     const nextBundleRefunds = await this.bundleDataClient.getNextBundleRefunds();

--- a/src/clients/bridges/ArbitrumAdapter.ts
+++ b/src/clients/bridges/ArbitrumAdapter.ts
@@ -220,7 +220,7 @@ export class ArbitrumAdapter extends BaseAdapter {
     } else {
       this.logger.debug({
         at: this.getName(),
-        message: "ETH balance below threhsold",
+        message: "ETH balance below threshold",
         threshold,
         ethBalance,
       });

--- a/src/clients/bridges/ZKSyncAdapter.ts
+++ b/src/clients/bridges/ZKSyncAdapter.ts
@@ -248,7 +248,7 @@ export class ZKSyncAdapter extends BaseAdapter {
     } else {
       this.logger.debug({
         at: this.getName(),
-        message: "ETH balance below threhsold",
+        message: "ETH balance below threshold",
         threshold,
         ethBalance,
       });

--- a/src/clients/bridges/op-stack/OpStackAdapter.ts
+++ b/src/clients/bridges/op-stack/OpStackAdapter.ts
@@ -154,7 +154,7 @@ export class OpStackAdapter extends BaseAdapter {
     } else {
       this.logger.debug({
         at: this.getName(),
-        message: "ETH balance below threhsold",
+        message: "ETH balance below threshold",
         threshold,
         ethBalance,
       });

--- a/src/common/Config.ts
+++ b/src/common/Config.ts
@@ -14,7 +14,6 @@ export class CommonConfig {
   readonly maxTxWait: number;
   readonly spokePoolChainsOverride: number[];
   readonly sendingTransactionsEnabled: boolean;
-  readonly bundleRefundLookback: number;
   readonly maxRelayerLookBack: number;
   readonly version: string;
   readonly maxConfigVersion: number;
@@ -35,7 +34,6 @@ export class CommonConfig {
       MAX_BLOCK_LOOK_BACK,
       MAX_TX_WAIT_DURATION,
       SEND_TRANSACTIONS,
-      BUNDLE_REFUND_LOOKBACK,
       SPOKE_POOL_CHAINS_OVERRIDE,
       ACROSS_BOT_VERSION,
       ACROSS_MAX_CONFIG_VERSION,
@@ -72,7 +70,6 @@ export class CommonConfig {
     }
     this.maxTxWait = Number(MAX_TX_WAIT_DURATION ?? 180); // 3 minutes
     this.sendingTransactionsEnabled = SEND_TRANSACTIONS === "true";
-    this.bundleRefundLookback = Number(BUNDLE_REFUND_LOOKBACK ?? 2);
   }
 
   /**

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -558,9 +558,10 @@ export class Monitor {
   }
 
   async updateLatestAndFutureRelayerRefunds(relayerBalanceReport: RelayerBalanceReport): Promise<void> {
-    // We realistically only need to check for refunds for the latest validated bundle.
+    // We realistically only need to check for refunds for the latest validated bundle so leave the bundle
+    // count value as its default value of 1.
     const validatedBundleRefunds: CombinedRefunds[] =
-      await this.clients.bundleDataClient.getPendingRefundsFromValidBundles(1);
+      await this.clients.bundleDataClient.getPendingRefundsFromValidBundles();
     const nextBundleRefunds = await this.clients.bundleDataClient.getNextBundleRefunds();
 
     // Calculate which fills have not yet been refunded for each monitored relayer.

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -558,8 +558,9 @@ export class Monitor {
   }
 
   async updateLatestAndFutureRelayerRefunds(relayerBalanceReport: RelayerBalanceReport): Promise<void> {
+    // We realistically only need to check for refunds for the latest validated bundle.
     const validatedBundleRefunds: CombinedRefunds[] =
-      await this.clients.bundleDataClient.getPendingRefundsFromValidBundles(this.monitorConfig.bundleRefundLookback);
+      await this.clients.bundleDataClient.getPendingRefundsFromValidBundles(1);
     const nextBundleRefunds = await this.clients.bundleDataClient.getNextBundleRefunds();
 
     // Calculate which fills have not yet been refunded for each monitored relayer.

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -29,8 +29,8 @@ export async function constructRelayerClients(
 ): Promise<RelayerClients> {
   const signerAddr = await baseSigner.getAddress();
   // The relayer only uses the HubPoolClient to query repayments refunds for the latest validated
-  // bundle and the pending bundle. 12 hours should cover these bundles in almost all cases.
-  const hubPoolLookBack = 3600 * 12;
+  // bundle and the pending bundle. 8 hours should cover the latest two bundles in almost all cases.
+  const hubPoolLookBack = 3600 * 8;
   const commonClients = await constructClients(logger, config, baseSigner, hubPoolLookBack);
   const { configStoreClient, hubPoolClient } = commonClients;
   await updateClients(commonClients, config);

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -117,7 +117,6 @@ export async function constructRelayerClients(
     bundleDataClient,
     adapterManager,
     crossChainTransferClient,
-    config.bundleRefundLookback,
     !config.sendingRebalancesEnabled
   );
 


### PR DESCRIPTION
We never practically need to look back more than 1 bundle, and trying to look back too many bundles leads weird errors in InventoryClient because it tries to compute bundle data using events its missing due to shortened HubPoolClient and SpokePoolClient lookbacks

Also, changes InventoryClient behavior that defaults taking repayment on mainnet if the BundleDataClient fails for some reason. We've seen in practice that taking repayment on mainnet for extended periods of time locks up bridge liquidity, so we'd actually rather take extra repayment on the spokes than on mainnet because we can always manually rebalance using external fast bridges or slow fills, rather than locking it up in 7 day ORU bridges
