### PR TITLE
fix(blockRangesAreInvalidForSpokePoolClients): Handle case where bundle range start block is 0

### DIFF
--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -130,7 +130,7 @@ export async function blockRangesAreInvalidForSpokeClients(
     // Note: Math.max the from block with the registration block of the spoke pool to handle the edge case for the first
     // bundle that set its start blocks equal 0.
     const bundleRangeFromBlock = Math.max(spokePoolClient.deploymentBlock, start);
-    if (bundleRangeFromBlock <= latestInvalidBundleStartBlockForChain || end > clientLastBlockQueried) {
+    if (bundleRangeFromBlock < latestInvalidBundleStartBlockForChain || end > clientLastBlockQueried) {
       return true;
     }
 

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -89,7 +89,7 @@ export async function blockRangesAreInvalidForSpokeClients(
   spokePoolClients: Record<number, SpokePoolClient>,
   blockRanges: number[][],
   chainIdListForBundleEvaluationBlockNumbers: number[],
-  latestInvalidBundleStartBlock: { [chainId: number]: number },
+  earliestValidBundleStartBlock: { [chainId: number]: number },
   isV3 = false
 ): Promise<boolean> {
   assert(blockRanges.length === chainIdListForBundleEvaluationBlockNumbers.length);
@@ -122,15 +122,15 @@ export async function blockRangesAreInvalidForSpokeClients(
 
     const clientLastBlockQueried = spokePoolClient.latestBlockSearched;
 
-    const latestInvalidBundleStartBlockForChain =
-      latestInvalidBundleStartBlock[chainId] ?? spokePoolClient.deploymentBlock;
+    const earliestValidBundleStartBlockForChain =
+      earliestValidBundleStartBlock[chainId] ?? spokePoolClient.deploymentBlock;
 
     // If range start block is less than the earliest spoke pool client we can validate or the range end block
     // is greater than the latest client end block, then ranges are invalid.
     // Note: Math.max the from block with the registration block of the spoke pool to handle the edge case for the first
     // bundle that set its start blocks equal 0.
     const bundleRangeFromBlock = Math.max(spokePoolClient.deploymentBlock, start);
-    if (bundleRangeFromBlock < latestInvalidBundleStartBlockForChain || end > clientLastBlockQueried) {
+    if (bundleRangeFromBlock < earliestValidBundleStartBlockForChain || end > clientLastBlockQueried) {
       return true;
     }
 

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -139,7 +139,13 @@ export async function blockRangesAreInvalidForSpokeClients(
         bundleRangeFromBlock,
         end
       );
-      if (endBlockTimestamps[chainId] - spokePoolClient.getOldestTime() < maxFillDeadlineBufferInBlockRange) {
+      // Skip this check if the spokePoolClient.fromBlock is less than or equal to the spokePool deployment block. 
+      // In this case, we have all the information for this SpokePool possible so there are no older deposits 
+      // that might have expired that we might miss.
+      if (
+        spokePoolClient.eventSearchConfig.fromBlock > spokePoolClient.deploymentBlock &&
+        endBlockTimestamps[chainId] - spokePoolClient.getOldestTime() < maxFillDeadlineBufferInBlockRange
+      ) {
         return true;
       }
     }

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -122,17 +122,23 @@ export async function blockRangesAreInvalidForSpokeClients(
 
     const clientLastBlockQueried = spokePoolClient.latestBlockSearched;
 
+    const latestInvalidBundleStartBlockForChain =
+      latestInvalidBundleStartBlock[chainId] ?? spokePoolClient.deploymentBlock;
+
     // If range start block is less than the earliest spoke pool client we can validate or the range end block
     // is greater than the latest client end block, then ranges are invalid.
-    // Note: Math.max the from block with the deployment block of the spoke pool to handle the edge case for the first
+    // Note: Math.max the from block with the registration block of the spoke pool to handle the edge case for the first
     // bundle that set its start blocks equal 0.
     const bundleRangeFromBlock = Math.max(spokePoolClient.deploymentBlock, start);
-    if (bundleRangeFromBlock <= latestInvalidBundleStartBlock[chainId] || end > clientLastBlockQueried) {
+    if (bundleRangeFromBlock <= latestInvalidBundleStartBlockForChain || end > clientLastBlockQueried) {
       return true;
     }
 
     if (endBlockTimestamps !== undefined) {
-      const maxFillDeadlineBufferInBlockRange = await spokePoolClient.getMaxFillDeadlineInRange(start, end);
+      const maxFillDeadlineBufferInBlockRange = await spokePoolClient.getMaxFillDeadlineInRange(
+        bundleRangeFromBlock,
+        end
+      );
       if (endBlockTimestamps[chainId] - spokePoolClient.getOldestTime() < maxFillDeadlineBufferInBlockRange) {
         return true;
       }

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -139,8 +139,8 @@ export async function blockRangesAreInvalidForSpokeClients(
         bundleRangeFromBlock,
         end
       );
-      // Skip this check if the spokePoolClient.fromBlock is less than or equal to the spokePool deployment block. 
-      // In this case, we have all the information for this SpokePool possible so there are no older deposits 
+      // Skip this check if the spokePoolClient.fromBlock is less than or equal to the spokePool deployment block.
+      // In this case, we have all the information for this SpokePool possible so there are no older deposits
       // that might have expired that we might miss.
       if (
         spokePoolClient.eventSearchConfig.fromBlock > spokePoolClient.deploymentBlock &&

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -268,7 +268,9 @@ describe("Dataworker block range-related utility methods", async function () {
       originSpokePoolClient.logger,
       fakeSpokePool,
       originSpokePoolClient.chainId,
-      originSpokePoolClient.deploymentBlock
+      originSpokePoolClient.eventSearchConfig.fromBlock-1 // Set deployment block less than eventSearchConfig.fromBlock
+      // to force blockRangesAreInvalidForSpokeClients to compare the client's oldestTime() with its 
+      // fill deadline buffer.
     );
     const blockRanges = [[mainnetDeploymentBlock + 1, mockSpokePoolClient.latestBlockSearched]];
     const endBlockTimestamps = await getTimestampsForBundleEndBlocks(

--- a/test/Dataworker.blockRangeUtils.ts
+++ b/test/Dataworker.blockRangeUtils.ts
@@ -268,8 +268,8 @@ describe("Dataworker block range-related utility methods", async function () {
       originSpokePoolClient.logger,
       fakeSpokePool,
       originSpokePoolClient.chainId,
-      originSpokePoolClient.eventSearchConfig.fromBlock-1 // Set deployment block less than eventSearchConfig.fromBlock
-      // to force blockRangesAreInvalidForSpokeClients to compare the client's oldestTime() with its 
+      originSpokePoolClient.eventSearchConfig.fromBlock - 1 // Set deployment block less than eventSearchConfig.fromBlock
+      // to force blockRangesAreInvalidForSpokeClients to compare the client's oldestTime() with its
       // fill deadline buffer.
     );
     const blockRanges = [[mainnetDeploymentBlock + 1, mockSpokePoolClient.latestBlockSearched]];


### PR DESCRIPTION
This  happens for the first bundle proposed containing a new chain
