### PR TITLE
fix(AcrossAPIClient): Use new Across app host

### DIFF
--- a/src/clients/AcrossAPIClient.ts
+++ b/src/clients/AcrossAPIClient.ts
@@ -18,7 +18,7 @@ export interface DepositLimits {
 }
 
 export class AcrossApiClient {
-  private endpoint = "https://across.to/api";
+  private endpoint = "https://app.across.to/api";
 
   private limits: { [token: string]: BigNumber } = {};
 


### PR DESCRIPTION
It's a little embarrassing to have been nudging third-party integrators to make this switch without having realised we also need to do it >.<