### PR TITLE
fix: Relayer should only add chains to CrossChainTransferClient that are supported in AdapterManager

### DIFF
--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -107,7 +107,12 @@ export async function constructRelayerClients(
     configStoreClient.getChainIdIndicesForBlock(),
     config.blockRangeEndBlockBuffer
   );
-  const crossChainTransferClient = new CrossChainTransferClient(logger, enabledChainIds, adapterManager);
+  const crossChainAdapterSupportedChains = adapterManager.supportedChains();
+  const crossChainTransferClient = new CrossChainTransferClient(
+    logger,
+    enabledChainIds.filter((chainId) => crossChainAdapterSupportedChains.includes(chainId)),
+    adapterManager
+  );
   const inventoryClient = new InventoryClient(
     signerAddr,
     logger,


### PR DESCRIPTION
This allows relayer to ignore chains that haven't implemented the full inventory manager function set

This is not a bug seen in prod because RELAYER_DESTINATION_CHAINS is set to not include linea