### PR TITLE
fix: Dataworker and BundleDataClient should only use chain ID indices from HubChain bundle start block

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -1109,7 +1109,7 @@ export class BundleDataClient {
       (
         await utils.mapAsync(chainIds, async (chainId, index) => {
           const blockRangeForChain = blockRangesForChains[index];
-          if (isChainDisabled(blockRangeForChain)) {
+          if (isChainDisabled(blockRangeForChain) || !blockRangeForChain) {
             return;
           }
           const [_startBlockForChain, _endBlockForChain] = blockRangeForChain;

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -416,11 +416,7 @@ export class BundleDataClient {
     };
 
     const _isChainDisabled = (chainId: number): boolean => {
-      const blockRangeForChain = getBlockRangeForChain(
-        blockRangesForChains,
-        chainId,
-        chainIds
-      );
+      const blockRangeForChain = getBlockRangeForChain(blockRangesForChains, chainId, chainIds);
       return isChainDisabled(blockRangeForChain);
     };
 
@@ -442,11 +438,7 @@ export class BundleDataClient {
     const _cachedBundleTimestamps = this.getBundleTimestampsFromCache(key);
     let bundleBlockTimestamps: { [chainId: string]: number[] } = {};
     if (!_cachedBundleTimestamps) {
-      bundleBlockTimestamps = await this.getBundleBlockTimestamps(
-        chainIds,
-        blockRangesForChains,
-        spokePoolClients
-      );
+      bundleBlockTimestamps = await this.getBundleBlockTimestamps(chainIds, blockRangesForChains, spokePoolClients);
       this.setBundleTimestampsInCache(key, bundleBlockTimestamps);
       if (logData) {
         this.logger.debug({
@@ -512,11 +504,7 @@ export class BundleDataClient {
           )
         );
 
-        const blockRangeForChain = getBlockRangeForChain(
-          blockRangesForChains,
-          Number(destinationChainId),
-          chainIds
-        );
+        const blockRangeForChain = getBlockRangeForChain(blockRangesForChains, Number(destinationChainId), chainIds);
 
         // Find all valid fills matching a deposit on the origin chain and sent on the destination chain.
         // Don't include any fills past the bundle end block for the chain, otherwise the destination client will
@@ -605,11 +593,7 @@ export class BundleDataClient {
 
     for (const originChainId of allChainIds) {
       const originClient = spokePoolClients[originChainId];
-      const originChainBlockRange = getBlockRangeForChain(
-        blockRangesForChains,
-        originChainId,
-        chainIds
-      );
+      const originChainBlockRange = getBlockRangeForChain(blockRangesForChains, originChainId, chainIds);
 
       for (const destinationChainId of allChainIds) {
         if (originChainId === destinationChainId) {
@@ -668,11 +652,7 @@ export class BundleDataClient {
         }
 
         const destinationClient = spokePoolClients[destinationChainId];
-        const destinationChainBlockRange = getBlockRangeForChain(
-          blockRangesForChains,
-          destinationChainId,
-          chainIds
-        );
+        const destinationChainBlockRange = getBlockRangeForChain(blockRangesForChains, destinationChainId, chainIds);
 
         // Keep track of fast fills that replaced slow fills, which we'll use to create "unexecutable" slow fills
         // if the slow fill request was sent in a prior bundle.
@@ -853,11 +833,7 @@ export class BundleDataClient {
             fill.relayExecutionInfo.fillType === FillType.ReplacedSlowFill,
             "Fill type should be ReplacedSlowFill."
           );
-          const destinationBlockRange = getBlockRangeForChain(
-            blockRangesForChains,
-            destinationChainId,
-            chainIds
-          );
+          const destinationBlockRange = getBlockRangeForChain(blockRangesForChains, destinationChainId, chainIds);
           if (
             // If the slow fill request that was replaced by this fill was in an older bundle, then we don't
             // need to check if the slow fill request was valid since we can assume all bundles in the past
@@ -896,11 +872,7 @@ export class BundleDataClient {
       const { deposit, slowFillRequest, fill } = v3RelayHashes[relayDataHash];
       assert(deposit, "Deposit should exist in relay hash dictionary.");
       const { destinationChainId } = deposit;
-      const destinationBlockRange = getBlockRangeForChain(
-        blockRangesForChains,
-        destinationChainId,
-        chainIds
-      );
+      const destinationBlockRange = getBlockRangeForChain(blockRangesForChains, destinationChainId, chainIds);
 
       // Only look for deposits that were mined before this bundle and that are newly expired.
       // If the fill deadline is lower than the bundle start block on the destination chain, then
@@ -1048,11 +1020,7 @@ export class BundleDataClient {
       unexecutableSlowFills
     );
     if (logData) {
-      const mainnetRange = getBlockRangeForChain(
-        blockRangesForChains,
-        this.clients.hubPoolClient.chainId,
-        chainIds
-      );
+      const mainnetRange = getBlockRangeForChain(blockRangesForChains, this.clients.hubPoolClient.chainId, chainIds);
       this.logger.debug({
         at: "BundleDataClient#loadData",
         message: `Finished loading spoke pool data for the equivalent of mainnet range: [${mainnetRange[0]}, ${mainnetRange[1]}]`,

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -221,10 +221,17 @@ export class BundleDataClient {
   // - Bundles that are pending liveness
   // - Not yet proposed bundles
   async getNextBundleRefunds(): Promise<CombinedRefunds> {
-    const futureBundleEvaluationBlockRanges = getWidestPossibleExpectedBlockRange(
+    const hubPoolClient = this.clients.hubPoolClient;
+    const nextBundleMainnetStartBlock = hubPoolClient.getNextBundleStartBlockNumber(
       this.chainIdListForBundleEvaluationBlockNumbers,
+      hubPoolClient.latestBlockSearched,
+      hubPoolClient.chainId
+    );
+    const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(nextBundleMainnetStartBlock);
+    const futureBundleEvaluationBlockRanges = getWidestPossibleExpectedBlockRange(
+      chainIds,
       this.spokePoolClients,
-      getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
+      getEndBlockBuffers(chainIds, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockSearched,
       this.clients.configStoreClient.getEnabledChains(this.clients.hubPoolClient.latestBlockSearched)

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -350,11 +350,7 @@ export class Dataworker {
       spokePoolClients,
       nextBundleMainnetStartBlock
     );
-    const mainnetBlockRange = getBlockRangeForChain(
-      blockRangesForProposal,
-      hubPoolClient.chainId,
-      chainIds
-    );
+    const mainnetBlockRange = getBlockRangeForChain(blockRangesForProposal, hubPoolClient.chainId, chainIds);
 
     // Exit early if spoke pool clients don't have early enough event data to satisfy block ranges for the
     // potential proposal

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -533,18 +533,22 @@ export class Dataworker {
       unexecutableSlowFills,
       bundleSlowFillsV3,
     };
-    const allValidFillsInRange = getFillsInRange(
-      allValidFills,
-      blockRangesForProposal,
-      this.chainIdListForBundleEvaluationBlockNumbers
-    );
-
     const hubPoolChainId = this.clients.hubPoolClient.chainId;
-    const mainnetBundleEndBlock = getBlockRangeForChain(
+    const [
+      mainnetBundleStartBlock,
+      mainnetBundleEndBlock,
+    ] = getBlockRangeForChain(
       blockRangesForProposal,
       hubPoolChainId,
       this.chainIdListForBundleEvaluationBlockNumbers
-    )[1];
+    );
+    const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleStartBlock)
+    const allValidFillsInRange = getFillsInRange(
+      allValidFills,
+      blockRangesForProposal,
+      chainIds
+    );
+
     const poolRebalanceRoot = await this._getPoolRebalanceRoot(
       spokePoolClients,
       blockRangesForProposal,

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -758,10 +758,18 @@ export class Dataworker {
       };
     }
 
-    const endBlockBuffers = getEndBlockBuffers(
-      this.chainIdListForBundleEvaluationBlockNumbers,
-      this.blockRangeEndBlockBuffer
+    const blockRangesImpliedByBundleEndBlocks = widestPossibleExpectedBlockRange.map((blockRange, index) => [
+      blockRange[0],
+      rootBundle.bundleEvaluationBlockNumbers[index],
+    ]);
+    const mainnetBlockRange = getBlockRangeForChain(
+      blockRangesImpliedByBundleEndBlocks,
+      hubPoolChainId,
+      this.chainIdListForBundleEvaluationBlockNumbers
     );
+    const mainnetBundleStartBlock = mainnetBlockRange[0];
+    const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleStartBlock);
+    const endBlockBuffers = getEndBlockBuffers(chainIds, this.blockRangeEndBlockBuffer);
 
     // Make sure that all end blocks are >= expected start blocks. Allow for situation where chain was halted
     // and bundle end blocks hadn't advanced at time of proposal, meaning that the end blocks were equal to the
@@ -781,7 +789,7 @@ export class Dataworker {
       return {
         valid: false,
         reason: PoolRebalanceUtils.generateMarkdownForDisputeInvalidBundleBlocks(
-          this.chainIdListForBundleEvaluationBlockNumbers,
+          chainIds,
           rootBundle,
           widestPossibleExpectedBlockRange,
           endBlockBuffers
@@ -810,7 +818,7 @@ export class Dataworker {
         return {
           valid: false,
           reason: PoolRebalanceUtils.generateMarkdownForDisputeInvalidBundleBlocks(
-            this.chainIdListForBundleEvaluationBlockNumbers,
+            chainIds,
             rootBundle,
             widestPossibleExpectedBlockRange,
             endBlockBuffers
@@ -834,18 +842,9 @@ export class Dataworker {
     // The block range that we'll use to construct roots will be the end block specified in the pending root bundle,
     // and the block right after the last valid root bundle proposal's end block. If the proposer didn't use the same
     // start block, then they might have missed events and the roots will be different.
-    const blockRangesImpliedByBundleEndBlocks = widestPossibleExpectedBlockRange.map((blockRange, index) => [
-      blockRange[0],
-      rootBundle.bundleEvaluationBlockNumbers[index],
-    ]);
-    const mainnetBlockRange = getBlockRangeForChain(
-      blockRangesImpliedByBundleEndBlocks,
-      hubPoolChainId,
-      this.chainIdListForBundleEvaluationBlockNumbers
-    );
+
     // Exit early if spoke pool clients don't have early enough event data to satisfy block ranges for the
     // pending proposal. Log an error loudly so that user knows that disputer needs to increase its lookback.
-    const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBlockRange[0]);
     if (
       Object.keys(earliestBlocksInSpokePoolClients).length > 0 &&
       (await blockRangesAreInvalidForSpokeClients(
@@ -893,8 +892,6 @@ export class Dataworker {
         reason: "out-of-date-config-store-version",
       };
     }
-
-    const mainnetBundleStartBlock = mainnetBlockRange[0];
 
     // Check if we have the right code to validate a bundle for the given block ranges.
     const versionAtProposalBlock =
@@ -990,7 +987,7 @@ export class Dataworker {
         "\n" +
         PoolRebalanceUtils.generateMarkdownForRootBundle(
           this.clients.hubPoolClient,
-          this.chainIdListForBundleEvaluationBlockNumbers,
+          chainIds,
           hubPoolChainId,
           blockRangesImpliedByBundleEndBlocks,
           [...expectedPoolRebalanceRoot.leaves],
@@ -2070,6 +2067,7 @@ export class Dataworker {
   ): void {
     try {
       const bundleEndBlocks = bundleBlockRange.map((block) => block[1]);
+      const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(bundleBlockRange[0][0]);
       this.clients.multiCallerClient.enqueueTransaction({
         contract: this.clients.hubPoolClient.hubPool, // target contract
         chainId: hubPoolChainId,
@@ -2078,7 +2076,7 @@ export class Dataworker {
         message: "Proposed new root bundle 🌱", // message sent to logger.
         mrkdwn: PoolRebalanceUtils.generateMarkdownForRootBundle(
           this.clients.hubPoolClient,
-          this.chainIdListForBundleEvaluationBlockNumbers,
+          chainIds,
           hubPoolChainId,
           bundleBlockRange,
           [...poolRebalanceLeaves],
@@ -2237,11 +2235,12 @@ export class Dataworker {
     spokePoolClients: SpokePoolClientsByChain,
     mainnetBundleStartBlock: number
   ): number[][] {
+    const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleStartBlock);
     return PoolRebalanceUtils.getWidestPossibleExpectedBlockRange(
       // We only want as many block ranges as there are chains enabled at the time of the bundle start block.
-      this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleStartBlock),
+      chainIds,
       spokePoolClients,
-      getEndBlockBuffers(this.chainIdListForBundleEvaluationBlockNumbers, this.blockRangeEndBlockBuffer),
+      getEndBlockBuffers(chainIds, this.blockRangeEndBlockBuffer),
       this.clients,
       this.clients.hubPoolClient.latestBlockSearched,
       // We only want to count enabled chains at the same time that we are loading chain ID indices.

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -345,6 +345,7 @@ export class Dataworker {
       hubPoolClient.latestBlockSearched,
       hubPoolClient.chainId
     );
+    const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(nextBundleMainnetStartBlock);
     const blockRangesForProposal = this._getWidestPossibleBlockRangeForNextBundle(
       spokePoolClients,
       nextBundleMainnetStartBlock
@@ -352,7 +353,7 @@ export class Dataworker {
     const mainnetBlockRange = getBlockRangeForChain(
       blockRangesForProposal,
       hubPoolClient.chainId,
-      this.chainIdListForBundleEvaluationBlockNumbers
+      chainIds
     );
 
     // Exit early if spoke pool clients don't have early enough event data to satisfy block ranges for the
@@ -362,7 +363,7 @@ export class Dataworker {
       (await blockRangesAreInvalidForSpokeClients(
         spokePoolClients,
         blockRangesForProposal,
-        this.chainIdListForBundleEvaluationBlockNumbers,
+        chainIds,
         earliestBlocksInSpokePoolClients,
         this.isV3(mainnetBlockRange[0])
       ))

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -851,12 +851,13 @@ export class Dataworker {
     );
     // Exit early if spoke pool clients don't have early enough event data to satisfy block ranges for the
     // pending proposal. Log an error loudly so that user knows that disputer needs to increase its lookback.
+    const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBlockRange[0]);
     if (
       Object.keys(earliestBlocksInSpokePoolClients).length > 0 &&
       (await blockRangesAreInvalidForSpokeClients(
         spokePoolClients,
         blockRangesImpliedByBundleEndBlocks,
-        this.chainIdListForBundleEvaluationBlockNumbers,
+        chainIds,
         earliestBlocksInSpokePoolClients,
         this.isV3(mainnetBlockRange[0])
       ))
@@ -881,7 +882,7 @@ export class Dataworker {
       at: "Dataworker#validate",
       message: "Implied bundle ranges are valid",
       blockRangesImpliedByBundleEndBlocks,
-      chainIdListForBundleEvaluationBlockNumbers: this.chainIdListForBundleEvaluationBlockNumbers,
+      chainIdListForBundleEvaluationBlockNumbers: chainIds,
     });
 
     // If config store version isn't up to date, return early. This is a simple rule that is perhaps too aggressive
@@ -1089,12 +1090,13 @@ export class Dataworker {
             this.clients.hubPoolClient.chainId,
             this.chainIdListForBundleEvaluationBlockNumbers
           );
+          const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBlockRange[0]);
           if (
             Object.keys(earliestBlocksInSpokePoolClients).length > 0 &&
             (await blockRangesAreInvalidForSpokeClients(
               spokePoolClients,
               blockNumberRanges,
-              this.chainIdListForBundleEvaluationBlockNumbers,
+              chainIds,
               earliestBlocksInSpokePoolClients,
               this.isV3(mainnetBlockRange[0])
             ))
@@ -1884,12 +1886,13 @@ export class Dataworker {
           hubPoolClient.chainId,
           this.chainIdListForBundleEvaluationBlockNumbers
         );
+        const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBlockRanges[0]);
         if (
           Object.keys(earliestBlocksInSpokePoolClients).length > 0 &&
           (await blockRangesAreInvalidForSpokeClients(
             spokePoolClients,
             blockNumberRanges,
-            this.chainIdListForBundleEvaluationBlockNumbers,
+            chainIds,
             earliestBlocksInSpokePoolClients,
             this.isV3(mainnetBlockRanges[0])
           ))

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -534,20 +534,13 @@ export class Dataworker {
       bundleSlowFillsV3,
     };
     const hubPoolChainId = this.clients.hubPoolClient.chainId;
-    const [
-      mainnetBundleStartBlock,
-      mainnetBundleEndBlock,
-    ] = getBlockRangeForChain(
+    const [mainnetBundleStartBlock, mainnetBundleEndBlock] = getBlockRangeForChain(
       blockRangesForProposal,
       hubPoolChainId,
       this.chainIdListForBundleEvaluationBlockNumbers
     );
-    const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleStartBlock)
-    const allValidFillsInRange = getFillsInRange(
-      allValidFills,
-      blockRangesForProposal,
-      chainIds
-    );
+    const chainIds = this.clients.configStoreClient.getChainIdIndicesForBlock(mainnetBundleStartBlock);
+    const allValidFillsInRange = getFillsInRange(allValidFills, blockRangesForProposal, chainIds);
 
     const poolRebalanceRoot = await this._getPoolRebalanceRoot(
       spokePoolClients,

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -100,7 +100,8 @@ export async function blockRangesAreInvalidForSpokeClients(
       blockRanges,
       chainIdListForBundleEvaluationBlockNumbers
     );
-    assert(Object.keys(endBlockTimestamps).length === Object.values(spokePoolClients).filter(isDefined).length);
+    // There should be a spoke pool client instantiated for every bundle timestamp.
+    assert(Object.keys(endBlockTimestamps).every((chainId) => spokePoolClients[chainId] !== undefined));
   }
   return utils.someAsync(blockRanges, async ([start, end], index) => {
     const chainId = chainIdListForBundleEvaluationBlockNumbers[index];

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -101,7 +101,7 @@ export async function blockRangesAreInvalidForSpokeClients(
       chainIdListForBundleEvaluationBlockNumbers
     );
     // There should be a spoke pool client instantiated for every bundle timestamp.
-    assert(Object.keys(endBlockTimestamps).every((chainId) => spokePoolClients[chainId] !== undefined));
+    assert(!Object.keys(endBlockTimestamps).some((chainId) => !isDefined(spokePoolClients[chainId])));
   }
   return utils.someAsync(blockRanges, async ([start, end], index) => {
     const chainId = chainIdListForBundleEvaluationBlockNumbers[index];


### PR DESCRIPTION
There  are errors when trying to access block ranges at indices that exist in chain IDs but not in the block ranges list
