### PR TITLE
fix: Avoid error where we try to compute refunds for a {l1Token, chainId} combination that doesn't exist

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -231,7 +231,6 @@ export class InventoryClient {
       // Consider any refunds from executed and to-be executed bundles.
       totalRefundsPerChain = await this.getBundleRefunds(l1Token);
     } catch (e) {
-      console.error(e);
       this.log("Failed to get bundle refunds, defaulting refund chain to hub chain");
       // Fallback to ignoring bundle refunds if calculating bundle refunds goes wrong.
       // This would create issues if there are relatively a lot of upcoming relayer refunds that would affect

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -172,7 +172,7 @@ export class InventoryClient {
           const destinationToken = this.getDestinationTokenForL1Token(l1Token, chainId);
           return [
             chainId,
-            this.bundleDataClient.getTotalRefund(refundsToConsider, this.relayer, Number(chainId), destinationToken),
+            this.bundleDataClient.getTotalRefund(refundsToConsider, this.relayer, chainId, destinationToken),
           ];
         })
     );

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -166,13 +166,15 @@ export class InventoryClient {
     refundsToConsider.push(nextBundleRefunds);
 
     return Object.fromEntries(
-      this.getEnabledChains().map((chainId) => {
-        const destinationToken = this.getDestinationTokenForL1Token(l1Token, chainId);
-        return [
-          chainId,
-          this.bundleDataClient.getTotalRefund(refundsToConsider, this.relayer, Number(chainId), destinationToken),
-        ];
-      })
+      this.getEnabledChains()
+        .filter((chainId) => this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, chainId))
+        .map((chainId) => {
+          const destinationToken = this.getDestinationTokenForL1Token(l1Token, chainId);
+          return [
+            chainId,
+            this.bundleDataClient.getTotalRefund(refundsToConsider, this.relayer, Number(chainId), destinationToken),
+          ];
+        })
     );
   }
 

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -258,8 +258,17 @@ describe("InventoryClient: Refund chain selection", async function () {
     bundleDataClient.setReturnedNextBundleRefunds({
       10: createRefunds(owner.address, toWei(5), l2TokensForWeth[10]),
     });
+    // We need HubPoolClient.l2TokenEnabledForL1Token() to return true for a given
+    // L1 token and destination chain ID, otherwise it won't be counted in upcoming
+    // refunds.
+    hubPoolClient.setEnableAllL2Tokens(true);
     expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(1);
     expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"166666666666666703"')).to.be.true; // (20-5)/(140-5)=0.11
+
+    // If we set this to false in this test, the destination chain will be default used since the refund data
+    // will be ignored.
+    hubPoolClient.setEnableAllL2Tokens(false);
+    expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(10);
   });
 
   it("Correctly throws when Deposit tokens are not equivalent", async function () {

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -6,6 +6,7 @@ import { MockConfigStoreClient } from "./MockConfigStoreClient";
 // Adds functions to MockHubPoolClient to facilitate Dataworker unit testing.
 export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
   public latestBundleEndBlocks: { [chainId: number]: number } = {};
+  public enableAllL2Tokens: boolean | undefined;
 
   constructor(
     logger: winston.Logger,
@@ -29,5 +30,16 @@ export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
   }
   setLpTokenInfo(l1Token: string, lastLpFeeUpdate: number, liquidReserves: BigNumber): void {
     this.lpTokens[l1Token] = { lastLpFeeUpdate, liquidReserves };
+  }
+
+  setEnableAllL2Tokens(enableAllL2Tokens: boolean): void {
+    this.enableAllL2Tokens = enableAllL2Tokens;
+  }
+
+  l2TokenEnabledForL1Token(l1Token: string, destinationChainId: number): boolean {
+    if (this.enableAllL2Tokens === undefined) {
+      return super.l2TokenEnabledForL1Token(l1Token, destinationChainId);
+    }
+    return this.enableAllL2Tokens;
   }
 }


### PR DESCRIPTION
For example, when `getBundleRefunds()` is called with `l1Token = USDT address`, then this function fails because USDT doesn't exist on Base, which is one of the enabled chains.