### PR TITLE
improve(FillUtils): Protect getUnfilledDeposits() against RPC error

### DIFF
--- a/src/relayer/Relayer.ts
+++ b/src/relayer/Relayer.ts
@@ -173,7 +173,12 @@ export class Relayer {
   private async _getUnfilledDeposits(): Promise<Record<number, RelayerUnfilledDeposit[]>> {
     const { hubPoolClient, spokePoolClients } = this.clients;
 
-    const unfilledDeposits = await getUnfilledDeposits(spokePoolClients, hubPoolClient, this.config.maxRelayerLookBack);
+    const unfilledDeposits = await getUnfilledDeposits(
+      spokePoolClients,
+      hubPoolClient,
+      this.config.maxRelayerLookBack,
+      this.logger
+    );
 
     // Filter the resulting unfilled deposits according to relayer configuration.
     Object.keys(unfilledDeposits).forEach((_destinationChainId) => {

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -74,8 +74,12 @@ export async function getUnfilledDeposits(
       const spokePoolClient = spokePoolClients[originChainId];
       const timestamp = spokePoolClient.getCurrentTime() - depositLookBack;
       const hints = { lowBlock: spokePoolClient.deploymentBlock };
-      const startBlock = await getBlockForTimestamp(originChainId, timestamp, blockFinder, redis, hints);
-      originFromBlocks[originChainId] = Math.max(spokePoolClient.deploymentBlock, startBlock);
+      try {
+        const startBlock = await getBlockForTimestamp(originChainId, timestamp, blockFinder, redis, hints);
+        originFromBlocks[originChainId] = Math.max(spokePoolClient.deploymentBlock, startBlock);
+      } catch {
+        // ...Failed! Do nothing to inherit the maximum lookback.
+      }
     });
   }
 

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -58,7 +58,7 @@ export async function getUnfilledDeposits(
   spokePoolClients: SpokePoolClientsByChain,
   hubPoolClient: HubPoolClient,
   depositLookBack?: number,
-  logger?: winston.Logger,
+  logger?: winston.Logger
 ): Promise<{ [chainId: number]: RelayerUnfilledDeposit[] }> {
   const unfilledDeposits: { [chainId: number]: RelayerUnfilledDeposit[] } = {};
   const chainIds = Object.values(spokePoolClients)

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -127,7 +127,7 @@ export async function getUnfilledDeposits(
       // Fall back to matching fills against deposits and infer FillStatus from that.
       fillStatus = deposits
         .map((deposit) => destinationClient.getValidUnfilledAmountForDeposit(deposit))
-        .map(({ unfilledAmount }) => unfilledAmount.eq(bnZero) ? FillStatus.Filled : FillStatus.Unfilled);
+        .map(({ unfilledAmount }) => (unfilledAmount.eq(bnZero) ? FillStatus.Filled : FillStatus.Unfilled));
     }
 
     unfilledDeposits[destinationChainId] = deposits

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -105,7 +105,7 @@ export async function getUnfilledDeposits(
     let fillStatus: number[];
     try {
       fillStatus = await sdkUtils.fillStatusArray(destinationClient.spokePool, deposits);
-    } catch (err) {
+    } catch {
       // Assume all deposits are unfilled by default. They may be filtered out later due to other
       // criteria, and any filled deposits will ultimately fail during fillV3Relay() simulation.
       fillStatus = deposits.map(() => FillStatus.Unfilled);

--- a/src/utils/FillUtils.ts
+++ b/src/utils/FillUtils.ts
@@ -106,8 +106,8 @@ export async function getUnfilledDeposits(
     try {
       fillStatus = await sdkUtils.fillStatusArray(destinationClient.spokePool, deposits);
     } catch {
-      // Assume all deposits are unfilled by default. They may be filtered out later due to other
-      // criteria, and any filled deposits will ultimately fail during fillV3Relay() simulation.
+      // Assume all deposits are unfilled. They may be filtered out later due to other criteria,
+      // and any filled deposits will ultimately fail during fillV3Relay() simulation.
       fillStatus = deposits.map(() => FillStatus.Unfilled);
     }
 


### PR DESCRIPTION
If the deposit fill status cannot be queried on the destination chain, revert to slower methods to determine the status. This fallback method is less accurate due to timing, but it allows execution to continue and the complete set of resulting deposits with unknown status will likely be reduced by subsequent filtering anyway (i.e. based on supported token, number of deposit confirmations, profitability, ...). The ultimate fill status for the residual deposits will be inferred at the time of fill simulation on the destination chain.