### PR TITLE
chore(ProfitClient): Reduce token warning to debug

### DIFF
--- a/src/clients/ProfitClient.ts
+++ b/src/clients/ProfitClient.ts
@@ -218,7 +218,7 @@ export class ProfitClient {
     const address = this.resolveTokenAddress(token);
     const price = this.tokenPrices[address];
     if (!isDefined(price)) {
-      this.logger.warn({ at: "ProfitClient#getPriceOfToken", message: `Token ${token} not in price list.`, address });
+      this.logger.debug({ at: "ProfitClient#getPriceOfToken", message: `Token ${token} not in price list.`, address });
       return bnZero;
     }
 


### PR DESCRIPTION
This fires on every run on testnet and pollutes the logs. It's a harmless issue and doesn't really need to be a warning; if someone encounters it in production they'll quickly figure it out anyway.