### PR TITLE
fix(USDT): allow BaseAdapter to support approving USDT

### DIFF
--- a/src/clients/bridges/BaseAdapter.ts
+++ b/src/clients/bridges/BaseAdapter.ts
@@ -168,12 +168,11 @@ export abstract class BaseAdapter {
     let mrkdwn = "*Approval transactions:* \n";
     for (const { l1Token, targetContract } of tokensToApprove) {
       const { hubChainId } = this;
-      const txnRequests = [];
+      const txs = [];
       if (TOKEN_APPROVALS_TO_FIRST_ZERO[hubChainId]?.includes(l1Token.address)) {
-        txnRequests.push(runTransaction(this.logger, l1Token, "approve", [targetContract, bnZero]));
+        txs.push(await runTransaction(this.logger, l1Token, "approve", [targetContract, bnZero]));
       }
-      txnRequests.push(runTransaction(this.logger, l1Token, "approve", [targetContract, MAX_UINT_VAL]));
-      const txs = await Promise.all(txnRequests);
+      txs.push(await runTransaction(this.logger, l1Token, "approve", [targetContract, MAX_UINT_VAL]));
       const receipts = await Promise.all(txs.map((tx) => tx.wait()));
       const hubNetwork = getNetworkName(hubChainId);
       const spokeNetwork = getNetworkName(this.chainId);

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -295,3 +295,13 @@ export const chainIdsToCctpDomains: { [chainId: number]: number } = {
   84532: 6, // Base Sepolia
   80001: 7, // Polygon PoS Mumbai
 };
+
+/**
+ * A mapping of chain IDs to tokens on that chain which need their allowance
+ * to first be zeroed before setting a new allowance. This is useful for
+ * tokens that have a non-standard approval process.
+ * @dev this is a generalization for USDT on Ethereum. Other tokens may be added
+ */
+export const TOKEN_APPROVALS_TO_FIRST_ZERO: Record<number, string[]> = {
+  1: ["0xdAC17F958D2ee523a2206206994597C13D831ec7"],
+};

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -303,5 +303,11 @@ export const chainIdsToCctpDomains: { [chainId: number]: number } = {
  * @dev this is a generalization for USDT on Ethereum. Other tokens may be added
  */
 export const TOKEN_APPROVALS_TO_FIRST_ZERO: Record<number, string[]> = {
-  [CHAIN_IDs.MAINNET]: [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]],
+  [CHAIN_IDs.MAINNET]: [
+    // Required for USDT on Mainnet. Spurred by the following vulnerability:
+    // https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    // Essentially the current version of USDT has a vulnerability whose solution
+    // requires the user to have a zero allowance prior to setting an approval.
+    TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]
+  ],
 };

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -308,6 +308,6 @@ export const TOKEN_APPROVALS_TO_FIRST_ZERO: Record<number, string[]> = {
     // https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
     // Essentially the current version of USDT has a vulnerability whose solution
     // requires the user to have a zero allowance prior to setting an approval.
-    TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]
+    TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET],
   ],
 };

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -303,5 +303,5 @@ export const chainIdsToCctpDomains: { [chainId: number]: number } = {
  * @dev this is a generalization for USDT on Ethereum. Other tokens may be added
  */
 export const TOKEN_APPROVALS_TO_FIRST_ZERO: Record<number, string[]> = {
-  1: ["0xdAC17F958D2ee523a2206206994597C13D831ec7"],
+  [CHAIN_IDs.MAINNET]: [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET],
 };

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -303,5 +303,5 @@ export const chainIdsToCctpDomains: { [chainId: number]: number } = {
  * @dev this is a generalization for USDT on Ethereum. Other tokens may be added
  */
 export const TOKEN_APPROVALS_TO_FIRST_ZERO: Record<number, string[]> = {
-  [CHAIN_IDs.MAINNET]: [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET],
+  [CHAIN_IDs.MAINNET]: [TOKEN_SYMBOLS_MAP.USDT.addresses[CHAIN_IDs.MAINNET]],
 };

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -1,4 +1,4 @@
-import { ethers } from "../utils";
+import { CHAIN_IDs, TOKEN_SYMBOLS_MAP, ethers } from "../utils";
 
 // Maximum supported version of the configuration loaded into the Across ConfigStore.
 // It protects bots from running outdated code against newer version of the on-chain config store.


### PR DESCRIPTION
USDT on mainnet requires a spender's allowance to be zero prior to approving more value. 

This PR adds a zero'd approval if the token attempting to be approved is USDT.