### PR TITLE
refactor: Remove top-level bot loop

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,14 +1,6 @@
 import minimist from "minimist";
 import { CommonConfig } from "./src/common";
-import {
-  config,
-  delay,
-  retrieveSignerFromCLIArgs,
-  help,
-  Logger,
-  usage,
-  winston,
-} from "./src/utils";
+import { config, delay, retrieveSignerFromCLIArgs, help, Logger, usage, winston } from "./src/utils";
 import { runRelayer } from "./src/relayer";
 import { runDataworker } from "./src/dataworker";
 import { runMonitor } from "./src/monitor";
@@ -51,8 +43,8 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
       await cmds[cmd](logger, signer);
     } catch (error) {
       logger.error({
-        at: `index`,
-        message: `There was an execution error!`,
+        at: "index",
+        message: "There was an execution error!",
         reason: error,
         e: error,
         error,

--- a/index.ts
+++ b/index.ts
@@ -73,6 +73,5 @@ if (require.main === module) {
         notificationPath: "across-error",
       });
       await delay(5); // Wait for transports to flush. May or may not be necessary.
-      await run(args);
     });
 }

--- a/index.ts
+++ b/index.ts
@@ -70,6 +70,6 @@ if (require.main === module) {
         error,
         notificationPath: "across-error",
       });
-      await delay(2);
+      await delay(5); // Wait for transports to flush. May or may not be necessary.
     });
 }

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ import { runFinalizer } from "./src/finalizer";
 import { version } from "./package.json";
 
 let logger: winston.Logger;
+let cmd: string;
 
 export async function run(args: { [k: string]: boolean | string }): Promise<void> {
   logger = Logger;
@@ -22,7 +23,7 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
   // todo Make the mode of operation an operand, rather than an option.
   // i.e. ts-node ./index.ts [options] <relayer|...>
   // Note: ts does not produce a narrow type from Object.keys, so we have to help.
-  const cmd = Object.keys(cmds).find((_cmd) => !!args[_cmd]);
+  cmd = Object.keys(cmds).find((_cmd) => !!args[_cmd]);
 
   if (cmd === "help") {
     cmds[cmd]();
@@ -63,11 +64,12 @@ if (require.main === module) {
     .catch(async (error) => {
       process.exitCode = 1;
       logger.error({
-        at: "index",
+        at: cmd ?? "unknown process",
         message: "There was an execution error!",
         reason: error,
         e: error,
         error,
+        args,
         notificationPath: "across-error",
       });
       await delay(5); // Wait for transports to flush. May or may not be necessary.

--- a/index.ts
+++ b/index.ts
@@ -73,5 +73,6 @@ if (require.main === module) {
         notificationPath: "across-error",
       });
       await delay(5); // Wait for transports to flush. May or may not be necessary.
+      await run(args);
     });
 }

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import minimist from "minimist";
-import { config, retrieveSignerFromCLIArgs, help, Logger, usage, winston } from "./src/utils";
+import { config, delay, retrieveSignerFromCLIArgs, help, Logger, usage, winston } from "./src/utils";
 import { runRelayer } from "./src/relayer";
 import { runDataworker } from "./src/dataworker";
 import { runMonitor } from "./src/monitor";
@@ -70,5 +70,6 @@ if (require.main === module) {
         error,
         notificationPath: "across-error",
       });
+      await delay(2);
     });
 }

--- a/index.ts
+++ b/index.ts
@@ -34,22 +34,10 @@ export async function run(args: { [k: string]: boolean | string }): Promise<void
     // todo: Update usage() to provide a hint that wallet is missing/malformed.
     usage(""); // no return
   } else {
+    // One global signer for use with a specific per-chain provider.
+    // todo: Support a void signer for monitor mode (only) if no wallet was supplied.
     const signer = await retrieveSignerFromCLIArgs();
-    try {
-      // One global signer for use with a specific per-chain provider.
-      // todo: Support a void signer for monitor mode (only) if no wallet was supplied.
-      await cmds[cmd](logger, signer);
-    } catch (error) {
-      logger.error({
-        at: "index",
-        message: "There was an execution error!",
-        reason: error,
-        e: error,
-        error,
-        notificationPath: "across-error",
-      });
-      process.exitCode = 1;
-    }
+    await cmds[cmd](logger, signer);
   }
 }
 
