### PR TITLE
fix(BundleDataClient): Handle refunds sent after pending bundle

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -177,7 +177,7 @@ export class BundleDataClient {
     if (!isDefined(this.clients?.arweaveClient)) {
       return undefined;
     }
-    const start = Date.now();
+    const start = performance.now();
     const persistedData = await this.clients.arweaveClient.getByTopic(
       this.getArweaveClientKey(blockRangesForChains),
       BundleDataSS

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -341,7 +341,7 @@ export class BundleDataClient {
     // for the next call to loadData.
     const { bundleFillsV3, expiredDepositsToRefundV3 } = await Promise.race([
       this.loadData(widestBundleBlockRanges, this.spokePoolClients, logData, attemptToLoadFromArweave),
-      loadDataTimeout(Number(process.env.LOAD_DATA_TIMEOUT ?? 10)), // Default 10s timeout
+      loadDataTimeout(Number(process.env.LOAD_DATA_TIMEOUT ?? 20)), // timeout denominated in seconds
     ]);
     const nextBundleRefunds = getRefundsFromBundle(bundleFillsV3, expiredDepositsToRefundV3);
     combinedRefunds.push(nextBundleRefunds);

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -319,6 +319,7 @@ export class BundleDataClient {
           refundsForChain[chainToSendRefundTo][repaymentToken] ??= {};
           const existingRefundAmount = refundsForChain[chainToSendRefundTo][repaymentToken][relayer] ?? bnZero;
           refundsForChain[chainToSendRefundTo][repaymentToken][relayer] = existingRefundAmount.add(refundAmount);
+        });
     }
     return refundsForChain;
   }

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -311,7 +311,9 @@ export class BundleDataClient {
             chainIds
           );
           // Assume that lp fees are 0 for the sake of speed. In the future we could batch compute
