### PR TITLE
chore(Dataworker): Explicitly require SpokePoolClient update

### DIFF
--- a/src/dataworker/DataworkerClientHelper.ts
+++ b/src/dataworker/DataworkerClientHelper.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import winston from "winston";
 import { DataworkerConfig } from "./DataworkerConfig";
 import {
@@ -103,6 +104,9 @@ export async function constructSpokePoolClientsForFastDataworker(
     "RequestedV3SlowFill",
     "FilledV3Relay",
   ]);
+  Object.values(spokePoolClients).forEach(({ chainId, isUpdated }) =>
+    assert(isUpdated, `Failed to update SpokePoolClient for chain ${chainId}`)
+  );
   return spokePoolClients;
 }
 


### PR DESCRIPTION
A pending update to the sdk will allow the SpokePoolClient to continue in an un-updated state. The relayer is OK with this but the Dataworker requires a complete set of updated SpokePoolClient instances. Pre-empt this pending change by requiring explicitly that all Dataworker SpokePoolClient instances updated successfully. This is a case where it's OK (and expected) to fail hard.