### PR TITLE
Revert "fix: Avoid error where we try to compute refunds for a {l1Token, chainId} combination that doesn't exist (#1378)"

### DIFF
--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -165,21 +165,15 @@ export class InventoryClient {
     const nextBundleRefunds = await this.bundleDataClient.getNextBundleRefunds();
     refundsToConsider.push(nextBundleRefunds);
 
-    return this.getEnabledChains().reduce((refunds: { [chainId: string]: BigNumber }, chainId) => {
-      if (!this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, chainId)) {
-        refunds[chainId] = toBN(0);
-      } else {
+    return Object.fromEntries(
+      this.getEnabledChains().map((chainId) => {
         const destinationToken = this.getDestinationTokenForL1Token(l1Token, chainId);
-        refunds[chainId] = this.bundleDataClient.getTotalRefund(
-          refundsToConsider,
-          this.relayer,
+        return [
           chainId,
-          destinationToken
-        );
-        return refunds;
-      }
-      return refunds;
-    }, {});
+          this.bundleDataClient.getTotalRefund(refundsToConsider, this.relayer, Number(chainId), destinationToken),
+        ];
+      })
+    );
   }
 
   // Work out where a relay should be refunded to optimally manage the bots inventory. If the inventory management logic

--- a/test/InventoryClient.RefundChain.ts
+++ b/test/InventoryClient.RefundChain.ts
@@ -258,17 +258,8 @@ describe("InventoryClient: Refund chain selection", async function () {
     bundleDataClient.setReturnedNextBundleRefunds({
       10: createRefunds(owner.address, toWei(5), l2TokensForWeth[10]),
     });
-    // We need HubPoolClient.l2TokenEnabledForL1Token() to return true for a given
-    // L1 token and destination chain ID, otherwise it won't be counted in upcoming
-    // refunds.
-    hubPoolClient.setEnableAllL2Tokens(true);
     expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(1);
     expect(lastSpyLogIncludes(spy, 'expectedPostRelayAllocation":"166666666666666703"')).to.be.true; // (20-5)/(140-5)=0.11
-
-    // If we set this to false in this test, the destination chain will be default used since the refund data
-    // will be ignored.
-    hubPoolClient.setEnableAllL2Tokens(false);
-    expect(await inventoryClient.determineRefundChainId(sampleDepositData)).to.equal(10);
   });
 
   it("Correctly throws when Deposit tokens are not equivalent", async function () {

--- a/test/mocks/MockHubPoolClient.ts
+++ b/test/mocks/MockHubPoolClient.ts
@@ -6,7 +6,6 @@ import { MockConfigStoreClient } from "./MockConfigStoreClient";
 // Adds functions to MockHubPoolClient to facilitate Dataworker unit testing.
 export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
   public latestBundleEndBlocks: { [chainId: number]: number } = {};
-  public enableAllL2Tokens: boolean | undefined;
 
   constructor(
     logger: winston.Logger,
@@ -30,16 +29,5 @@ export class MockHubPoolClient extends clients.mocks.MockHubPoolClient {
   }
   setLpTokenInfo(l1Token: string, lastLpFeeUpdate: number, liquidReserves: BigNumber): void {
     this.lpTokens[l1Token] = { lastLpFeeUpdate, liquidReserves };
-  }
-
-  setEnableAllL2Tokens(enableAllL2Tokens: boolean): void {
-    this.enableAllL2Tokens = enableAllL2Tokens;
-  }
-
-  l2TokenEnabledForL1Token(l1Token: string, destinationChainId: number): boolean {
-    if (this.enableAllL2Tokens === undefined) {
-      return super.l2TokenEnabledForL1Token(l1Token, destinationChainId);
-    }
-    return this.enableAllL2Tokens;
   }
 }


### PR DESCRIPTION
This reverts commit cf222c0ac0eb4f934c399b0efb8175d5e1b95767.