### PR TITLE
refactor: Drop v2 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.14",
     "@across-protocol/contracts-v2": "2.5.4",
-    "@across-protocol/sdk-v2": "0.22.19",
+    "@across-protocol/sdk-v2": "0.23.0",
     "@arbitrum/sdk": "^3.1.3",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@across-protocol/constants-v2": "1.0.14",
     "@across-protocol/contracts-v2": "2.5.4",
-    "@across-protocol/sdk-v2": "0.23.0",
+    "@across-protocol/sdk-v2": "0.23.1",
     "@arbitrum/sdk": "^3.1.3",
     "@consensys/linea-sdk": "^0.2.1",
     "@defi-wonderland/smock": "^2.3.5",

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -1,6 +1,5 @@
 import * as _ from "lodash";
 import {
-  DepositWithBlock,
   ProposedRootBundle,
   SlowFillRequestWithBlock,
   SpokePoolClientsByChain,
@@ -684,7 +683,7 @@ export class BundleDataClient {
                 // TODO: Invalid slow fill request. Maybe worth logging.
                 return;
               }
-              const matchedDeposit: DepositWithBlock = historicalDeposit.deposit;
+              const matchedDeposit: V3DepositWithBlock = historicalDeposit.deposit;
               // @dev Since queryHistoricalDepositForFill validates the slow fill request by checking individual
               // object property values against the deposit's, we
               // sanity check it here by comparing the full relay hashes. If there's an error here then the

--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -227,7 +227,7 @@ export class ProfitClient {
 
   async getTotalGasCost(deposit: V3Deposit, fillAmount?: BigNumber): Promise<TransactionCostEstimate> {
     const { destinationChainId: chainId } = deposit;
-    fillAmount ??= sdkUtils.getDepositOutputAmount(deposit);
+    fillAmount ??= deposit.outputAmount;
 
     // If there's no attached message, gas consumption from previous fills can be used in most cases.
     // @todo: Simulate this per-token in future, because some ERC20s consume more gas.
@@ -257,7 +257,7 @@ export class ProfitClient {
     fillAmount?: BigNumber
   ): Promise<Pick<FillProfit, "nativeGasCost" | "tokenGasCost" | "gasTokenPriceUsd" | "gasCostUsd">> {
     const { destinationChainId: chainId } = deposit;
-    fillAmount ??= sdkUtils.getDepositOutputAmount(deposit);
+    fillAmount ??= deposit.outputAmount;
 
     const gasToken = this.resolveGasToken(chainId);
     const gasTokenPriceUsd = this.getPriceOfToken(gasToken.symbol);
@@ -404,7 +404,7 @@ export class ProfitClient {
   getFillAmountInUsd(deposit: Deposit, fillAmount: BigNumber): BigNumber {
     const l1TokenInfo = this.hubPoolClient.getTokenInfoForDeposit(deposit);
     if (!l1TokenInfo) {
-      const inputToken = sdkUtils.getDepositInputToken(deposit);
+      const { inputToken } = deposit;
       throw new Error(
         `ProfitClient#getFillAmountInUsd missing l1TokenInfo for deposit with origin token: ${inputToken}`
       );

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -126,6 +126,7 @@ export class Dataworker {
   }
 
   isV3(_blockNumber: number): boolean {
+    _blockNumber; // lint
     return true;
   }
 

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -198,7 +198,7 @@ export function _buildSlowRelayRoot(bundleSlowFillsV3: BundleSlowFills): {
   };
 }
 
-function buildV3SlowFillLeaf(deposit: interfaces.V3Deposit): V3SlowFillLeaf {
+function buildV3SlowFillLeaf(deposit: interfaces.Deposit): V3SlowFillLeaf {
   const lpFee = deposit.inputAmount.mul(deposit.realizedLpFeePct).div(fixedPointAdjustment);
 
   return {

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -198,7 +198,7 @@ export function _buildSlowRelayRoot(bundleSlowFillsV3: BundleSlowFills): {
   };
 }
 
-function buildV3SlowFillLeaf(deposit: interfaces.Deposit): V3SlowFillLeaf {
+function buildV3SlowFillLeaf(deposit: interfaces.V3Deposit): V3SlowFillLeaf {
   const lpFee = deposit.inputAmount.mul(deposit.realizedLpFeePct).div(fixedPointAdjustment);
 
   return {

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -390,8 +390,8 @@ export function generateMarkdownForRootBundle(
 
   let slowRelayLeavesPretty = "";
   slowRelayLeaves.forEach((leaf, index) => {
-    const outputToken = sdkUtils.getRelayDataOutputToken(leaf.relayData);
-    const destinationChainId = sdkUtils.getSlowFillLeafChainId(leaf);
+    const { outputToken } = leaf.relayData;
+    const destinationChainId = leaf.chainId;
     const outputTokenDecimals = hubPoolClient.getTokenInfo(destinationChainId, outputToken).decimals;
     const lpFeePct = sdkUtils.getSlowFillLeafLpFeePct(leaf);
 

--- a/src/interfaces/BundleData.ts
+++ b/src/interfaces/BundleData.ts
@@ -2,17 +2,17 @@ import { interfaces } from "@across-protocol/sdk-v2";
 import { BigNumber } from "../utils";
 export type ExpiredDepositsToRefundV3 = {
   [originChainId: number]: {
-    [originToken: string]: interfaces.V3DepositWithBlock[];
+    [originToken: string]: interfaces.DepositWithBlock[];
   };
 };
 
 export type BundleDepositsV3 = {
   [originChainId: number]: {
-    [originToken: string]: interfaces.V3DepositWithBlock[];
+    [originToken: string]: interfaces.DepositWithBlock[];
   };
 };
 
-export interface BundleFillV3 extends interfaces.V3FillWithBlock {
+export interface BundleFillV3 extends interfaces.FillWithBlock {
   lpFeePct: BigNumber;
 }
 
@@ -29,12 +29,12 @@ export type BundleFillsV3 = {
 
 export type BundleExcessSlowFills = {
   [destinationChainId: number]: {
-    [destinationToken: string]: interfaces.V3DepositWithBlock[];
+    [destinationToken: string]: interfaces.DepositWithBlock[];
   };
 };
 export type BundleSlowFills = {
   [destinationChainId: number]: {
-    [destinationToken: string]: interfaces.V3DepositWithBlock[];
+    [destinationToken: string]: interfaces.DepositWithBlock[];
   };
 };
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -59,17 +59,11 @@ export const { FillType, FillStatus } = interfaces;
 
 export type CachingMechanismInterface = interfaces.CachingMechanismInterface;
 
-// V2 / V3 interfaces
-export type V2RelayData = interfaces.V2RelayData;
-export type V3RelayData = interfaces.V3RelayData;
-export type V2Deposit = interfaces.V2Deposit;
-export type V3Deposit = interfaces.V3Deposit;
-export type V2DepositWithBlock = interfaces.V2DepositWithBlock;
-export type V3DepositWithBlock = interfaces.V3DepositWithBlock;
-export type V2SpeedUp = interfaces.V2SpeedUp;
-export type V3SpeedUp = interfaces.V3SpeedUp;
-export type V2Fill = interfaces.V2Fill;
-export type V3Fill = interfaces.V3Fill;
-export type V2FillWithBlock = interfaces.V2FillWithBlock;
-export type V3FillWithBlock = interfaces.V3FillWithBlock;
-export type V3SlowFillLeaf = interfaces.V3SlowFillLeaf;
+// V3 shims (to be removed later)
+export type V3RelayData = interfaces.RelayData;
+export type V3Deposit = interfaces.Deposit;
+export type V3DepositWithBlock = interfaces.DepositWithBlock;
+export type V3SpeedUp = interfaces.SpeedUp;
+export type V3Fill = interfaces.Fill;
+export type V3FillWithBlock = interfaces.FillWithBlock;
+export type V3SlowFillLeaf = interfaces.SlowFillLeaf;

--- a/src/scripts/validateRunningBalances.ts
+++ b/src/scripts/validateRunningBalances.ts
@@ -19,7 +19,6 @@
 //      which also indicates an amount of tokens that need to be taken out of the spoke pool to execute those refunds
 //  - excess_t_c_{i,i+1,i+2,...} should therefore be consistent unless tokens are dropped onto the spoke pool.
 
-import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import {
   bnZero,
   winston,
@@ -257,7 +256,7 @@ export async function runScript(_logger: winston.Logger, baseSigner: Signer): Pr
 
             if (slowFillsForPoolRebalanceLeaf.length > 0) {
               for (const slowFillForChain of slowFillsForPoolRebalanceLeaf) {
-                const destinationChainId = sdkUtils.getSlowFillLeafChainId(slowFillForChain);
+                const destinationChainId = slowFillForChain.chainId;
                 const fillsForSameDeposit = bundleSpokePoolClients[destinationChainId]
                   .getFillsForOriginChain(slowFillForChain.relayData.originChainId)
                   .filter(

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -1,7 +1,7 @@
 import assert from "assert";
 import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { HubPoolClient, SpokePoolClient } from "../clients";
-import { Fill, FillStatus, SpokePoolClientsByChain, V2DepositWithBlock, V3DepositWithBlock } from "../interfaces";
+import { Fill, FillStatus, SpokePoolClientsByChain, V3DepositWithBlock } from "../interfaces";
 import { getBlockForTimestamp, getRedisCache } from "../utils";
 import { isDefined } from "./";
 import { getBlockRangeForChain } from "../dataworker/DataworkerUtils";
@@ -25,20 +25,13 @@ export function getRefundInformationFromFill(
     hubPoolClient.chainId,
     chainIdListForBundleEvaluationBlockNumbers
   )[1];
-  let l1TokenCounterpart: string;
-  if (sdkUtils.isV3Fill(fill)) {
-    l1TokenCounterpart = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      fill.inputToken,
-      fill.originChainId,
-      endBlockForMainnet
-    );
-  } else {
-    l1TokenCounterpart = hubPoolClient.getL1TokenForL2TokenAtBlock(
-      sdkUtils.getFillOutputToken(fill),
-      fill.destinationChainId,
-      endBlockForMainnet
-    );
-  }
+
+  const l1TokenCounterpart = hubPoolClient.getL1TokenForL2TokenAtBlock(
+    fill.inputToken,
+    fill.originChainId,
+    endBlockForMainnet
+  );
+
   const repaymentToken = hubPoolClient.getL2TokenForL1TokenAtBlock(
     l1TokenCounterpart,
     chainToSendRefundTo,
@@ -102,8 +95,7 @@ export async function getUnfilledDeposits(
         // Find all unfilled deposits for the current loops originChain -> destinationChain.
         return originClient
           .getDepositsForDestinationChain(destinationChainId)
-          .filter((deposit) => deposit.blockNumber >= earliestBlockNumber)
-          .filter(sdkUtils.isV3Deposit<V3DepositWithBlock, V2DepositWithBlock>); // @todo: Remove after v2 deprecated.
+          .filter((deposit) => deposit.blockNumber >= earliestBlockNumber);
       })
       .flat();
 

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -891,7 +891,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       await updateAllClients();
       const requests = spokePoolClient_2.getSlowFillRequestsForOriginChain(originChainId);
       expect(requests.length).to.equal(1);
-      expect(sdkUtils.getV3RelayHashFromEvent(requests[0])).to.equal(sdkUtils.getV3RelayHashFromEvent(depositObject));
+      expect(sdkUtils.getRelayHashFromEvent(requests[0])).to.equal(sdkUtils.getRelayHashFromEvent(depositObject));
 
       const data1 = await dataworkerInstance.clients.bundleDataClient.loadData(getDefaultBlockRange(5), {
         ...spokePoolClients,
@@ -942,7 +942,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       await mockOriginSpokePoolClient.update(["V3FundsDeposited"]);
 
       // Let's make fill status for the relay hash always return Filled.
-      const expiredDepositHash = sdkUtils.getV3RelayHashFromEvent(mockOriginSpokePoolClient.getDeposits()[0]);
+      const expiredDepositHash = sdkUtils.getRelayHashFromEvent(mockOriginSpokePoolClient.getDeposits()[0]);
       mockDestinationSpokePool.fillStatuses.whenCalledWith(expiredDepositHash).returns(interfaces.FillStatus.Filled);
 
       // Now, load a bundle that doesn't include the deposit in its range.
@@ -996,7 +996,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       await mockOriginSpokePoolClient.update(["V3FundsDeposited"]);
 
       // Let's make fill status for the relay hash always return RequestedSlowFill.
-      const expiredDepositHash = sdkUtils.getV3RelayHashFromEvent(mockOriginSpokePoolClient.getDeposits()[0]);
+      const expiredDepositHash = sdkUtils.getRelayHashFromEvent(mockOriginSpokePoolClient.getDeposits()[0]);
       mockDestinationSpokePool.fillStatuses
         .whenCalledWith(expiredDepositHash)
         .returns(interfaces.FillStatus.RequestedSlowFill);
@@ -1025,7 +1025,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       await mockOriginSpokePoolClient.update(["V3FundsDeposited"]);
 
       // Let's make fill status for the relay hash always return Unfilled.
-      const expiredDepositHash = sdkUtils.getV3RelayHashFromEvent(mockOriginSpokePoolClient.getDeposits()[0]);
+      const expiredDepositHash = sdkUtils.getRelayHashFromEvent(mockOriginSpokePoolClient.getDeposits()[0]);
       mockDestinationSpokePool.fillStatuses.whenCalledWith(expiredDepositHash).returns(interfaces.FillStatus.Unfilled);
 
       // Now, load a bundle that doesn't include the deposit in its range.
@@ -1058,7 +1058,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       await mockDestinationSpokePoolClient.update(["RequestedV3SlowFill"]);
 
       // Let's make fill status for the relay hash always return RequestedSlowFill.
-      const expiredDepositHash = sdkUtils.getV3RelayHashFromEvent(mockOriginSpokePoolClient.getDeposits()[0]);
+      const expiredDepositHash = sdkUtils.getRelayHashFromEvent(mockOriginSpokePoolClient.getDeposits()[0]);
       mockDestinationSpokePool.fillStatuses
         .whenCalledWith(expiredDepositHash)
         .returns(interfaces.FillStatus.RequestedSlowFill);

--- a/test/Relayer.BasicFill.ts
+++ b/test/Relayer.BasicFill.ts
@@ -1,6 +1,5 @@
 import { clients, constants, utils as sdkUtils } from "@across-protocol/sdk-v2";
 import { AcrossApiClient, ConfigStoreClient, MultiCallerClient, TokenClient } from "../src/clients";
-import { V2FillWithBlock, V3FillWithBlock } from "../src/interfaces";
 import { CONFIG_STORE_VERSION } from "../src/common";
 import { bnOne, getUnfilledDeposits } from "../src/utils";
 import { Relayer } from "../src/relayer/Relayer";
@@ -30,7 +29,7 @@ import {
   expect,
   fillV3Relay,
   getLastBlockTime,
-  getV3RelayHash,
+  getRelayDataHash,
   lastSpyLogIncludes,
   randomAddress,
   setupTokensForWallet,
@@ -205,14 +204,12 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
       expect(tx.length).to.equal(1); // There should have been exactly one transaction.
 
       await Promise.all([spokePoolClient_1.update(), spokePoolClient_2.update(), hubPoolClient.update()]);
-      const fills = spokePoolClient_2
-        .getFillsForOriginChain(deposit.originChainId)
-        .filter(sdkUtils.isV3Fill<V3FillWithBlock, V2FillWithBlock>);
-      expect(fills.length).to.equal(1);
-      const fill = fills.at(-1)!;
+      let fill = spokePoolClient_2.getFillsForOriginChain(deposit.originChainId).at(-1);
+      expect(fill).to.exist;
+      fill = fill!;
 
-      expect(getV3RelayHash(fill, fill.destinationChainId)).to.equal(
-        getV3RelayHash(deposit, deposit.destinationChainId)
+      expect(getRelayDataHash(fill, fill.destinationChainId)).to.equal(
+        getRelayDataHash(deposit, deposit.destinationChainId)
       );
 
       // Re-run the execution loop and validate that no additional relays are sent.
@@ -519,15 +516,12 @@ describe("Relayer: Check for Unfilled Deposits and Fill", async function () {
           expect(tx.length).to.equal(1); // There should have been exactly one transaction.
 
           await spokePoolClient_2.update();
-          const fills = spokePoolClient_2
-            .getFillsForRelayer(relayer.address)
-            .filter(sdkUtils.isV3Fill<V3FillWithBlock, V2FillWithBlock>);
-          expect(fills.length).to.equal(1);
-          const fill = fills.at(-1)!;
+          let fill = spokePoolClient_2.getFillsForRelayer(relayer.address).at(-1);
+          expect(fill).to.exist;
+          fill = fill!;
 
-          expect(sdkUtils.isV3Fill(fill)).to.be.true;
-          expect(getV3RelayHash(fill, fill.destinationChainId)).to.equal(
-            getV3RelayHash(deposit, deposit.destinationChainId)
+          expect(getRelayDataHash(fill, fill.destinationChainId)).to.equal(
+            getRelayDataHash(deposit, deposit.destinationChainId)
           );
 
           expect(fill.relayExecutionInfo.updatedOutputAmount.eq(deposit.outputAmount)).to.be.false;

--- a/test/Relayer.SlowFill.ts
+++ b/test/Relayer.SlowFill.ts
@@ -30,7 +30,7 @@ import {
   ethers,
   expect,
   getLastBlockTime,
-  getV3RelayHash,
+  getRelayDataHash,
   lastSpyLogIncludes,
   setupTokensForWallet,
   sinon,
@@ -206,8 +206,8 @@ describe("Relayer: Initiates slow fill requests", async function () {
     expect(slowFillRequest).to.exist;
     slowFillRequest = slowFillRequest!; // tsc coersion
 
-    expect(getV3RelayHash(slowFillRequest, slowFillRequest.destinationChainId)).to.equal(
-      getV3RelayHash(deposit, deposit.destinationChainId)
+    expect(getRelayDataHash(slowFillRequest, slowFillRequest.destinationChainId)).to.equal(
+      getRelayDataHash(deposit, deposit.destinationChainId)
     );
 
     await relayerInstance.checkForUnfilledDepositsAndFill();

--- a/test/Relayer.UnfilledDeposits.ts
+++ b/test/Relayer.UnfilledDeposits.ts
@@ -12,7 +12,6 @@ import {
 } from "./constants";
 import { MockInventoryClient, MockProfitClient, MockConfigStoreClient, MockedMultiCallerClient } from "./mocks";
 import {
-  assert,
   BigNumber,
   Contract,
   SignerWithAddress,
@@ -287,7 +286,6 @@ describe("Relayer: Unfilled Deposits", async function () {
       expect(unfilledDeposit.deposit.depositId).to.equal(deposit.depositId);
 
       // expect unfilled deposit to have the same outputAmount, but a lower updatedOutputAmount.
-      assert(sdkUtils.isV3Deposit(unfilledDeposit.deposit));
       expect(unfilledDeposit.deposit.outputAmount).to.deep.eq(outputAmount);
       expect(unfilledDeposit.deposit.updatedOutputAmount).to.deep.eq(updatedOutputAmount);
     });
@@ -307,9 +305,8 @@ describe("Relayer: Unfilled Deposits", async function () {
     await updateAllClients();
     unfilledDeposits = await _getUnfilledDeposits();
     expect(unfilledDeposits.length).to.equal(1);
-    assert(sdkUtils.isV3Deposit(unfilledDeposits[0].deposit));
-    expect(sdkUtils.getV3RelayHash(unfilledDeposits[0].deposit, destinationChainId)).to.equal(
-      sdkUtils.getV3RelayHash(deposit, deposit.destinationChainId)
+    expect(sdkUtils.getRelayDataHash(unfilledDeposits[0].deposit, destinationChainId)).to.equal(
+      sdkUtils.getRelayDataHash(deposit, deposit.destinationChainId)
     );
 
     await fillV3Relay(spokePool_2, deposit, relayer);

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -57,7 +57,7 @@ export const {
   modifyRelayHelper,
   randomAddress,
 } = utils;
-export const { getV3RelayHash } = sdkUtils;
+export const { getRelayDataHash } = sdkUtils;
 
 export type SignerWithAddress = utils.SignerWithAddress;
 export { assert, chai, expect, BigNumber, Contract, FakeContract, sinon, toBN, toBNWei, toWei, utf8ToHex, winston };

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,10 +45,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.22.19":
-  version "0.22.19"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.22.19.tgz#65531294f3ccaacf3b2323f400e530a1e2ab6210"
-  integrity sha512-7b6eT9nKKnrBZVxzB+h3QsSNonsQbCfnbN3vSME/ZPjCmJGgWJj1O8LVwLn/6xNpOoLg13TD6aOkZQAjG+Oeyg==
+"@across-protocol/sdk-v2@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.23.0.tgz#46cd4da93b52c0c7d37a71c84576ed32d3fe7af2"
+  integrity sha512-PsdJ9HdnoGTQ3ubfUwWC4oFOQGzn3Srosg3/nVzWOBfKR4fr2dNTsmoxCb4WIRBhawP8XiQfkv38eJoikkto6g==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,10 +45,10 @@
     "@openzeppelin/contracts" "4.1.0"
     "@uma/core" "^2.18.0"
 
-"@across-protocol/sdk-v2@0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.23.0.tgz#46cd4da93b52c0c7d37a71c84576ed32d3fe7af2"
-  integrity sha512-PsdJ9HdnoGTQ3ubfUwWC4oFOQGzn3Srosg3/nVzWOBfKR4fr2dNTsmoxCb4WIRBhawP8XiQfkv38eJoikkto6g==
+"@across-protocol/sdk-v2@0.23.1":
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/@across-protocol/sdk-v2/-/sdk-v2-0.23.1.tgz#1d60d9aa0654311d69ab89fd6065038d1ffd3a2b"
+  integrity sha512-xwNmf9SQuSrObc/uhFLyrzmo+dircsZNQMedsqU2oqJLTV2Tet5/r2GOa7d5PRp1XektBFKPE6fZ3z3BSikTOQ==
   dependencies:
     "@across-protocol/across-token" "^1.0.0"
     "@across-protocol/constants-v2" "^1.0.14"


### PR DESCRIPTION
A follow-up change would drop all references to V3 types in favour of the vanilla variants. That hasn't been done here to keep this change on the smaller side.

(nb. requires a new sdk-v2 package so it's expected to fail build)