### PR TITLE
fix(BundleDataClient): Catch undefined SpokePoolClient

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -383,7 +383,7 @@ export class BundleDataClient {
       .filter((chainId) => !_isChainDisabled(chainId));
     allChainIds.forEach((chainId) => {
       const spokePoolClient = spokePoolClients[chainId];
-      if (!spokePoolClient.isUpdated) {
+      if (spokePoolClient && !spokePoolClient.isUpdated) {
         throw new Error(`SpokePoolClient for chain ${chainId} not updated.`);
       }
     });

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -380,10 +380,10 @@ export class BundleDataClient {
     // Infer chain ID's to load from number of block ranges passed in.
     const allChainIds = blockRangesForChains
       .map((_blockRange, index) => chainIds[index])
-      .filter((chainId) => !_isChainDisabled(chainId));
+      .filter((chainId) => !_isChainDisabled(chainId) && spokePoolClients[chainId] !== undefined);
     allChainIds.forEach((chainId) => {
       const spokePoolClient = spokePoolClients[chainId];
-      if (spokePoolClient && !spokePoolClient.isUpdated) {
+      if (!spokePoolClient.isUpdated) {
         throw new Error(`SpokePoolClient for chain ${chainId} not updated.`);
       }
     });

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -771,7 +771,8 @@ export class BundleDataClient {
         // If there is a valid fill that we saw matching this deposit, then it does not need a refund.
         !fill &&
         deposit.fillDeadline < bundleBlockTimestamps[destinationChainId][1] &&
-        deposit.fillDeadline >= bundleBlockTimestamps[destinationChainId][0]
+        deposit.fillDeadline >= bundleBlockTimestamps[destinationChainId][0] &&
+        spokePoolClients[destinationChainId] !== undefined
       ) {
         // If we haven't seen a fill matching this deposit, then we need to rule out that it was filled a long time ago
         // by checkings its on-chain fill status.


### PR DESCRIPTION
One more instance where spoke pool could be undefined, because the client for a destination chain for an expired deposit might not exist

Follow up to #1384 