### PR TITLE
improve(Dataworker): Make logs more clear when choosing to skip exchange rate updates

### DIFF
--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1554,7 +1554,7 @@ export class Dataworker {
     const l1TokensWithPotentiallyOlderUpdate = expectedTrees.poolRebalanceTree.leaves.reduce((l1TokenSet, leaf) => {
       const currLeafL1Tokens = leaf.l1Tokens;
       currLeafL1Tokens.forEach((l1Token) => {
-        if (!l1TokenSet.includes[l1Token] && !updatedL1Tokens.has(l1Token)) {
+        if (!l1TokenSet.includes(l1Token) && !updatedL1Tokens.has(l1Token)) {
           l1TokenSet.push(l1Token);
         }
       });

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -1880,8 +1880,11 @@ export class Dataworker {
       const latestFeesCompoundedTime =
         this.clients.hubPoolClient.getLpTokenInfoForL1Token(l1Token)?.lastLpFeeUpdate ?? 0;
       // Force update every 2 days:
-      const timeToNextUpdate = 2 * 24 * 60 * 60 - (this.clients.hubPoolClient.currentTime - latestFeesCompoundedTime);
-      if (this.clients.hubPoolClient.currentTime === undefined || timeToNextUpdate < 0) {
+      if (
+        this.clients.hubPoolClient.currentTime === undefined ||
+        this.clients.hubPoolClient.currentTime - latestFeesCompoundedTime <= 2 * 24 * 60 * 60
+      ) {
+        const timeToNextUpdate = 2 * 24 * 60 * 60 - (this.clients.hubPoolClient.currentTime - latestFeesCompoundedTime);
         this.logger.debug({
           at: "Dataworker#_updateOldExchangeRates",
           message: `Skipping exchange rate update for ${tokenSymbol} because it was recently updated. Seconds to next update: ${timeToNextUpdate}s`,
@@ -1914,7 +1917,6 @@ export class Dataworker {
         at: "Dataworker#_updateOldExchangeRates",
         message: `Updating exchange rate for ${tokenSymbol}`,
         lastUpdateTime: latestFeesCompoundedTime,
-        timeToNextUpdate,
         currentLiquidReserves,
         updatedLiquidReserves,
         l1Token,

--- a/test/Dataworker.executePoolRebalances.ts
+++ b/test/Dataworker.executePoolRebalances.ts
@@ -244,7 +244,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
         const updated = await dataworkerInstance._updateExchangeRatesBeforeExecutingNonHubChainLeaves(
           {},
           balanceAllocator,
-          [{ netSendAmounts: [toBNWei(-1)], l1Tokens: [l1Token_1.address] }],
+          [{ netSendAmounts: [toBNWei(-1)], l1Tokens: [l1Token_1.address], chainId: 1 }],
           true
         );
         expect(updated.size).to.equal(0);
@@ -259,7 +259,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
         const updated = await dataworkerInstance._updateExchangeRatesBeforeExecutingNonHubChainLeaves(
           {},
           balanceAllocator,
-          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address] }],
+          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 }],
           true
         );
         expect(updated.size).to.equal(0);
@@ -274,7 +274,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
             [l1Token_1.address]: liquidReserves,
           },
           balanceAllocator,
-          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address] }],
+          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 }],
           true
         );
         expect(updated.size).to.equal(0);
@@ -288,7 +288,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
         const updated = await dataworkerInstance._updateExchangeRatesBeforeExecutingNonHubChainLeaves(
           {},
           balanceAllocator,
-          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address] }],
+          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 }],
           true
         );
         expect(lastSpyLogLevel(spy)).to.equal("error");
@@ -307,7 +307,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
         const updated = await dataworkerInstance._updateExchangeRatesBeforeExecutingNonHubChainLeaves(
           {},
           balanceAllocator,
-          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address] }],
+          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 }],
           true
         );
         expect(updated.size).to.equal(1);
@@ -326,7 +326,7 @@ describe("Dataworker: Execute pool rebalances", async function () {
             [l1Token_1.address]: liquidReserves,
           },
           balanceAllocator,
-          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address] }],
+          [{ netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 }],
           true
         );
         expect(updated.size).to.equal(1);
@@ -346,8 +346,8 @@ describe("Dataworker: Execute pool rebalances", async function () {
           },
           balanceAllocator,
           [
-            { netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address] },
-            { netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address] },
+            { netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 },
+            { netSendAmounts: [netSendAmount], l1Tokens: [l1Token_1.address], chainId: 1 },
           ],
           true
         );


### PR DESCRIPTION
- Add details to logs
- Fix one bug to skip duplicate tokens in `_updateOldExchangeRates`.