### PR TITLE
feat: Cache limits for 5 mins from Across API

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -157,7 +157,7 @@ export class AcrossApiClient {
             url,
             params,
             result,
-          })
+          });
           continue;
         }
         if (redis) {


### PR DESCRIPTION
Lots of relayers running at same time is stressful on API requests