@@ -70,17 +58,17 @@ if (require.main === module) {
 
   run(args)
     .then(() => {
-      // eslint-disable-next-line no-process-exit
-      process.exit(0);
+      process.exitCode = 0;
     })
     .catch(async (error) => {
+      process.exitCode = 1;
       logger.error({
-        at: "InfrastructureEntryPoint",
-        message: "There was an error in the main entry point!",
+        at: "index",
+        message: "There was an execution error!",
+        reason: error,
+        e: error,
         error,
         notificationPath: "across-error",
       });
-      await delay(5);
-      await run(args);
     });
 }

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,4 @@
 import minimist from "minimist";
-import { CommonConfig } from "./src/common";
 import { config, delay, retrieveSignerFromCLIArgs, help, Logger, usage, winston } from "./src/utils";
 import { runRelayer } from "./src/relayer";
 import { runDataworker } from "./src/dataworker";

--- a/index.ts
+++ b/index.ts
@@ -11,7 +11,6 @@ let logger: winston.Logger;
 
 export async function run(args: { [k: string]: boolean | string }): Promise<void> {
   logger = Logger;
-  const config = new CommonConfig(process.env);
 
   const cmds = {
     dataworker: runDataworker,

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import minimist from "minimist";
-import { config, delay, retrieveSignerFromCLIArgs, help, Logger, usage, winston } from "./src/utils";
+import { config, retrieveSignerFromCLIArgs, help, Logger, usage, winston } from "./src/utils";
 import { runRelayer } from "./src/relayer";
 import { runDataworker } from "./src/dataworker";
 import { runMonitor } from "./src/monitor";

--- a/src/utils/ExecutionUtils.ts
+++ b/src/utils/ExecutionUtils.ts
@@ -1,4 +1,4 @@
-import { AnyObject, delay, winston } from "./";
+import { delay, winston } from "./";
 
 export async function processEndPollingLoop(
   logger: winston.Logger,

--- a/src/utils/ExecutionUtils.ts
+++ b/src/utils/ExecutionUtils.ts
@@ -16,28 +16,6 @@ export async function processEndPollingLoop(
   return false;
 }
 
-export async function processCrash(
-  logger: winston.Logger,
-  fileName: string,
-  pollingDelay: number,
-  error: AnyObject
-): Promise<boolean> {
-  logger.error({
-    at: `${fileName}#index`,
-    message: `There was an execution error! ${pollingDelay != 0 ? "Re-running loop" : ""}`,
-    reason: error,
-    e: error,
-    error,
-    notificationPath: "across-error",
-  });
-  await delay(5);
-  if (pollingDelay === 0) {
-    return true;
-  }
-
-  return false;
-}
-
 export function startupLogLevel(config: { pollingDelay: number }): string {
   return config.pollingDelay > 0 ? "info" : "debug";
 }


### PR DESCRIPTION
The bot currently has 2 independent checks on POLLING_MODE - once at the top-level `index.ts` and once at `src/relayer/Relayer.ts`. A pending change will update `src/relayer/Relayer.ts` to support exiting gracefully after a SIGHUP request. The upper-layer check in `index.ts` prevents this by determining whether to loop or exit based on `config.pollingDelay`. There doesn't seem to be a strong justification for applying this looping at both levels, so remove the top-level of encapsulation for simplicity. Any bot personalities that require special looping behaviour can implement it locally, and if we see a common pattern emerge then it can bubble up to the top level once more.