-          // these or make hardcoded assumptions based on the origin-repayment chain direction.
+          // these or make hardcoded assumptions based on the origin-repayment chain direction. This might result
+          // in slight over estimations of refunds, but its not clear whether underestimating or overestimating is
+          // worst from the relayer's perspective.
           const refundAmount = fill.inputAmount;
           refundsForChain[chainToSendRefundTo] ??= {};
           refundsForChain[chainToSendRefundTo][repaymentToken] ??= {};

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -325,7 +325,7 @@ export class BundleDataClient {
       await delay(timeout);
       this.logger.debug({
         at: "BundleDataClient#getNextBundleRefunds",
-        message: `Timeout (${timeout / 60}s) loading next bundle refunds.`,
+        message: `Timeout (${timeout}s) loading next bundle refunds.`,
       });
       return {
         bundleFillsV3: {},
@@ -341,7 +341,7 @@ export class BundleDataClient {
     // for the next call to loadData.
     const { bundleFillsV3, expiredDepositsToRefundV3 } = await Promise.race([
       this.loadData(widestBundleBlockRanges, this.spokePoolClients, logData, attemptToLoadFromArweave),
-      loadDataTimeout(Number(process.env.LOAD_DATA_TIMEOUT ?? 10 * 60)),
+      loadDataTimeout(Number(process.env.LOAD_DATA_TIMEOUT ?? 10)), // Default 10s timeout
     ]);
     const nextBundleRefunds = getRefundsFromBundle(bundleFillsV3, expiredDepositsToRefundV3);
     combinedRefunds.push(nextBundleRefunds);

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -314,16 +314,11 @@ export class BundleDataClient {
           // these or make hardcoded assumptions based on the origin-repayment chain direction. This might result
           // in slight over estimations of refunds, but its not clear whether underestimating or overestimating is
           // worst from the relayer's perspective.
-          const refundAmount = fill.inputAmount;
+          const { relayer, inputAmount: refundAmount } = fill;
           refundsForChain[chainToSendRefundTo] ??= {};
           refundsForChain[chainToSendRefundTo][repaymentToken] ??= {};
-          if (refundsForChain[chainToSendRefundTo][repaymentToken][fill.relayer]) {
-            refundsForChain[chainToSendRefundTo][repaymentToken][fill.relayer] =
-              refundsForChain[chainToSendRefundTo][repaymentToken][fill.relayer].add(refundAmount);
-          } else {
-            refundsForChain[chainToSendRefundTo][repaymentToken][fill.relayer] = refundAmount;
-          }
-        });
+          const existingRefundAmount = refundsForChain[chainToSendRefundTo][repaymentToken][relayer] ?? bnZero;
+          refundsForChain[chainToSendRefundTo][repaymentToken][relayer] = existingRefundAmount.add(refundAmount);
     }
     return refundsForChain;
   }

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -323,10 +323,6 @@ export class BundleDataClient {
     // if it takes too long.
     const loadDataTimeout = async (timeout: number): Promise<LoadDataReturnValue> => {
       await delay(timeout);
-      this.logger.debug({
-        at: "BundleDataClient#getNextBundleRefunds",
-        message: `Timeout (${timeout}s) loading next bundle refunds.`,
-      });
       return {
         bundleFillsV3: {},
         expiredDepositsToRefundV3: {},
@@ -341,7 +337,7 @@ export class BundleDataClient {
     // for the next call to loadData.
     const { bundleFillsV3, expiredDepositsToRefundV3 } = await Promise.race([
       this.loadData(widestBundleBlockRanges, this.spokePoolClients, logData, attemptToLoadFromArweave),
-      loadDataTimeout(Number(process.env.LOAD_DATA_TIMEOUT ?? 20)), // timeout denominated in seconds
+      loadDataTimeout(Number(process.env.LOAD_DATA_TIMEOUT ?? 15)), // timeout denominated in seconds
     ]);
     const nextBundleRefunds = getRefundsFromBundle(bundleFillsV3, expiredDepositsToRefundV3);
     combinedRefunds.push(nextBundleRefunds);

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -771,7 +771,8 @@ export class BundleDataClient {
         // If there is a valid fill that we saw matching this deposit, then it does not need a refund.
         !fill &&
         deposit.fillDeadline < bundleBlockTimestamps[destinationChainId][1] &&
-        deposit.fillDeadline >= bundleBlockTimestamps[destinationChainId][0]
+        deposit.fillDeadline >= bundleBlockTimestamps[destinationChainId][0] &&
+        spokePoolClients[destinationChainId] !== undefined
       ) {
         // If we haven't seen a fill matching this deposit, then we need to rule out that it was filled a long time ago
         // by checkings its on-chain fill status.

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -264,6 +264,15 @@ export class BundleDataClient {
     } else {
       const { bundleFillsV3, expiredDepositsToRefundV3 } = arweaveData;
       combinedRefunds = getRefundsFromBundle(bundleFillsV3, expiredDepositsToRefundV3);
+      // If we don't have a spoke pool client for a chain, then we won't be able to deduct refunds correctly for this
+      // chain. For most of the pending bundle's liveness period, these past refunds are already executed so this is
+      // a reasonable assumption. This empty refund chain also matches what the alternative
+      // `getApproximateRefundsForBlockRange` would return.
+      Object.keys(combinedRefunds).forEach((chainId) => {
+        if (this.spokePoolClients[Number(chainId)] === undefined) {
+          delete combinedRefunds[Number(chainId)];
+        }
+      });
     }
 
     // The latest proposed bundle's refund leaves might have already been partially or entirely executed.

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -337,7 +337,7 @@ export class BundleDataClient {
     // for the next call to loadData.
     const { bundleFillsV3, expiredDepositsToRefundV3 } = await Promise.race([
       this.loadData(widestBundleBlockRanges, this.spokePoolClients, logData, attemptToLoadFromArweave),
-      loadDataTimeout(Number(process.env.LOAD_DATA_TIMEOUT ?? 15)), // timeout denominated in seconds
+      loadDataTimeout(Number(process.env.LOAD_DATA_TIMEOUT ?? 20)), // timeout denominated in seconds
     ]);
     const nextBundleRefunds = getRefundsFromBundle(bundleFillsV3, expiredDepositsToRefundV3);
     combinedRefunds.push(nextBundleRefunds);

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -208,7 +208,7 @@ export class BundleDataClient {
     };
     this.logger.debug({
       at: "BundleDataClient#loadPersistedDataFromArweave",
-      message: `Loaded persisted data from Arweave in ${Math.floor(Date.now() - start) / 1000}s.`,
+      message: `Loaded persisted data from Arweave in ${Math.floor(performance.now() - start) / 1000}s.`,
       blockRanges: JSON.stringify(blockRangesForChains),
       bundleData: prettyPrintV3SpokePoolEvents(
         bundleData.bundleDepositsV3,
@@ -462,7 +462,7 @@ export class BundleDataClient {
     spokePoolClients: SpokePoolClientsByChain,
     logData = true
   ): Promise<LoadDataReturnValue> {
-    const start = Date.now();
+    const start = performance.now();
     const key = JSON.stringify(blockRangesForChains);
 
     if (!this.clients.configStoreClient.isUpdated) {
@@ -1013,15 +1013,6 @@ export class BundleDataClient {
       expiredDepositsToRefundV3,
       unexecutableSlowFills
     );
-    if (logData) {
-      const mainnetRange = getBlockRangeForChain(blockRangesForChains, this.clients.hubPoolClient.chainId, chainIds);
-      this.logger.debug({
-        at: "BundleDataClient#loadData",
-        message: `Finished loading V3 spoke pool data for the equivalent of mainnet range: [${mainnetRange[0]}, ${mainnetRange[1]}]`,
-        blockRangesForChains,
-        ...v3SpokeEventsReadable,
-      });
-    }
 
     if (bundleInvalidFillsV3.length > 0) {
       this.logger.debug({
@@ -1034,7 +1025,7 @@ export class BundleDataClient {
 
     this.logger.debug({
       at: "BundleDataClient#_loadData",
-      message: `Computed bundle data in ${Math.floor(Date.now() - start) / 1000}s.`,
+      message: `Computed bundle data in ${Math.floor(performance.now() - start) / 1000}s.`,
       blockRangesForChains: JSON.stringify(blockRangesForChains),
       v3SpokeEventsReadable,
     });

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -245,7 +245,7 @@ export class InventoryClient {
     try {
       // Consider any refunds from executed and to-be executed bundles. If bundle data client doesn't return in
       // time, return an object with zero refunds for all chains.
-      totalRefundsPerChain = await Promise.race([this.getBundleRefunds(l1Token), getBundleRefundTimeout(40 * 60)]);
+      totalRefundsPerChain = await Promise.race([this.getBundleRefunds(l1Token), getBundleRefundTimeout(45 * 60)]);
     } catch (e) {
       this.log("Failed to get pending and next bundle refunds, ignoring them in repayment chain choice", {
         l1Token,

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -195,13 +195,11 @@ export class InventoryClient {
     // Increase virtual balance by pending relayer refunds from the latest valid bundle and the
     // upcoming bundle. We can assume that all refunds from the second latest valid bundle have already
     // been executed.
-    if (this.bundleRefundsPromise) {
-      refundsToConsider = await this.bundleRefundsPromise;
-    } else {
+    if (!isDefined(this.bundleRefundsPromise)) {
       // @dev Save this as a promise so that other parallel calls to this function don't make the same call.
       this.bundleRefundsPromise = this.getAllBundleRefunds();
-      refundsToConsider = lodash.cloneDeep(await this.bundleRefundsPromise);
     }
+    refundsToConsider = lodash.cloneDeep(await this.bundleRefundsPromise);
 
     return this.getEnabledChains().reduce((refunds: { [chainId: string]: BigNumber }, chainId) => {
       if (!this.hubPoolClient.l2TokenEnabledForL1Token(l1Token, chainId)) {

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -160,8 +160,8 @@ export class InventoryClient {
     // @dev This call can take a long time if bundle data for the latest bundle and the pending bundle is not
     // available on Arweave.
     const [pendingRefunds, nextBundleRefunds] = await Promise.all([
-      this.bundleDataClient.getPendingRefundsFromValidBundles(),
-      this.bundleDataClient.getNextBundleRefunds(this.relayer),
+      this.bundleDataClient.getPendingRefundsFromValidBundles([this.relayer]),
+      this.bundleDataClient.getNextBundleRefunds([this.relayer]),
     ]);
     refunds.push(...pendingRefunds, ...nextBundleRefunds);
     this.logger.debug({
@@ -169,16 +169,24 @@ export class InventoryClient {
       message: "Remaining refunds from last validated bundle (excludes already executed refunds)",
       refunds: pendingRefunds[0],
     });
-    this.logger.debug({
-      at: "InventoryClient#getAllBundleRefunds",
-      message: "Refunds from pending bundle",
-      refunds: nextBundleRefunds[0],
-    });
-    this.logger.debug({
-      at: "InventoryClient#getAllBundleRefunds",
-      message: "Refunds from upcoming bundle",
-      refunds: nextBundleRefunds[1],
-    });
+    if (nextBundleRefunds.length === 2) {
+      this.logger.debug({
+        at: "InventoryClient#getAllBundleRefunds",
+        message: "Refunds from pending bundle",
+        refunds: nextBundleRefunds[0],
+      });
+      this.logger.debug({
+        at: "InventoryClient#getAllBundleRefunds",
+        message: "Refunds from upcoming bundle",
+        refunds: nextBundleRefunds[1],
+      });
+    } else {
+      this.logger.debug({
+        at: "InventoryClient#getAllBundleRefunds",
+        message: "Refunds from upcoming bundle",
+        refunds: nextBundleRefunds[0],
+      });
+    }
     return refunds;
   }
 

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -225,11 +225,11 @@ export class InventoryClient {
     let cumulativeVirtualBalanceWithShortfall = cumulativeVirtualBalance.sub(chainShortfall);
     let chainVirtualBalanceWithShortfallPostRelay = chainVirtualBalanceWithShortfall.sub(outputAmount);
 
-    const startTime = Date.now();
+    const startTime = performance.now();
     // Consider any refunds from executed and to-be executed bundles. If bundle data client doesn't return in
     // time, return an object with zero refunds for all chains.
     const totalRefundsPerChain: { [chainId: string]: BigNumber } = await this.getBundleRefunds(l1Token);
-    this.log(`Time taken to get bundle refunds: ${Math.floor(Date.now() - startTime) / 1000}s`, {
+    this.log(`Time taken to get bundle refunds: ${Math.floor(performance.now() - startTime) / 1000}s`, {
       l1Token,
       totalRefundsPerChain,
     });

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -229,7 +229,7 @@ export class InventoryClient {
     // Consider any refunds from executed and to-be executed bundles. If bundle data client doesn't return in
     // time, return an object with zero refunds for all chains.
     const totalRefundsPerChain: { [chainId: string]: BigNumber } = await this.getBundleRefunds(l1Token);
-    this.log(`Time taken to get bundle refunds: ${Math.floor(performance.now() - startTime) / 1000}s`, {
+    this.log(`Time taken to get bundle refunds: ${Math.round((performance.now() - startTime) / 1000)}s`, {
       l1Token,
       totalRefundsPerChain,
     });

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -248,7 +248,7 @@ export class InventoryClient {
     try {
       // Consider any refunds from executed and to-be executed bundles. If bundle data client doesn't return in
       // time, return an object with zero refunds for all chains.
-      totalRefundsPerChain = await Promise.race([this.getBundleRefunds(l1Token), getBundleRefundTimeout(45 * 60)]);
+      totalRefundsPerChain = await Promise.race([this.getBundleRefunds(l1Token), getBundleRefundTimeout(30 * 60)]);
     } catch (e) {
       this.log("Failed to get pending and next bundle refunds, ignoring them in repayment chain choice", {
         l1Token,

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -157,8 +157,6 @@ export class InventoryClient {
 
   async getAllBundleRefunds(): Promise<CombinedRefunds[]> {
     const refunds: CombinedRefunds[] = [];
-    // @dev This call can take a long time if bundle data for the latest bundle and the pending bundle is not
-    // available on Arweave.
     const [pendingRefunds, nextBundleRefunds] = await Promise.all([
       this.bundleDataClient.getPendingRefundsFromValidBundles([this.relayer]),
       this.bundleDataClient.getNextBundleRefunds([this.relayer]),
@@ -200,6 +198,7 @@ export class InventoryClient {
     if (this.bundleRefundsPromise) {
       refundsToConsider = await this.bundleRefundsPromise;
     } else {
+      // @dev Save this as a promise so that other parallel calls to this function don't make the same call.
       this.bundleRefundsPromise = this.getAllBundleRefunds();
       refundsToConsider = lodash.cloneDeep(await this.bundleRefundsPromise);
     }

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -248,7 +248,7 @@ export class InventoryClient {
     try {
       // Consider any refunds from executed and to-be executed bundles. If bundle data client doesn't return in
       // time, return an object with zero refunds for all chains.
-      totalRefundsPerChain = await Promise.race([this.getBundleRefunds(l1Token), getBundleRefundTimeout(30 * 60)]);
+      totalRefundsPerChain = await Promise.race([this.getBundleRefunds(l1Token), getBundleRefundTimeout(45 * 60)]);
     } catch (e) {
       this.log("Failed to get pending and next bundle refunds, ignoring them in repayment chain choice", {
         l1Token,

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -242,6 +242,9 @@ export class InventoryClient {
 
     const startTime = Date.now();
     let totalRefundsPerChain: { [chainId: string]: BigNumber } = {};
+    // TODO: Remove this try-catch. getBundleRefunds should never fail in practice. This was originally added
+    // to catch the case where the relayer's lookback is insufficient to compute a bundle but I believe the current
+    // loadData implementation will just miss events in the case where the lookback is too short, rather than fail.
     try {
       // Consider any refunds from executed and to-be executed bundles. If bundle data client doesn't return in
       // time, return an object with zero refunds for all chains.

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -158,8 +158,8 @@ export class InventoryClient {
   async getAllBundleRefunds(): Promise<CombinedRefunds[]> {
     const refunds: CombinedRefunds[] = [];
     const [pendingRefunds, nextBundleRefunds] = await Promise.all([
-      this.bundleDataClient.getPendingRefundsFromValidBundles([this.relayer]),
-      this.bundleDataClient.getNextBundleRefunds([this.relayer]),
+      this.bundleDataClient.getPendingRefundsFromValidBundles(this.relayer),
+      this.bundleDataClient.getNextBundleRefunds(this.relayer),
     ]);
     refunds.push(...pendingRefunds, ...nextBundleRefunds);
     this.logger.debug({

--- a/src/clients/InventoryClient.ts
+++ b/src/clients/InventoryClient.ts
@@ -157,6 +157,8 @@ export class InventoryClient {
 
   async getAllBundleRefunds(): Promise<CombinedRefunds[]> {
     const refunds: CombinedRefunds[] = [];
+    // @dev This call can take a long time if bundle data for the latest bundle and the pending bundle is not
+    // available on Arweave.
     const [pendingRefunds, nextBundleRefunds] = await Promise.all([
       this.bundleDataClient.getPendingRefundsFromValidBundles(),
       this.bundleDataClient.getNextBundleRefunds(this.relayer),

--- a/src/dataworker/Dataworker.ts
+++ b/src/dataworker/Dataworker.ts
@@ -473,7 +473,7 @@ export class Dataworker {
   ): Promise<ProposeRootBundleReturnType> {
     const timerStart = Date.now();
     const { bundleDepositsV3, bundleFillsV3, bundleSlowFillsV3, unexecutableSlowFills, expiredDepositsToRefundV3 } =
-      await this.clients.bundleDataClient.loadData(blockRangesForProposal, spokePoolClients, logData);
+      await this.clients.bundleDataClient.loadData(blockRangesForProposal, spokePoolClients);
     // Prepare information about what we need to store to
     // Arweave for the bundle. We will be doing this at a
     // later point so that we can confirm that this data is

--- a/src/dataworker/DataworkerUtils.ts
+++ b/src/dataworker/DataworkerUtils.ts
@@ -578,7 +578,7 @@ export async function persistDataToArweave(
   logger: winston.Logger,
   tag?: string
 ): Promise<void> {
-  const startTime = Date.now();
+  const startTime = performance.now();
   // Check if data already exists on Arweave with the given tag.
   // If so, we don't need to persist it again.
   const matchingTxns = await client.getByTopic(tag, any());
@@ -603,7 +603,7 @@ export async function persistDataToArweave(
       balance,
     });
   }
-  const endTime = Date.now();
+  const endTime = performance.now();
   logger.debug({
     at: "Dataworker#index",
     message: `Time to persist data to Arweave: ${endTime - startTime}ms`,

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -24,7 +24,6 @@ import {
   winston,
   assert,
   getNetworkName,
-  isDefined,
 } from "../utils";
 import { DataworkerClients } from "./DataworkerClientHelper";
 
@@ -228,32 +227,6 @@ export function getRunningBalanceForL1Token(
 ): BigNumber {
   const desiredTransferAmount = computeDesiredTransferAmountToSpoke(runningBalance, spokePoolTargetBalance);
   return runningBalance.sub(desiredTransferAmount);
-}
-
-// Return block ranges for blocks after initialBlockRanges and up to widestBlockRanges.
-// If a chain is disabled or doesn't have a spoke pool client, return a range of 0
-export function getBlockRangeDelta(
-  initialBlockRanges: number[][],
-  widestBlockRanges: number[][],
-  spokePoolClients: { [chainId: number]: SpokePoolClient },
-  enabledChainIds: number[]
-): number[][] {
-  return widestBlockRanges.map((blockRange, index) => {
-    // If chain is disabled, return disabled range
-    if (initialBlockRanges[index][0] === initialBlockRanges[index][1]) {
-      return initialBlockRanges[index];
-    }
-    // If no spoke pool client for chain, consider it disabled
-    if (!isDefined(spokePoolClients[enabledChainIds[index]])) {
-      return [initialBlockRanges[index][1], initialBlockRanges[index][1]];
-    }
-    // If pending bundle end block and widest end block are the same, return an empty range since there are no
-    // "new" events to consider for this chain.
-    if (initialBlockRanges[index][1] >= blockRange[1]) {
-      return [initialBlockRanges[index][1], initialBlockRanges[index][1]];
-    }
-    return [initialBlockRanges[index][1] + 1, blockRange[1]];
-  });
 }
 
 // This returns a possible next block range that could be submitted as a new root bundle, or used as a reference

--- a/src/dataworker/PoolRebalanceUtils.ts
+++ b/src/dataworker/PoolRebalanceUtils.ts
@@ -24,6 +24,7 @@ import {
   winston,
   assert,
   getNetworkName,
+  isDefined,
 } from "../utils";
 import { DataworkerClients } from "./DataworkerClientHelper";
 
@@ -227,6 +228,32 @@ export function getRunningBalanceForL1Token(
 ): BigNumber {
   const desiredTransferAmount = computeDesiredTransferAmountToSpoke(runningBalance, spokePoolTargetBalance);
   return runningBalance.sub(desiredTransferAmount);
+}
+
+// Return block ranges for blocks after initialBlockRanges and up to widestBlockRanges.
+// If a chain is disabled or doesn't have a spoke pool client, return a range of 0
+export function getBlockRangeDelta(
+  initialBlockRanges: number[][],
+  widestBlockRanges: number[][],
+  spokePoolClients: { [chainId: number]: SpokePoolClient },
+  enabledChainIds: number[]
+): number[][] {
+  return widestBlockRanges.map((blockRange, index) => {
+    // If chain is disabled, return disabled range
+    if (initialBlockRanges[index][0] === initialBlockRanges[index][1]) {
+      return initialBlockRanges[index];
+    }
+    // If no spoke pool client for chain, consider it disabled
+    if (!isDefined(spokePoolClients[enabledChainIds[index]])) {
+      return [initialBlockRanges[index][1], initialBlockRanges[index][1]];
+    }
+    // If pending bundle end block and widest end block are the same, return an empty range since there are no
+    // "new" events to consider for this chain.
+    if (initialBlockRanges[index][1] >= blockRange[1]) {
+      return [initialBlockRanges[index][1], initialBlockRanges[index][1]];
+    }
+    return [initialBlockRanges[index][1] + 1, blockRange[1]];
+  });
 }
 
 // This returns a possible next block range that could be submitted as a new root bundle, or used as a reference

--- a/src/dataworker/index.ts
+++ b/src/dataworker/index.ts
@@ -54,13 +54,13 @@ export async function createDataworker(
 }
 export async function runDataworker(_logger: winston.Logger, baseSigner: Signer): Promise<void> {
   logger = _logger;
-  let loopStart = Date.now();
+  let loopStart = performance.now();
   const { clients, config, dataworker } = await createDataworker(logger, baseSigner);
   logger.debug({
     at: "Dataworker#index",
-    message: `Time to update non-spoke clients: ${(Date.now() - loopStart) / 1000}s`,
+    message: `Time to update non-spoke clients: ${(performance.now() - loopStart) / 1000}s`,
   });
-  loopStart = Date.now();
+  loopStart = performance.now();
 
   let bundleDataToPersist: BundleDataToPersistToDALayerType | undefined = undefined;
   try {
@@ -187,9 +187,11 @@ export async function runDataworker(_logger: winston.Logger, baseSigner: Signer)
 
       logger.debug({
         at: "Dataworker#index",
-        message: `Time to update spoke pool clients and run dataworker function: ${(Date.now() - loopStart) / 1000}s`,
+        message: `Time to update spoke pool clients and run dataworker function: ${
+          (performance.now() - loopStart) / 1000
+        }s`,
       });
-      loopStart = Date.now();
+      loopStart = performance.now();
 
       if (await processEndPollingLoop(logger, "Dataworker", config.pollingDelay)) {
         break;

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -570,9 +570,11 @@ export class Monitor {
         this.updateRelayerRefunds(refunds, relayerBalanceReport[relayer], relayer, BalanceType.PENDING);
       }
     }
-    for (const relayer of this.monitorConfig.monitoredRelayers) {
-      this.updateRelayerRefunds(nextBundleRefunds, relayerBalanceReport[relayer], relayer, BalanceType.NEXT);
-      this.updateCrossChainTransfers(relayer, relayerBalanceReport[relayer]);
+    for (const refunds of nextBundleRefunds) {
+      for (const relayer of this.monitorConfig.monitoredRelayers) {
+        this.updateRelayerRefunds(refunds, relayerBalanceReport[relayer], relayer, BalanceType.NEXT);
+        this.updateCrossChainTransfers(relayer, relayerBalanceReport[relayer]);
+      }
     }
   }
 

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -554,12 +554,10 @@ export class Monitor {
   }
 
   async updateLatestAndFutureRelayerRefunds(relayerBalanceReport: RelayerBalanceReport): Promise<void> {
-    // We realistically only need to check for refunds for the latest validated bundle so leave the bundle
-    // count value as its default value of 1.
     const validatedBundleRefunds: CombinedRefunds[] =
-      await this.clients.bundleDataClient.getPendingRefundsFromValidBundles(this.monitorConfig.monitoredRelayers);
+      await this.clients.bundleDataClient.getPendingRefundsFromValidBundles(...this.monitorConfig.monitoredRelayers);
     const nextBundleRefunds = await this.clients.bundleDataClient.getNextBundleRefunds(
-      this.monitorConfig.monitoredRelayers
+      ...this.monitorConfig.monitoredRelayers
     );
 
     // Calculate which fills have not yet been refunded for each monitored relayer.

--- a/src/monitor/Monitor.ts
+++ b/src/monitor/Monitor.ts
@@ -561,8 +561,10 @@ export class Monitor {
     // We realistically only need to check for refunds for the latest validated bundle so leave the bundle
     // count value as its default value of 1.
     const validatedBundleRefunds: CombinedRefunds[] =
-      await this.clients.bundleDataClient.getPendingRefundsFromValidBundles();
-    const nextBundleRefunds = await this.clients.bundleDataClient.getNextBundleRefunds();
+      await this.clients.bundleDataClient.getPendingRefundsFromValidBundles(this.monitorConfig.monitoredRelayers);
+    const nextBundleRefunds = await this.clients.bundleDataClient.getNextBundleRefunds(
+      this.monitorConfig.monitoredRelayers
+    );
 
     // Calculate which fills have not yet been refunded for each monitored relayer.
     for (const refunds of validatedBundleRefunds) {

--- a/test/Dataworker.executeRelayerRefunds.ts
+++ b/test/Dataworker.executeRelayerRefunds.ts
@@ -136,7 +136,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       await updateAllClients();
 
       // No bundle is validated so no refunds.
-      const refunds = await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
+      const refunds = await bundleDataClient.getPendingRefundsFromValidBundles(relayer.address);
       expect(bundleDataClient.getTotalRefund(refunds, relayer.address, destinationChainId, erc20_2.address)).to.equal(
         toBN(0)
       );
@@ -157,7 +157,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       await updateAllClients();
       const validatedRootBundles = hubPoolClient.getValidatedRootBundles();
       expect(validatedRootBundles.length).to.equal(1);
-      const refunds = await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
+      const refunds = await bundleDataClient.getPendingRefundsFromValidBundles(relayer.address);
       const totalRefund1 = bundleDataClient.getTotalRefund(
         refunds,
         relayer.address,
@@ -191,8 +191,8 @@ describe("Dataworker: Execute relayer refunds", async function () {
       // then it means that `getPendingRefundsFromLatestBundle` is mutating the return value of `.loadData` which is
       // stored in the bundle data client's cache. `getPendingRefundsFromLatestBundle` should instead be using a
       // deep cloned copy of `.loadData`'s output.
-      await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
-      const postExecutionRefunds = await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
+      await bundleDataClient.getPendingRefundsFromValidBundles(relayer.address);
+      const postExecutionRefunds = await bundleDataClient.getPendingRefundsFromValidBundles(relayer.address);
       expect(
         bundleDataClient.getTotalRefund(postExecutionRefunds, relayer.address, destinationChainId, erc20_2.address)
       ).to.equal(toBN(0));
@@ -227,14 +227,14 @@ describe("Dataworker: Execute relayer refunds", async function () {
 
       // Should include refunds for most recently validated bundle but not count first one
       // since they were already refunded.
-      const refunds2 = await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
+      const refunds2 = await bundleDataClient.getPendingRefundsFromValidBundles(relayer.address);
       expect(bundleDataClient.getTotalRefund(refunds2, relayer.address, destinationChainId, erc20_2.address)).to.gt(0);
     });
     it("Refunds in next bundle", async function () {
       // Before proposal should show refunds:
       expect(
         bundleDataClient.getRefundsFor(
-          (await bundleDataClient.getNextBundleRefunds([relayer.address]))[0],
+          (await bundleDataClient.getNextBundleRefunds(relayer.address))[0],
           relayer.address,
           destinationChainId,
           erc20_2.address
@@ -249,7 +249,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       // After proposal but before execution should show upcoming refund:
       expect(
         bundleDataClient.getRefundsFor(
-          (await bundleDataClient.getNextBundleRefunds([relayer.address]))[0],
+          (await bundleDataClient.getNextBundleRefunds(relayer.address))[0],
           relayer.address,
           destinationChainId,
           erc20_2.address
@@ -264,7 +264,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
 
       // Should reset to no refunds in "next bundle", though these will show up in pending bundle.
       await updateAllClients();
-      expect(await bundleDataClient.getNextBundleRefunds([relayer.address])).to.deep.equal([{}]);
+      expect(await bundleDataClient.getNextBundleRefunds(relayer.address)).to.deep.equal([{}]);
     });
   });
 });

--- a/test/Dataworker.executeRelayerRefunds.ts
+++ b/test/Dataworker.executeRelayerRefunds.ts
@@ -237,7 +237,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       // Before proposal should show refunds:
       expect(
         bundleDataClient.getRefundsFor(
-          await bundleDataClient.getNextBundleRefunds(),
+          (await bundleDataClient.getNextBundleRefunds())[0],
           relayer.address,
           destinationChainId,
           erc20_2.address
@@ -252,7 +252,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       // After proposal but before execution should show upcoming refund:
       expect(
         bundleDataClient.getRefundsFor(
-          await bundleDataClient.getNextBundleRefunds(),
+          (await bundleDataClient.getNextBundleRefunds())[0],
           relayer.address,
           destinationChainId,
           erc20_2.address
@@ -267,7 +267,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
 
       // Should reset to no refunds in "next bundle", though these will show up in pending bundle.
       await updateAllClients();
-      expect(await bundleDataClient.getNextBundleRefunds()).to.deep.equal({});
+      expect(await bundleDataClient.getNextBundleRefunds()).to.deep.equal([{}]);
     });
   });
 });

--- a/test/Dataworker.executeRelayerRefunds.ts
+++ b/test/Dataworker.executeRelayerRefunds.ts
@@ -136,7 +136,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       await updateAllClients();
 
       // No bundle is validated so no refunds.
-      const refunds = await bundleDataClient.getPendingRefundsFromValidBundles(2);
+      const refunds = await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
       expect(bundleDataClient.getTotalRefund(refunds, relayer.address, destinationChainId, erc20_2.address)).to.equal(
         toBN(0)
       );
@@ -157,7 +157,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       await updateAllClients();
       const validatedRootBundles = hubPoolClient.getValidatedRootBundles();
       expect(validatedRootBundles.length).to.equal(1);
-      const refunds = await bundleDataClient.getPendingRefundsFromValidBundles(2);
+      const refunds = await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
       const totalRefund1 = bundleDataClient.getTotalRefund(
         refunds,
         relayer.address,
@@ -171,9 +171,6 @@ describe("Dataworker: Execute relayer refunds", async function () {
         toBN(0)
       );
       expect(bundleDataClient.getTotalRefund(refunds, relayer.address, destinationChainId, erc20_1.address)).to.equal(
-        toBN(0)
-      );
-      expect(bundleDataClient.getTotalRefund(refunds, hubPool.address, destinationChainId, erc20_2.address)).to.equal(
         toBN(0)
       );
 
@@ -194,8 +191,8 @@ describe("Dataworker: Execute relayer refunds", async function () {
       // then it means that `getPendingRefundsFromLatestBundle` is mutating the return value of `.loadData` which is
       // stored in the bundle data client's cache. `getPendingRefundsFromLatestBundle` should instead be using a
       // deep cloned copy of `.loadData`'s output.
-      await bundleDataClient.getPendingRefundsFromValidBundles(2);
-      const postExecutionRefunds = await bundleDataClient.getPendingRefundsFromValidBundles(2);
+      await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
+      const postExecutionRefunds = await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
       expect(
         bundleDataClient.getTotalRefund(postExecutionRefunds, relayer.address, destinationChainId, erc20_2.address)
       ).to.equal(toBN(0));
@@ -230,14 +227,14 @@ describe("Dataworker: Execute relayer refunds", async function () {
 
       // Should include refunds for most recently validated bundle but not count first one
       // since they were already refunded.
-      const refunds2 = await bundleDataClient.getPendingRefundsFromValidBundles(2);
+      const refunds2 = await bundleDataClient.getPendingRefundsFromValidBundles([relayer.address], 2);
       expect(bundleDataClient.getTotalRefund(refunds2, relayer.address, destinationChainId, erc20_2.address)).to.gt(0);
     });
     it("Refunds in next bundle", async function () {
       // Before proposal should show refunds:
       expect(
         bundleDataClient.getRefundsFor(
-          (await bundleDataClient.getNextBundleRefunds())[0],
+          (await bundleDataClient.getNextBundleRefunds([relayer.address]))[0],
           relayer.address,
           destinationChainId,
           erc20_2.address
@@ -252,7 +249,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
       // After proposal but before execution should show upcoming refund:
       expect(
         bundleDataClient.getRefundsFor(
-          (await bundleDataClient.getNextBundleRefunds())[0],
+          (await bundleDataClient.getNextBundleRefunds([relayer.address]))[0],
           relayer.address,
           destinationChainId,
           erc20_2.address
@@ -267,7 +264,7 @@ describe("Dataworker: Execute relayer refunds", async function () {
 
       // Should reset to no refunds in "next bundle", though these will show up in pending bundle.
       await updateAllClients();
-      expect(await bundleDataClient.getNextBundleRefunds()).to.deep.equal([{}]);
+      expect(await bundleDataClient.getNextBundleRefunds([relayer.address])).to.deep.equal([{}]);
     });
   });
 });

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -477,7 +477,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         spokePoolClients
       );
       expect(data1.bundleFillsV3[repaymentChainId][l1Token_1.address].fills.length).to.equal(1);
-      expect(spyLogIncludes(spy, -1, "invalid V3 fills in range")).to.be.true;
+      expect(spyLogIncludes(spy, -2, "invalid V3 fills in range")).to.be.true;
     });
     it("Matches fill with deposit with outputToken = 0x0", async function () {
       await depositV3(
@@ -728,7 +728,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         [originChainId]: spokePoolClient_1,
         [destinationChainId]: spokePoolClient_2,
       });
-      expect(spyLogIncludes(spy, -2, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -3, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
       expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address].length).to.equal(1);
       expect(data1.bundleDepositsV3).to.deep.equal({});
     });
@@ -869,7 +869,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       });
       // Here we can see that the historical query for the deposit actually succeeds, but the deposit itself
       // was not one eligible to be slow filled.
-      expect(spyLogIncludes(spy, -2, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -3, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
 
       expect(data1.bundleSlowFillsV3).to.deep.equal({});
       expect(data1.bundleDepositsV3).to.deep.equal({});

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -477,7 +477,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         spokePoolClients
       );
       expect(data1.bundleFillsV3[repaymentChainId][l1Token_1.address].fills.length).to.equal(1);
-      expect(spyLogIncludes(spy, -1, "invalid V3 fills in range")).to.be.true;
+      expect(spyLogIncludes(spy, -2, "invalid V3 fills in range")).to.be.true;
     });
     it("Matches fill with deposit with outputToken = 0x0", async function () {
       await depositV3(

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -366,7 +366,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         [originChainId]: spokePoolClient_1,
         [destinationChainId]: spokePoolClient_2,
       });
-      expect(spyLogIncludes(spy, -3, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -2, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
       expect(data1.bundleFillsV3[repaymentChainId][l1Token_1.address].fills.length).to.equal(1);
       expect(data1.bundleDepositsV3).to.deep.equal({});
     });
@@ -477,7 +477,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         spokePoolClients
       );
       expect(data1.bundleFillsV3[repaymentChainId][l1Token_1.address].fills.length).to.equal(1);
-      expect(spyLogIncludes(spy, -2, "invalid V3 fills in range")).to.be.true;
+      expect(spyLogIncludes(spy, -1, "invalid V3 fills in range")).to.be.true;
     });
     it("Matches fill with deposit with outputToken = 0x0", async function () {
       await depositV3(
@@ -728,7 +728,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         [originChainId]: spokePoolClient_1,
         [destinationChainId]: spokePoolClient_2,
       });
-      expect(spyLogIncludes(spy, -3, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -2, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
       expect(data1.bundleSlowFillsV3[destinationChainId][erc20_2.address].length).to.equal(1);
       expect(data1.bundleDepositsV3).to.deep.equal({});
     });
@@ -869,7 +869,7 @@ describe("Dataworker: Load data used in all functions", async function () {
       });
       // Here we can see that the historical query for the deposit actually succeeds, but the deposit itself
       // was not one eligible to be slow filled.
-      expect(spyLogIncludes(spy, -3, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -2, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
 
       expect(data1.bundleSlowFillsV3).to.deep.equal({});
       expect(data1.bundleDepositsV3).to.deep.equal({});

--- a/test/Dataworker.loadData.ts
+++ b/test/Dataworker.loadData.ts
@@ -366,7 +366,7 @@ describe("Dataworker: Load data used in all functions", async function () {
         [originChainId]: spokePoolClient_1,
         [destinationChainId]: spokePoolClient_2,
       });
-      expect(spyLogIncludes(spy, -2, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
+      expect(spyLogIncludes(spy, -3, "Located V3 deposit outside of SpokePoolClient's search range")).is.true;
       expect(data1.bundleFillsV3[repaymentChainId][l1Token_1.address].fills.length).to.equal(1);
       expect(data1.bundleDepositsV3).to.deep.equal({});
     });

--- a/test/Monitor.ts
+++ b/test/Monitor.ts
@@ -1,4 +1,3 @@
-import { utils as sdkUtils } from "@across-protocol/sdk-v2";
 import {
   BalanceAllocator,
   BundleDataClient,
@@ -74,10 +73,9 @@ describe("Monitor", async function () {
     }
   };
 
-  const { fixedPointAdjustment: fixedPoint } = sdkUtils;
   const computeRelayerRefund = async (request: V3DepositWithBlock & { paymentChainId: number }): Promise<BigNumber> => {
-    const { realizedLpFeePct } = await hubPoolClient.computeRealizedLpFeePct(request);
-    return request.inputAmount.mul(fixedPoint.sub(realizedLpFeePct)).div(fixedPoint);
+    // @dev Monitor currently doesn't factor in LP fee into relayer refund calculation for simplicity and speed.
+    return request.inputAmount;
   };
 
   beforeEach(async function () {

--- a/test/mocks/MockBundleDataClient.ts
+++ b/test/mocks/MockBundleDataClient.ts
@@ -9,8 +9,8 @@ export class MockBundleDataClient extends BundleDataClient {
     return [this.pendingBundleRefunds];
   }
 
-  async getNextBundleRefunds(): Promise<CombinedRefunds> {
-    return this.nextBundleRefunds;
+  async getNextBundleRefunds(): Promise<CombinedRefunds[]> {
+    return [this.nextBundleRefunds];
   }
 
   setReturnedPendingBundleRefunds(refunds: CombinedRefunds): void {


### PR DESCRIPTION
- Fixes regression introduced in [#1362](https://github.com/across-protocol/relayer-v2/issues/1362) where refunds sent after proposed bundle are no longer computed and accounted for in `InventoryClient.resolveRepaymentChain` in favor of loading pendling bundle data from Arweave
- Removes `loadData` calls from all InventoryClient flows and replaces it with a function `getApproximateRefundsForBlockRange()` that filters on fills sent by relayer within the bundle block range and assumes all fills are valid which is a fair assumption and greatly speeds up the inventory client run
- Removes try-catch in InventoryClient since we should not expect any failures anymore when computing bundle refunds
- Adds Promise.all and promise caching to speed up overall inventory client call to `getBundleRefunds`
- Adds detailed logging

Fixes ACX-2039