### PR TITLE
improve: decrease finalizer HubPoolClient lookback

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -239,7 +239,10 @@ export class InventoryClient {
         })
       );
     }
-    this.log(`Time taken to get bundle refunds: ${Math.floor(Date.now() - startTime) / 1000}s`, totalRefundsPerChain);
+    this.log(`Time taken to get bundle refunds: ${Math.floor(Date.now() - startTime) / 1000}s`, {
+      l1Token: l1Token,
+      totalRefundsPerChain,
+    });
 
     // Add upcoming refunds going to this destination chain.
     chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfallPostRelay.add(
@@ -263,6 +266,7 @@ export class InventoryClient {
     const refundChainId = expectedPostRelayAllocation.gt(targetPct) ? hubChainId : destinationChainId;
 
     this.log("Evaluated refund Chain", {
+      l1Token: l1Token,
       chainShortfall,
       chainVirtualBalance,
       chainVirtualBalanceWithShortfall,

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -316,7 +316,12 @@ export async function constructFinalizerClients(
   commonClients: Clients;
   spokePoolClients: SpokePoolClientsByChain;
 }> {
-  const commonClients = await constructClients(_logger, config, baseSigner);
+  // The finalizer only uses the HubPoolClient to look up the *latest* l1 tokens matching an l2 token that was
+  // withdrawn to L1, so assuming these L1 tokens do not change in the future, then we can reduce the hub pool
+  // client lookback. Note, this should not be impacted by L2 tokens changing, for example when changing
+  // USDC.e --> USDC because the l1 token matching both L2 version stays the same.
+  const hubPoolLookBack = 3600 * 8;
+  const commonClients = await constructClients(_logger, config, baseSigner, hubPoolLookBack);
   await updateFinalizerClients(commonClients);
 
   // Construct spoke pool clients for all chains that are not *currently* disabled. Caller can override


### PR DESCRIPTION
Finalizer doesn't need HubPoolClient for most part except for latest data. This saves ~20-60s updating the hub pool client