### PR TITLE
fix(relayer): Post-process external inventory config

### DIFF
--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -124,6 +124,7 @@ export async function constructRelayerClients(
       const msg = typeguards.isError(err) ? err.message : (err as Record<string, unknown>)?.code;
       throw new Error(`Inventory config error in ${config.externalInventoryConfig} (${msg ?? "unknown error"})`);
     }
+    config.parseInventoryConfig();
     logger.debug({
       at: "Relayer#constructRelayerClients",
       message: "Updated Inventory config.",

--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -1,4 +1,4 @@
-import { typeguards, utils as sdkUtils } from "@across-protocol/sdk-v2";
+import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import winston from "winston";
 import { AcrossApiClient, BundleDataClient, InventoryClient, ProfitClient, TokenClient } from "../clients";
 import { AdapterManager, CrossChainTransferClient } from "../clients/bridges";
@@ -11,7 +11,7 @@ import {
   updateSpokePoolClients,
 } from "../common";
 import { SpokePoolClientsByChain } from "../interfaces";
-import { isDefined, readFile, Signer } from "../utils";
+import { Signer } from "../utils";
 import { RelayerConfig } from "./RelayerConfig";
 
 export interface RelayerClients extends Clients {
@@ -114,24 +114,6 @@ export async function constructRelayerClients(
     enabledChainIds.filter((chainId) => crossChainAdapterSupportedChains.includes(chainId)),
     adapterManager
   );
-
-  // If an external inventory configuration was defined, read it in now before instantiating the InventoryClient.
-  if (isDefined(config.externalInventoryConfig)) {
-    const _inventoryConfig = await readFile(config.externalInventoryConfig);
-    try {
-      config.inventoryConfig = JSON.parse(_inventoryConfig);
-    } catch (err) {
-      const msg = typeguards.isError(err) ? err.message : (err as Record<string, unknown>)?.code;
-      throw new Error(`Inventory config error in ${config.externalInventoryConfig} (${msg ?? "unknown error"})`);
-    }
-    config.parseInventoryConfig();
-    logger.debug({
-      at: "Relayer#constructRelayerClients",
-      message: "Updated Inventory config.",
-      source: config.externalInventoryConfig,
-      inventoryConfig: config.inventoryConfig,
-    });
-  }
 
   const inventoryClient = new InventoryClient(
     signerAddr,

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -76,42 +76,7 @@ export class RelayerConfig extends CommonConfig {
     this.inventoryConfig = isDefined(RELAYER_EXTERNAL_INVENTORY_CONFIG)
       ? readFileSync(RELAYER_EXTERNAL_INVENTORY_CONFIG)
       : JSON.parse(RELAYER_INVENTORY_CONFIG ?? "{}");
-    this.parseInventoryConfig();
 
-    this.minRelayerFeePct = toBNWei(MIN_RELAYER_FEE_PCT || Constants.RELAYER_MIN_FEE_PCT);
-
-    this.debugProfitability = DEBUG_PROFITABILITY === "true";
-    this.relayerGasPadding = toBNWei(RELAYER_GAS_PADDING || Constants.DEFAULT_RELAYER_GAS_PADDING);
-    this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
-    this.relayerMessageGasMultiplier = toBNWei(
-      RELAYER_GAS_MESSAGE_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MESSAGE_MULTIPLIER
-    );
-    this.sendingRelaysEnabled = SEND_RELAYS === "true";
-    this.sendingRebalancesEnabled = SEND_REBALANCES === "true";
-    this.sendingMessageRelaysEnabled = SEND_MESSAGE_RELAYS === "true";
-    this.skipRelays = SKIP_RELAYS === "true";
-    this.skipRebalancing = SKIP_REBALANCING === "true";
-    this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
-    this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";
-    (this.minDepositConfirmations = MIN_DEPOSIT_CONFIRMATIONS
-      ? JSON.parse(MIN_DEPOSIT_CONFIRMATIONS)
-      : Constants.MIN_DEPOSIT_CONFIRMATIONS),
-      Object.keys(this.minDepositConfirmations).forEach((threshold) => {
-        Object.keys(this.minDepositConfirmations[threshold]).forEach((chainId) => {
-          const nBlocks: number = this.minDepositConfirmations[threshold][chainId];
-          assert(
-            !isNaN(nBlocks) && nBlocks >= 0,
-            `Chain ${chainId} minimum deposit confirmations for "${threshold}" threshold missing or invalid (${nBlocks}).`
-          );
-        });
-      });
-    // Force default thresholds in MDC config.
-    this.minDepositConfirmations["default"] = Constants.DEFAULT_MIN_DEPOSIT_CONFIRMATIONS;
-    this.ignoreLimits = RELAYER_IGNORE_LIMITS === "true";
-  }
-
-  // Post-process the imported JSON to scale the configured values to 18 decimals.
-  private parseInventoryConfig(): void {
     if (Object.keys(this.inventoryConfig).length > 0) {
       this.inventoryConfig = replaceAddressCase(this.inventoryConfig); // Cast any non-address case addresses.
       this.inventoryConfig.wrapEtherThreshold = this.inventoryConfig.wrapEtherThreshold
@@ -124,7 +89,7 @@ export class RelayerConfig extends CommonConfig {
       this.inventoryConfig.wrapEtherTargetPerChain ??= {};
       assert(
         this.inventoryConfig.wrapEtherThreshold.gte(this.inventoryConfig.wrapEtherTarget),
-        `default wrapEtherThreshold ${this.inventoryConfig.wrapEtherThreshold} must be >= default wrapEtherTarget ${this.inventoryConfig.wrapEtherTarget}}`
+        `default wrapEtherThreshold ${this.inventoryConfig.wrapEtherThreshold} must be >= default wrapEtherTarget ${this.inventoryConfig.wrapEtherTarget}`
       );
 
       // Validate the per chain target and thresholds for wrapping ETH:
@@ -173,5 +138,36 @@ export class RelayerConfig extends CommonConfig {
         });
       });
     }
+
+    this.minRelayerFeePct = toBNWei(MIN_RELAYER_FEE_PCT || Constants.RELAYER_MIN_FEE_PCT);
+
+    this.debugProfitability = DEBUG_PROFITABILITY === "true";
+    this.relayerGasPadding = toBNWei(RELAYER_GAS_PADDING || Constants.DEFAULT_RELAYER_GAS_PADDING);
+    this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
+    this.relayerMessageGasMultiplier = toBNWei(
+      RELAYER_GAS_MESSAGE_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MESSAGE_MULTIPLIER
+    );
+    this.sendingRelaysEnabled = SEND_RELAYS === "true";
+    this.sendingRebalancesEnabled = SEND_REBALANCES === "true";
+    this.sendingMessageRelaysEnabled = SEND_MESSAGE_RELAYS === "true";
+    this.skipRelays = SKIP_RELAYS === "true";
+    this.skipRebalancing = SKIP_REBALANCING === "true";
+    this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
+    this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";
+    (this.minDepositConfirmations = MIN_DEPOSIT_CONFIRMATIONS
+      ? JSON.parse(MIN_DEPOSIT_CONFIRMATIONS)
+      : Constants.MIN_DEPOSIT_CONFIRMATIONS),
+      Object.keys(this.minDepositConfirmations).forEach((threshold) => {
+        Object.keys(this.minDepositConfirmations[threshold]).forEach((chainId) => {
+          const nBlocks: number = this.minDepositConfirmations[threshold][chainId];
+          assert(
+            !isNaN(nBlocks) && nBlocks >= 0,
+            `Chain ${chainId} minimum deposit confirmations for "${threshold}" threshold missing or invalid (${nBlocks}).`
+          );
+        });
+      });
+    // Force default thresholds in MDC config.
+    this.minDepositConfirmations["default"] = Constants.DEFAULT_MIN_DEPOSIT_CONFIRMATIONS;
+    this.ignoreLimits = RELAYER_IGNORE_LIMITS === "true";
   }
 }

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -73,7 +73,6 @@ export class RelayerConfig extends CommonConfig {
       !isDefined(RELAYER_EXTERNAL_INVENTORY_CONFIG) || !isDefined(RELAYER_INVENTORY_CONFIG),
       "Concurrent inventory management configurations detected."
     );
-    this.externalInventoryConfig = RELAYER_EXTERNAL_INVENTORY_CONFIG;
     this.inventoryConfig = isDefined(RELAYER_EXTERNAL_INVENTORY_CONFIG)
       ? readFileSync(RELAYER_EXTERNAL_INVENTORY_CONFIG)
       : JSON.parse(RELAYER_INVENTORY_CONFIG ?? "{}");

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -69,6 +69,8 @@ export class RelayerConfig extends CommonConfig {
       ? JSON.parse(SLOW_DEPOSITORS).map((depositor) => ethers.utils.getAddress(depositor))
       : [];
 
+    this.minRelayerFeePct = toBNWei(MIN_RELAYER_FEE_PCT || Constants.RELAYER_MIN_FEE_PCT);
+
     assert(
       !isDefined(RELAYER_EXTERNAL_INVENTORY_CONFIG) || !isDefined(RELAYER_INVENTORY_CONFIG),
       "Concurrent inventory management configurations detected."
@@ -138,8 +140,6 @@ export class RelayerConfig extends CommonConfig {
         });
       });
     }
