### PR TITLE
improve(relayer): Parallel processing for destination chain fills

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -42,13 +42,13 @@ export class Relayer {
    * @param invalidFills An array of any invalid fills detected for this deposit.
    * @returns A boolean indicator determining whether the relayer configuration permits the deposit to be filled.
    */
-  filterDeposit({ deposit, version, invalidFills }: RelayerUnfilledDeposit): boolean {
+  filterDeposit({ deposit, version: depositVersion, invalidFills }: RelayerUnfilledDeposit): boolean {
     const { depositId, originChainId, destinationChainId, depositor, recipient, inputToken, outputToken } = deposit;
     const { acrossApiClient, configStoreClient, hubPoolClient } = this.clients;
     const { ignoredAddresses, relayerTokens, acceptInvalidFills } = this.config;
 
     // If we don't have the latest code to support this deposit, skip it.
-    if (version > configStoreClient.configStoreVersion) {
+    if (depositVersion > configStoreClient.configStoreVersion) {
       this.logger.warn({
         at: "Relayer::getUnfilledDeposits",
         message: "Skipping deposit that is not supported by this relayer version.",

--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { utils as ethersUtils } from "ethers";
 import { L1Token, V3Deposit, V3DepositWithBlock } from "../interfaces";
@@ -374,7 +373,11 @@ export class Relayer {
       if (unfilledDeposits.length === 0) {
         return;
       }
-        await this.evaluateFills(unfilledDeposits.map(({ deposit }) => deposit), maxBlockNumbers, sendSlowRelays);
+      await this.evaluateFills(
+        unfilledDeposits.map(({ deposit }) => deposit),
+        maxBlockNumbers,
+        sendSlowRelays
+      );
     });
 
     // If during the execution run we had shortfalls or unprofitable fills then handel it by producing associated logs.


### PR DESCRIPTION
Relayer fills are currently processed as a flat array. When messages are involved this requires simulation of the fill on the destination chain, thus incurring delay. In these cases, take the opportunity to process other fills whilst awaiting the outcome of the simulation. This is also another step towards containing RPC misbehaviour to the affected chain and preventing contagion to other destinations.