### PR TITLE
feat(relayer): Gracefully stop on SIGHUP

### DIFF
--- a/src/utils/ExecutionUtils.ts
+++ b/src/utils/ExecutionUtils.ts
@@ -3,9 +3,10 @@ import { AnyObject, delay, winston } from "./";
 export async function processEndPollingLoop(
   logger: winston.Logger,
   fileName: string,
-  pollingDelay: number
+  pollingDelay: number,
+  stop = false
 ): Promise<boolean> {
-  if (pollingDelay === 0) {
+  if (pollingDelay === 0 || stop) {
     logger.debug({ at: `${fileName}#index`, message: "End of serverless execution loop - terminating process" });
     await delay(5); // Add a small delay to ensure the transports have fully flushed upstream.
     return true;


### PR DESCRIPTION
This change permits the operator to request the relayer to stop at the end of its current loop. This is mostly useful for polling mode, where the relayer will loop repeatedly.

While here, add in some per-loop performance reporting and refactor a little bit by pulling some code out of the large try...catch statement.