-
-    this.minRelayerFeePct = toBNWei(MIN_RELAYER_FEE_PCT || Constants.RELAYER_MIN_FEE_PCT);
 
     this.debugProfitability = DEBUG_PROFITABILITY === "true";
     this.relayerGasPadding = toBNWei(RELAYER_GAS_PADDING || Constants.DEFAULT_RELAYER_GAS_PADDING);

--- a/src/relayer/RelayerConfig.ts
+++ b/src/relayer/RelayerConfig.ts
@@ -77,9 +77,42 @@ export class RelayerConfig extends CommonConfig {
     );
     this.externalInventoryConfig = RELAYER_EXTERNAL_INVENTORY_CONFIG;
     this.inventoryConfig = JSON.parse(RELAYER_INVENTORY_CONFIG ?? "{}");
+    this.parseInventoryConfig();
 
     this.minRelayerFeePct = toBNWei(MIN_RELAYER_FEE_PCT || Constants.RELAYER_MIN_FEE_PCT);
 
+    this.debugProfitability = DEBUG_PROFITABILITY === "true";
+    this.relayerGasPadding = toBNWei(RELAYER_GAS_PADDING || Constants.DEFAULT_RELAYER_GAS_PADDING);
+    this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
+    this.relayerMessageGasMultiplier = toBNWei(
+      RELAYER_GAS_MESSAGE_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MESSAGE_MULTIPLIER
+    );
+    this.sendingRelaysEnabled = SEND_RELAYS === "true";
+    this.sendingRebalancesEnabled = SEND_REBALANCES === "true";
+    this.sendingMessageRelaysEnabled = SEND_MESSAGE_RELAYS === "true";
+    this.skipRelays = SKIP_RELAYS === "true";
+    this.skipRebalancing = SKIP_REBALANCING === "true";
+    this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
+    this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";
+    (this.minDepositConfirmations = MIN_DEPOSIT_CONFIRMATIONS
+      ? JSON.parse(MIN_DEPOSIT_CONFIRMATIONS)
+      : Constants.MIN_DEPOSIT_CONFIRMATIONS),
+      Object.keys(this.minDepositConfirmations).forEach((threshold) => {
+        Object.keys(this.minDepositConfirmations[threshold]).forEach((chainId) => {
+          const nBlocks: number = this.minDepositConfirmations[threshold][chainId];
+          assert(
+            !isNaN(nBlocks) && nBlocks >= 0,
+            `Chain ${chainId} minimum deposit confirmations for "${threshold}" threshold missing or invalid (${nBlocks}).`
+          );
+        });
+      });
+    // Force default thresholds in MDC config.
+    this.minDepositConfirmations["default"] = Constants.DEFAULT_MIN_DEPOSIT_CONFIRMATIONS;
+    this.ignoreLimits = RELAYER_IGNORE_LIMITS === "true";
+  }
+
+  // Post-process the imported JSON to scale the configured values to 18 decimals.
+  parseInventoryConfig(): void {
     if (Object.keys(this.inventoryConfig).length > 0) {
       this.inventoryConfig = replaceAddressCase(this.inventoryConfig); // Cast any non-address case addresses.
       this.inventoryConfig.wrapEtherThreshold = this.inventoryConfig.wrapEtherThreshold
@@ -141,33 +174,5 @@ export class RelayerConfig extends CommonConfig {
         });
       });
     }
