### PR TITLE
Revert "improve(relayer): Drop unused SpokePool events (#1272)"

### DIFF
--- a/src/relayer/RelayerClientHelper.ts
+++ b/src/relayer/RelayerClientHelper.ts
@@ -162,6 +162,8 @@ export async function updateRelayerClients(clients: RelayerClients, config: Rela
     "RequestedV3SlowFill",
     "FilledV3Relay",
     "EnabledDepositRoute",
+    "RelayedRootBundle",
+    "ExecutedRelayerRefundRoot",
   ]);
 
   // Update the token client first so that inventory client has latest balances.


### PR DESCRIPTION
This reverts commit d3a614d581c09aeb744a7508f81299688ef9d31a.

These events were incorrectly dropped in a commit that aimed to reduce RPC overheads. In practice it neglects that that Relayer relies on these events via the InventoryClient and indirectly via the BundleDataClient.