### PR TITLE
fix: InventoryClient should set default values for `totalRefundsPerChain`

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -233,8 +233,13 @@ export class InventoryClient {
       // Fallback to ignoring bundle refunds if calculating bundle refunds goes wrong.
       // This would create issues if there are relatively a lot of upcoming relayer refunds that would affect
       // the relayer's repayment chain of choice.
+      totalRefundsPerChain = Object.fromEntries(
+        this.getEnabledChains().map((chainId) => {
+          return [chainId, toBN(0)];
+        })
+      );
     }
-    this.log(`Time taken to get bundle refunds: ${Math.floor(Date.now() - startTime) / 1000}s`);
+    this.log(`Time taken to get bundle refunds: ${Math.floor(Date.now() - startTime) / 1000}s`, totalRefundsPerChain);
 
     // Add upcoming refunds going to this destination chain.
     chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfallPostRelay.add(

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -316,12 +316,7 @@ export async function constructFinalizerClients(
   commonClients: Clients;
   spokePoolClients: SpokePoolClientsByChain;
 }> {
-  // The finalizer only uses the HubPoolClient to look up the *latest* l1 tokens matching an l2 token that was
-  // withdrawn to L1, so assuming these L1 tokens do not change in the future, then we can reduce the hub pool
-  // client lookback. Note, this should not be impacted by L2 tokens changing, for example when changing
-  // USDC.e --> USDC because the l1 token matching both L2 version stays the same.
-  const hubPoolLookBack = 3600 * 8;
-  const commonClients = await constructClients(_logger, config, baseSigner, hubPoolLookBack);
+  const commonClients = await constructClients(_logger, config, baseSigner);
   await updateFinalizerClients(commonClients);
 
   // Construct spoke pool clients for all chains that are not *currently* disabled. Caller can override

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -316,7 +316,12 @@ export async function constructFinalizerClients(
   commonClients: Clients;
   spokePoolClients: SpokePoolClientsByChain;
 }> {
-  const commonClients = await constructClients(_logger, config, baseSigner);
+  // The finalizer only uses the HubPoolClient to look up the *latest* l1 tokens matching an l2 token that was
+  // withdrawn to L1, so assuming these L1 tokens do not change in the future, then we can reduce the hub pool
+  // client lookback. Note, this should not be impacted by L2 tokens changing, for example when changing
+  // USDC.e --> USDC because the l1 token matching both L2 version stays the same.
+  const hubPoolLookBack = 3600 * 8;
+  const commonClients = await constructClients(_logger, config, baseSigner, hubPoolLookBack);
   await updateFinalizerClients(commonClients);
 
   // Construct spoke pool clients for all chains that are not *currently* disabled. Caller can override


### PR DESCRIPTION
d35608d1b5522c4f12b0d018c8de173d1cbe8f02 changed behavior of this try-catch such that if catch is called, code continues rather than short circuiting. Therefore we need a default value for totalRefunds≈
