### PR TITLE
improve(finalizer): Optimize lookback windows

### DIFF
--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -79,8 +79,8 @@ export async function finalize(
   spokePoolClients: SpokePoolClientsByChain,
   configuredChainIds: number[],
   submitFinalizationTransactions: boolean,
-  optimisticRollupFinalizationWindow = Math.floor(6.5 * oneDaySeconds),
-  polygonFinalizationWindow = Math.floor(0.75 * oneDaySeconds)
+  optimisticRollupFinalizationWindow = 7 * oneDaySeconds,
+  polygonFinalizationWindow = 1 * oneDaySeconds
 ): Promise<void> {
   const finalizationWindows: { [chainId: number]: number } = {
     // Mainnets

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -79,14 +79,14 @@ export async function finalize(
   spokePoolClients: SpokePoolClientsByChain,
   configuredChainIds: number[],
   submitFinalizationTransactions: boolean,
-  optimisticRollupFinalizationWindow = 5 * oneDaySeconds,
-  polygonFinalizationWindow = 5 * oneDaySeconds
+  optimisticRollupFinalizationWindow = Math.floor(6.5 * oneDaySeconds),
+  polygonFinalizationWindow = Math.floor(0.75 * oneDaySeconds)
 ): Promise<void> {
   const finalizationWindows: { [chainId: number]: number } = {
     // Mainnets
     10: optimisticRollupFinalizationWindow, // Optimism Mainnet
     137: polygonFinalizationWindow, // Polygon Mainnet
-    324: oneDaySeconds * 4, // zkSync Mainnet
+    324: oneDaySeconds * 2, // zkSync Mainnet
     8453: optimisticRollupFinalizationWindow, // Base Mainnet
     42161: optimisticRollupFinalizationWindow, // Arbitrum One Mainnet
     534352: oneHourSeconds * 4, // Scroll Mainnet

--- a/src/finalizer/index.ts
+++ b/src/finalizer/index.ts
@@ -80,15 +80,15 @@ export async function finalize(
   configuredChainIds: number[],
   submitFinalizationTransactions: boolean,
   optimisticRollupFinalizationWindow = 7 * oneDaySeconds,
-  polygonFinalizationWindow = 1 * oneDaySeconds
+  polygonFinalizationWindow = oneDaySeconds
 ): Promise<void> {
   const finalizationWindows: { [chainId: number]: number } = {
     // Mainnets
-    10: optimisticRollupFinalizationWindow, // Optimism Mainnet
-    137: polygonFinalizationWindow, // Polygon Mainnet
-    324: oneDaySeconds * 2, // zkSync Mainnet
-    8453: optimisticRollupFinalizationWindow, // Base Mainnet
-    42161: optimisticRollupFinalizationWindow, // Arbitrum One Mainnet
+    10: optimisticRollupFinalizationWindow, // Optimism Mainnet.
+    137: polygonFinalizationWindow, // Polygon Mainnet. Withdrawals take up to 3 hours to finalize.
+    324: oneDaySeconds, // zkSync Mainnet. Withdrawals take 1 day to finalize.
+    8453: optimisticRollupFinalizationWindow, // Base Mainnet.
+    42161: optimisticRollupFinalizationWindow, // Arbitrum One Mainnet.
     534352: oneHourSeconds * 4, // Scroll Mainnet
 
     // Testnets

--- a/src/finalizer/utils/opStack.ts
+++ b/src/finalizer/utils/opStack.ts
@@ -47,7 +47,7 @@ export async function opStackFinalizer(
   const crossChainMessenger = getOptimismClient(chainId, signer);
 
   // Sort tokensBridged events by their age. Submit proofs for recent events, and withdrawals for older events.
-  // - Don't submit proofs for finlizations older than 1 day
+  // - Don't submit proofs for finalizations older than 1 day
   // - Don't try to withdraw tokens that are not past the 7 day challenge period
   const blockFinder = undefined;
   const redis = await getRedisCache(logger);


### PR DESCRIPTION

A lot of the finalizer slowdown currently is querying withdrawl status information about TokenBridgedEvents. Optimize the lookback settings with the following changes
- OpStack: Don't submit proofs for any transaction older than 1 day. Don't try to withdraw any withdrawal earlier than 6.5 days old
- Polygon: Don't try to withdraw anything younger than 0.75 days
- ZkSync: Don't try to withdraw anything younger than 2 days
