### PR TITLE
fix: call sample-wrapping function

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -53,8 +53,7 @@ class RateLimitedProvider extends ethers.providers.StaticJsonRpcProvider {
     // request. This queue sends out requests concurrently, but stops once the concurrency limit is reached. The
     // maxConcurrency is configured here.
     this.queue = createQueue(async ({ sendArgs, resolve, reject }: RateLimitTask) => {
-      await this
-        .wrapSendWithLog(...sendArgs)
+      await this.wrapSendWithLog(...sendArgs)
         .then(resolve)
         .catch(reject);
     }, maxConcurrency);

--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -53,8 +53,8 @@ class RateLimitedProvider extends ethers.providers.StaticJsonRpcProvider {
     // request. This queue sends out requests concurrently, but stops once the concurrency limit is reached. The
     // maxConcurrency is configured here.
     this.queue = createQueue(async ({ sendArgs, resolve, reject }: RateLimitTask) => {
-      await super
-        .send(...sendArgs)
+      await this
+        .wrapSendWithLog(...sendArgs)
         .then(resolve)
         .catch(reject);
     }, maxConcurrency);


### PR DESCRIPTION
The [previous PR](https://github.com/across-protocol/relayer-v2/pull/1315) for log sampling included the function, but didn't call it. This PR fixes that omission.