### PR TITLE
fix(circle): mitigate circle-ci build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.11",
     "@across-protocol/contracts-v2": "2.5.0-beta.7",
-    "@across-protocol/sdk-v2": "0.22.12",
+    "@across-protocol/sdk-v2": "0.22.14",
     "@arbitrum/sdk": "^3.1.3",
     "@defi-wonderland/smock": "^2.3.5",
-    "@eth-optimism/sdk": "^3.2.1",
+    "@eth-optimism/sdk": "^3.2.2",
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/abstract-provider": "^5.7.0",
     "@ethersproject/abstract-signer": "^5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,15 +50,15 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.22.12":
-  version "0.22.12"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.12.tgz#885326437ff45bf9fca0b0ff6b8f6fde289c3127"
-  integrity sha512-iN4pNaMxateXm/eHag34LDzTn3wzCDIQamKuykEVCaIrSr+8jHtEzK1UBVg9KGZzLUU+R3B1INCdCOK1YTLuYw==
+"@across-protocol/sdk-v2@0.22.14":
+  version "0.22.14"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.14.tgz#f0b86d94e59c0478ec062539822407506550f2ac"
+  integrity sha512-U6baVww6xeK9X1iMobnJYclCCbU22RwKJ0ZrcliMvfYzUAXCLYeRrD7x2Stg0XFHwctiVjlr/QeKyIc8KeVWbQ==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.12"
     "@across-protocol/contracts-v2" "2.5.0-beta.7"
-    "@eth-optimism/sdk" "^3.1.8"
+    "@eth-optimism/sdk" "^3.2.2"
     "@pinata/sdk" "^2.1.0"
     "@types/mocha" "^10.0.1"
     "@uma/sdk" "^0.34.1"
@@ -477,11 +477,6 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@eth-optimism/contracts-bedrock@0.16.2":
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts-bedrock/-/contracts-bedrock-0.16.2.tgz#065ad561c3c8b942e4e0dd3d0ea6ed7e00a0f8f0"
-  integrity sha512-a2+f7soDbrd6jV74U02EpyMwQt2iZeDZ4c2ZwgkObcxXUZLZQ2ELt/VRFBf8TIL3wYcBOGpUa1aXAE2oHQ7oRA==
-
 "@eth-optimism/contracts-bedrock@0.17.1":
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/@eth-optimism/contracts-bedrock/-/contracts-bedrock-0.17.1.tgz#729b1dc53ec23d02ea9e68181f994955129f7415"
@@ -560,22 +555,10 @@
     ethers "^5.5.4"
     lodash "^4.17.21"
 
-"@eth-optimism/sdk@^3.1.8":
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-3.1.8.tgz#af68d1d58e0d71539363a273a50815233b54c83a"
-  integrity sha512-hvv7f3xE5JWIRN1lSiBUeRXdr2Ue+Ircgl612Gi/WvW1M3KGWQzCO0GYl858yheM8ROZOboOjSyKRy+ObubJkw==
-  dependencies:
-    "@eth-optimism/contracts" "0.6.0"
-    "@eth-optimism/contracts-bedrock" "0.16.2"
-    "@eth-optimism/core-utils" "0.13.1"
-    lodash "^4.17.21"
-    merkletreejs "^0.3.11"
-    rlp "^2.2.7"
-
-"@eth-optimism/sdk@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-3.2.1.tgz#70e10c84580fd9c02d82a6482cd233f8b317632b"
-  integrity sha512-COmnT2zRzFn2XhMW/OD1ML3gCrT6SO95YF3hV/Mx3G1G4Q6zOv09rwU1avH/OcqdDMBmZ/DTrZm+9OVmc+YPlQ==
+"@eth-optimism/sdk@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/sdk/-/sdk-3.2.2.tgz#732c2d6fde96a25303b3c5b39b3b3ed1f913d9aa"
+  integrity sha512-P8YXAlh2lun0KZlwrw4FqmK4kNIoOOzI816XXhfkW3nMVADGRAru3TKSM74MgmEuyGiHrA9EoPRq1WLqUX4B0w==
   dependencies:
     "@eth-optimism/contracts" "0.6.0"
     "@eth-optimism/contracts-bedrock" "0.17.1"


### PR DESCRIPTION
Version 3.2.2 of `@eth-optimism/sdk` removes the pre-install build script for `only allow pnpm`. This should resolve the outstanding issue we've been facing with intermittent CircleCI build failures in the relayer-v2.

In order to resolve this, @evaldofelipe and I have been working on the following steps after we identified the faulty package:
1. Bump the SDK's @eth-optimism/sdk version
2. Bump the Relayer's @eth-optimism/sdk version & bump the SDK-v2