### PR TITLE
improve(dataworker): Warm BundleData loadData cache

### DIFF
--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -137,6 +137,8 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
           fromBlocks
         );
 
+        // Warm cache before executing slow and refund leaves.
+        await dataworker.warmBundleDataCache(spokePoolClients, fromBlocks);
         // Execute slow relays before relayer refunds to give them priority for any L2 funds.
         await dataworker.executeSlowRelayLeaves(
           spokePoolClients,


### PR DESCRIPTION
I’ve noticed that the executor is very slow and seems to stall for a long time when evaluating L2 leaves. I believe the problem is that the executor tries to execute leaves for all chains in parallel. For example, the executor tries to execute leaves from the latest 2 root bundles for 7 chains in parallel. That means that  this [function](https://github.com/across-protocol/relayer-v2/blob/2a986a267c72af02390124ffee545840f14f7b0a/src/dataworker/Dataworker.ts#L1094) which calls `BundleDataClient.loadData`  is running 7 times in parallel. The `loadData` function is designed to cache the bundle data in-memory (not in Redis!) but we can’t take advantage of this if we call it many times in parallel.

Therefore, I propose warming this cache for each executor run, which ensures we call `loadData` only once per executor run.

To add confluence to this observation about the source of slowdown, the execution of the relayer refund roots is very fast compared to the slow roots, and they `loadData` over the exact same block ranges. In this case, the refund root execution logic runs AFTER the loadData cache has been warmed.
