### PR TITLE
improve: Send quorum warning to across-warn channel

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -440,6 +440,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       logger.debug({
         at: "ProviderUtils",
         message: "Some providers mismatched with the quorum result or failed 🚸",
+        notificationPath: "across-warn",
         method,
         params,
         quorumProviders,

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -437,7 +437,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       .filter(([, result]) => compareRpcResults(method, result, quorumResult))
       .map(([provider]) => provider.connection.url);
     if (Object.keys(mismatchedProviders).length > 0 || errors.length > 0) {
-      logger.warn({
+      logger.debug({
         at: "ProviderUtils",
         message: "Some providers mismatched with the quorum result or failed 🚸",
         method,

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -437,7 +437,7 @@ export class RetryProvider extends ethers.providers.StaticJsonRpcProvider {
       .filter(([, result]) => compareRpcResults(method, result, quorumResult))
       .map(([provider]) => provider.connection.url);
     if (Object.keys(mismatchedProviders).length > 0 || errors.length > 0) {
-      logger.debug({
+      logger.warn({
         at: "ProviderUtils",
         message: "Some providers mismatched with the quorum result or failed 🚸",
         notificationPath: "across-warn",


### PR DESCRIPTION
We should collect warnings that we want to see but don't want to pollute other channels in a new `across-warn` channel