### PR TITLE
improve(Dataworker): Don't send error-level log if invalid bundle reason is expected to be benign

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1424,13 +1424,27 @@ export class Dataworker {
     );
 
     if (!valid) {
-      this.logger.error({
-        at: "Dataworker#executePoolRebalanceLeaves",
-        message: "Found invalid proposal after challenge period!",
-        reason,
-        e: reason,
-        notificationPath: "across-error",
-      });
+      // In the case where the Dataworker config is improperly configured, emit an error level alert so bot runner
+      // can get dataworker running ASAP.
+      if (ERROR_DISPUTE_REASONS.has(reason)) {
+        this.logger.error({
+          at: "Dataworker#executePoolRebalanceLeaves",
+          message: "Dataworker configuration error needs to be fixed",
+          reason,
+        });
+      } else if (IGNORE_DISPUTE_REASONS.has(reason)) {
+        this.logger.debug({
+          at: "Dataworker#executePoolRebalanceLeaves",
+          message: "Dataworker configuration error, should resolve itself eventually 😪",
+          reason,
+        });
+      } else {
+        this.logger.error({
+          at: "Dataworker#executePoolRebalanceLeaves",
+          message: "Found invalid proposal after challenge period!",
+          mrkdwn: reason,
+        });
+      }
       return;
     }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1442,7 +1442,7 @@ export class Dataworker {
         this.logger.error({
           at: "Dataworker#executePoolRebalanceLeaves",
           message: "Found invalid proposal after challenge period!",
-          mrkdwn: reason,
+          reason,
         });
       }
       return;

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1426,22 +1426,21 @@ export class Dataworker {
     if (!valid) {
       // In the case where the Dataworker config is improperly configured, emit an error level alert so bot runner
       // can get dataworker running ASAP.
-    if (IGNORE_DISPUTE_REASONS.has(reason)) {
-      this.logger.debug({
-        at: "Dataworker#executePoolRebalanceLeaves",
-        message:
-          "Dataworker configuration error, should resolve itself eventually 😪",
-        reason,
-      });
-    } else {
-      this.logger.error({
-        at: "Dataworker#executePoolRebalanceLeaves",
-        message: ERROR_DISPUTE_REASONS.has(reason)
-          ? "Dataworker configuration error needs to be fixed"
-          : "Found invalid proposal after challenge period!",
-        reason,
-      });
-    }
+      if (IGNORE_DISPUTE_REASONS.has(reason)) {
+        this.logger.debug({
+          at: "Dataworker#executePoolRebalanceLeaves",
+          message: "Dataworker configuration error, should resolve itself eventually 😪",
+          reason,
+        });
+      } else {
+        this.logger.error({
+          at: "Dataworker#executePoolRebalanceLeaves",
+          message: ERROR_DISPUTE_REASONS.has(reason)
+            ? "Dataworker configuration error needs to be fixed"
+            : "Found invalid proposal after challenge period!",
+          reason,
+        });
+      }
       return;
     }
 

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1426,25 +1426,22 @@ export class Dataworker {
     if (!valid) {
       // In the case where the Dataworker config is improperly configured, emit an error level alert so bot runner
       // can get dataworker running ASAP.
-      if (ERROR_DISPUTE_REASONS.has(reason)) {
-        this.logger.error({
-          at: "Dataworker#executePoolRebalanceLeaves",
-          message: "Dataworker configuration error needs to be fixed",
-          reason,
-        });
-      } else if (IGNORE_DISPUTE_REASONS.has(reason)) {
-        this.logger.debug({
-          at: "Dataworker#executePoolRebalanceLeaves",
-          message: "Dataworker configuration error, should resolve itself eventually 😪",
-          reason,
-        });
-      } else {
-        this.logger.error({
-          at: "Dataworker#executePoolRebalanceLeaves",
-          message: "Found invalid proposal after challenge period!",
-          reason,
-        });
-      }
+    if (IGNORE_DISPUTE_REASONS.has(reason)) {
+      this.logger.debug({
+        at: "Dataworker#executePoolRebalanceLeaves",
+        message:
+          "Dataworker configuration error, should resolve itself eventually 😪",
+        reason,
+      });
+    } else {
+      this.logger.error({
+        at: "Dataworker#executePoolRebalanceLeaves",
+        message: ERROR_DISPUTE_REASONS.has(reason)
+          ? "Dataworker configuration error needs to be fixed"
+          : "Found invalid proposal after challenge period!",
+        reason,
+      });
+    }
       return;
     }
 


### PR DESCRIPTION
This copies the logic from `validatePendingRootBundle` that also should be used in executePoolRebalanceLeaf