### PR TITLE
feat(linea): add entry for atomic depositor

### DIFF
--- a/contracts/AtomicWethDepositor.sol
+++ b/contracts/AtomicWethDepositor.sol
@@ -39,7 +39,8 @@ interface LineaL1MessageService {
 
 /**
  * @notice Contract deployed on Ethereum helps relay bots atomically unwrap and bridge WETH over the canonical chain
- * bridges for Optimism, Base, Boba, ZkSync, and Polygon. Needed as these chains only support bridging of ETH, not WETH.
+ * bridges for Optimism, Base, Boba, ZkSync, Linea, and Polygon. Needed as these chains only support bridging of ETH, 
+ * not WETH.
  */
 
 contract AtomicWethDepositor {
@@ -53,6 +54,7 @@ contract AtomicWethDepositor {
         LineaL1MessageService(0xd19d4B5d358258f05D7B411E21A1460D11B0876F);
 
     event ZkSyncEthDepositInitiated(address indexed from, address indexed to, uint256 amount);
+    event LineaEthDepositInitiated(address indexed from, address indexed to, uint256 amount);
 
     function bridgeWethToOvm(address to, uint256 amount, uint32 l2Gas, uint256 chainId) public {
         weth.transferFrom(msg.sender, address(this), amount);
@@ -79,6 +81,8 @@ contract AtomicWethDepositor {
         weth.transferFrom(msg.sender, address(this), amount);
         weth.withdraw(amount);
         lineaL1MessageService.sendMessage{ value: amount + msg.value }(to, msg.value, "");
+        // Emit an event that we can easily track in the Linea-related adapters/finalizers
+        emit LineaEthDepositInitiated(msg.sender, to, amount);
     }
 
     function bridgeWethToZkSync(

--- a/contracts/AtomicWethDepositor.sol
+++ b/contracts/AtomicWethDepositor.sol
@@ -78,7 +78,7 @@ contract AtomicWethDepositor {
     function bridgeWethToLinea(address to, uint256 amount) public payable {
         weth.transferFrom(msg.sender, address(this), amount);
         weth.withdraw(amount);
-        lineaL1MessageService.sendMessage{ value: amount }(to, 0, "");
+        lineaL1MessageService.sendMessage{ value: amount + msg.value }(to, msg.value, "");
     }
 
     function bridgeWethToZkSync(

--- a/contracts/AtomicWethDepositor.sol
+++ b/contracts/AtomicWethDepositor.sol
@@ -39,7 +39,7 @@ interface LineaL1MessageService {
 
 /**
  * @notice Contract deployed on Ethereum helps relay bots atomically unwrap and bridge WETH over the canonical chain
- * bridges for Optimism, Base, Boba, ZkSync, Linea, and Polygon. Needed as these chains only support bridging of ETH, 
+ * bridges for Optimism, Base, Boba, ZkSync, Linea, and Polygon. Needed as these chains only support bridging of ETH,
  * not WETH.
  */
 


### PR DESCRIPTION
Atomic WETH deposits aren't supported on Linea. We should use the Atomic depositor to unwrap/send WETH to Linea.

An item to note:
1. By only passing the `value` equal to the `amount` we're effectively preventing the AtomicWETHDepositor from allowing automatic executions to Linea. This is how the `LineaChainAdapter` performs its transfer.
2. To allow optional automatic filling, we'd need to be able to pass payable value such that `lineaL1MessageService.send{ value: amount + msg.value }(...)`