### PR TITLE
fix(BundleDataClient): Filter chains based on which spoke pool clients are passed in to loadData

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -383,7 +383,7 @@ export class BundleDataClient {
       .filter((chainId) => !_isChainDisabled(chainId));
     allChainIds.forEach((chainId) => {
       const spokePoolClient = spokePoolClients[chainId];
-      if (!spokePoolClient.isUpdated) {
+      if (spokePoolClient && !spokePoolClient.isUpdated) {
         throw new Error(`SpokePoolClient for chain ${chainId} not updated.`);
       }
     });

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -380,10 +380,10 @@ export class BundleDataClient {
     // Infer chain ID's to load from number of block ranges passed in.
     const allChainIds = blockRangesForChains
       .map((_blockRange, index) => chainIds[index])
-      .filter((chainId) => !_isChainDisabled(chainId));
+      .filter((chainId) => !_isChainDisabled(chainId) && spokePoolClients[chainId] !== undefined);
     allChainIds.forEach((chainId) => {
       const spokePoolClient = spokePoolClients[chainId];
-      if (spokePoolClient && !spokePoolClient.isUpdated) {
+      if (!spokePoolClient.isUpdated) {
         throw new Error(`SpokePoolClient for chain ${chainId} not updated.`);
       }
     });


### PR DESCRIPTION
Not every spoke pool client will be defined, therefore no need to check if one that doesn't exist is "updated"