-    this.debugProfitability = DEBUG_PROFITABILITY === "true";
-    this.relayerGasPadding = toBNWei(RELAYER_GAS_PADDING || Constants.DEFAULT_RELAYER_GAS_PADDING);
-    this.relayerGasMultiplier = toBNWei(RELAYER_GAS_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MULTIPLIER);
-    this.relayerMessageGasMultiplier = toBNWei(
-      RELAYER_GAS_MESSAGE_MULTIPLIER || Constants.DEFAULT_RELAYER_GAS_MESSAGE_MULTIPLIER
-    );
-    this.sendingRelaysEnabled = SEND_RELAYS === "true";
-    this.sendingRebalancesEnabled = SEND_REBALANCES === "true";
-    this.sendingMessageRelaysEnabled = SEND_MESSAGE_RELAYS === "true";
-    this.skipRelays = SKIP_RELAYS === "true";
-    this.skipRebalancing = SKIP_REBALANCING === "true";
-    this.sendingSlowRelaysEnabled = SEND_SLOW_RELAYS === "true";
-    this.acceptInvalidFills = ACCEPT_INVALID_FILLS === "true";
-    (this.minDepositConfirmations = MIN_DEPOSIT_CONFIRMATIONS
-      ? JSON.parse(MIN_DEPOSIT_CONFIRMATIONS)
-      : Constants.MIN_DEPOSIT_CONFIRMATIONS),
-      Object.keys(this.minDepositConfirmations).forEach((threshold) => {
-        Object.keys(this.minDepositConfirmations[threshold]).forEach((chainId) => {
-          const nBlocks: number = this.minDepositConfirmations[threshold][chainId];
-          assert(
-            !isNaN(nBlocks) && nBlocks >= 0,
-            `Chain ${chainId} minimum deposit confirmations for "${threshold}" threshold missing or invalid (${nBlocks}).`
-          );
-        });
-      });
-    // Force default thresholds in MDC config.
-    this.minDepositConfirmations["default"] = Constants.DEFAULT_MIN_DEPOSIT_CONFIRMATIONS;
-    this.ignoreLimits = RELAYER_IGNORE_LIMITS === "true";
   }
 }

--- a/src/utils/fsUtils.ts
+++ b/src/utils/fsUtils.ts
@@ -1,5 +1,16 @@
 import * as fs from "fs/promises";
+import { readFileSync as _readFileSync } from "node:fs";
 import { typeguards } from "@across-protocol/sdk-v2";
+
+export function readFileSync(fileName: string): string {
+  try {
+    return _readFileSync(fileName, { encoding: "utf8" });
+  } catch (err) {
+    // @dev fs methods can return errors that are not Error objects (i.e. errno).
+    const msg = typeguards.isError(err) ? err.message : (err as Record<string, unknown>)?.code;
+    throw new Error(`Unable to read ${fileName} (${msg ?? "unknown error"})`);
+  }
+}
 
 export async function readFile(fileName: string): Promise<string> {
   try {


### PR DESCRIPTION
The recent change to support externally-defined inventory configs neglected to post-process the imported config. It's important to scale each configured amount before taking the config into use.