### PR TITLE
feat: Support specifying read-only address for void signers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -70,7 +70,7 @@ if (require.main === module) {
 
   const opts = {
     boolean: ["dataworker", "finalizer", "help", "monitor", "relayer"],
-    string: ["wallet", "keys"],
+    string: ["wallet", "keys", "address"],
     default: { wallet: "secret" },
     alias: { h: "help" },
     unknown: usage,

--- a/src/utils/CLIUtils.ts
+++ b/src/utils/CLIUtils.ts
@@ -1,7 +1,7 @@
 import minimist from "minimist";
 import { Signer } from "ethers";
+import { constants as sdkConsts } from "@across-protocol/sdk-v2";
 import { SignerOptions, getSigner } from "./SignerUtils";
-import { isDefined } from "./TypeGuards";
 
 const keyTypes = ["secret", "mnemonic", "privateKey", "gckms", "void"];
 
@@ -10,10 +10,19 @@ const keyTypes = ["secret", "mnemonic", "privateKey", "gckms", "void"];
  * @returns A signer based on the CLI args.
  */
 export function retrieveSignerFromCLIArgs(): Promise<Signer> {
+  const opts = {
+    string: ["wallet", "keys", "address"],
+    default: {
+      wallet: "secret",
+      address: sdkConsts.DEFAULT_SIMULATED_RELAYER_ADDRESS,
+    },
+  };
+
   // Call into the process' argv to retrieve the CLI args.
-  const args = minimist(process.argv.slice(2));
+  const args = minimist(process.argv.slice(2), opts);
+
   // Resolve the wallet type & verify that it is valid.
-  const keyType = (args.wallet as string) ?? "secret";
+  const keyType = args.wallet ?? "secret";
   if (!isValidKeyType(keyType)) {
     throw new Error(`Unsupported key type (${keyType}); expected one of: ${keyTypes.join(", ")}.`);
   }
@@ -21,9 +30,11 @@ export function retrieveSignerFromCLIArgs(): Promise<Signer> {
   // Build out the signer options to pass to the signer utils.
   const signerOptions: SignerOptions = {
     keyType,
-    gckmsKeys: isDefined(args.keys) ? [args.keys] : [],
+    gckmsKeys: args.keys ?? [],
+    roAddress: args.address,
     cleanEnv: false, // TODO: We don't want to clean the env for now. This will be changed in the future.
   };
+
   // Return the signer.
   return getSigner(signerOptions);
 }
@@ -33,6 +44,6 @@ export function retrieveSignerFromCLIArgs(): Promise<Signer> {
  * @param keyType The key type to check.
  * @returns True if the key type is valid, false otherwise.
  */
-function isValidKeyType(keyType: unknown): keyType is "secret" | "mnemonic" | "privateKey" | "gckms" | "void" {
-  return keyTypes.includes(keyType as string);
+function isValidKeyType(keyType: string): keyType is "secret" | "mnemonic" | "privateKey" | "gckms" | "void" {
+  return keyTypes.includes(keyType);
 }

--- a/src/utils/Help.ts
+++ b/src/utils/Help.ts
@@ -1,12 +1,13 @@
 export function usage(badInput: string | undefined = undefined): boolean {
   let usageStr = badInput ? `\nUnrecognized input: "${badInput}".\n\n` : "";
-  const walletOpts = "secret|mnemonic|privateKey|gckms";
+  const walletTypes = "secret|mnemonic|privateKey|gckms|void";
+  const walletUsage = `--wallet <${walletTypes}> | --wallet void [--address <ro-address>]`;
 
   usageStr += `
     Usage:
     \tnode ./dist/index.js --help
-    \tnode ./dist/index.js [-h] <--monitor|--relayer>      [--wallet <${walletOpts}>]
-    \tnode ./dist/index.js [-h] <--dataworker|--finalizer> [--wallet <${walletOpts}>]
+    \tnode ./dist/index.js [-h] <--monitor|--relayer>      [${walletUsage}]
+    \tnode ./dist/index.js [-h] <--dataworker|--finalizer> [${walletUsage}]
   `.slice(1); // Skip leading newline
 
   // eslint-disable-next-line no-console


### PR DESCRIPTION
This allows the various bot personalities to masquerade any arbitrary EOA and will make it significantly easier to test inventory configuration as another relayer.

The default read-only address is set to the main RL relayer, so to it's now possible to simulate it with the following incantation:

  yarn relay --wallet void