### PR TITLE
hotfix(reporter): sanitize undefined range

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -1109,7 +1109,7 @@ export class BundleDataClient {
       (
         await utils.mapAsync(chainIds, async (chainId, index) => {
           const blockRangeForChain = blockRangesForChains[index];
-          if (isChainDisabled(blockRangeForChain)) {
+          if (!isDefined(blockRangeForChain) || isChainDisabled(blockRangeForChain)) {
             return;
           }
           const [_startBlockForChain, _endBlockForChain] = blockRangeForChain;


### PR DESCRIPTION
We should check that we are passing a defined block range to the `isChainDisabled` function.

Note: we do call `isChainDisabled` in other locations, namely the private `_isChainDisabled` function which takes a `chainId` instead of an arbitrary block range.