### PR TITLE
fix: add chainId to rpc samples

### DIFF
--- a/src/utils/ProviderUtils.ts
+++ b/src/utils/ProviderUtils.ts
@@ -70,6 +70,7 @@ class RateLimitedProvider extends ethers.providers.StaticJsonRpcProvider {
         provider: getOriginFromURL(this.connection.url),
         method,
         params,
+        chainId: this.network.chainId,
       };
 
       // In this path we log an rpc response sample.


### PR DESCRIPTION
Previously these samples didn't include chainId, but this will be useful to filter for.