### PR TITLE
[WIP] refactor(BundleDataClient): Tweak executed refund computation

### DIFF
--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -342,10 +342,7 @@ export class BundleDataClient {
         continue;
       }
 
-      const executedRefunds = this.getExecutedRefunds(
-        spokePoolClient,
-        bundleContainingRefunds.relayerRefundRoot
-      );
+      const executedRefunds = this.getExecutedRefunds(spokePoolClient, bundleContainingRefunds.relayerRefundRoot);
 
       for (const tokenAddress of Object.keys(allRefunds[chainId])) {
         const refunds = allRefunds[chainId][tokenAddress];

--- a/src/clients/BundleDataClient.ts
+++ b/src/clients/BundleDataClient.ts
@@ -337,11 +337,13 @@ export class BundleDataClient {
   deductExecutedRefunds(allRefunds: CombinedRefunds, bundleContainingRefunds: ProposedRootBundle): CombinedRefunds {
     for (const chainIdStr of Object.keys(allRefunds)) {
       const chainId = Number(chainIdStr);
-      if (!isDefined(this.spokePoolClients[chainId])) {
+      const spokePoolClient = this.spokePoolClients[chainId];
+      if (!isDefined(spokePoolClient)) {
         continue;
       }
+
       const executedRefunds = this.getExecutedRefunds(
-        this.spokePoolClients[chainId],
+        spokePoolClient,
         bundleContainingRefunds.relayerRefundRoot
       );
 


### PR DESCRIPTION
There's apparently a bug here, such that `this.getExecutedRefunds()` can be called with an undefined SpokePoolClient. I can't see how it can occur given the existing code.